### PR TITLE
fix: improve pre-commit configuration for better developer experience

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,15 @@
+# Pre-commit configuration
+default_install_hook_types: [pre-commit, pre-push, commit-msg]
+default_stages: [pre-commit]
+
 repos:
   # Ruff for linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.4
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix]
       - id: ruff-format
-        args: [--exit-non-zero-on-format]
 
   # MyPy for type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ sphinx-autodoc-typehints>=1.19.0
 
 # Project dependencies needed for autodoc
 structlog
-pydantic>=2.0.0
+pydantic>=2.11.0
 pydantic-settings>=2.0.0
 anyio
 

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -13,6 +13,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from fapilog import AsyncLogger, UniversalSettings
+from fapilog.core.settings import LogLevel
 
 
 async def main() -> None:
@@ -20,7 +21,7 @@ async def main() -> None:
 
     # Configure async-first logging
     settings = UniversalSettings(
-        level="INFO",
+        level=LogLevel.INFO,
         sinks=["stdout"],
         async_processing=True,
         zero_copy_operations=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,19 @@ dependencies = [
     "mypy>=1.17.1",
     "types-requests",
     "types-PyYAML",
+    # Core runtime dependencies needed for type checking
+    "fastapi>=0.115.0",
+    "pydantic>=2.11.0",
+    "pydantic-settings>=2.0.0",
+    "httpx>=0.24.0",
+    "orjson>=3.9.0",
+    "prometheus-client>=0.17.0",
+    "psutil>=5.9.0; sys_platform != 'win32'",
+    # Test dependencies needed for type checking test files
+    "pytest>=8.4.0",
+    "pytest-asyncio>=1.1.0",
+    "pytest-cov>=6.2.0",
+    "pytest-benchmark>=4.0.0",
 ]
 
 [tool.hatch.envs.typecheck.env-vars]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,11 @@ module = [
 ]
 disallow_untyped_defs = false
 disallow_incomplete_defs = false
+disallow_untyped_decorators = false
+warn_return_any = false
+warn_unused_ignores = false
+warn_unreachable = false
+strict_equality = false
 
 [tool.coverage.run]
 source = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-benchmark>=4.0.0",
     "ruff>=0.1.0",
-    "mypy>=1.5.0",
+    "mypy>=1.17.1",
     "pre-commit>=3.3.0",
     "black>=23.0.0",
     "isort>=5.12.0",
@@ -140,7 +140,7 @@ dependencies = [
     "pytest-cov>=4.0.0",
     "pytest-benchmark>=4.0.0",
     "ruff>=0.1.0",
-    "mypy>=1.5.0",
+    "mypy>=1.17.1",
     "pre-commit>=3.3.0",
 ]
 
@@ -171,7 +171,7 @@ format = "ruff format src tests"
 [tool.hatch.envs.typecheck]
 detached = true
 dependencies = [
-    "mypy>=1.5.0",
+    "mypy>=1.17.1",
     "types-requests",
     "types-PyYAML",
 ]
@@ -283,7 +283,8 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["fapilog.core.settings"]
-warn_unused_ignores = false  # Pydantic field_validator decorators vary between MyPy versions
+# Pydantic v2 field_validator decorators need type ignores until MyPy catches up
+warn_unused_ignores = false
 
 [tool.coverage.run]
 source = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dependencies = [
     "aiofiles>=23.0.0",
     
     # FastAPI and Pydantic v2
-    "fastapi>=0.100.0",
-    "pydantic>=2.0.0",
+    "fastapi>=0.115.0",
+    "pydantic>=2.11.0",
     "pydantic-settings>=2.0.0",
     
     # HTTP client for sinks
@@ -83,11 +83,11 @@ siem = [
 # Development tools
 dev = [
     "hatch>=1.7.0",
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=4.0.0",
+    "pytest>=8.4.0",
+    "pytest-asyncio>=1.1.0",
+    "pytest-cov>=6.2.0",
     "pytest-benchmark>=4.0.0",
-    "ruff>=0.1.0",
+    "ruff>=0.12.0",
     "mypy>=1.17.1",
     "pre-commit>=3.3.0",
     "black>=23.0.0",
@@ -135,11 +135,11 @@ include = [
 [tool.hatch.envs.default]
 dependencies = [
     "hatch>=1.7.0",
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=4.0.0",
+    "pytest>=8.4.0",
+    "pytest-asyncio>=1.1.0",
+    "pytest-cov>=6.2.0",
     "pytest-benchmark>=4.0.0",
-    "ruff>=0.1.0",
+    "ruff>=0.12.0",
     "mypy>=1.17.1",
     "pre-commit>=3.3.0",
 ]
@@ -157,7 +157,7 @@ check = "pre-commit run --all-files"
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
-    "ruff>=0.1.0",
+    "ruff>=0.12.0",
 ]
 
 [tool.hatch.envs.lint.env-vars]
@@ -185,13 +185,13 @@ typecheck = "mypy src tests examples"
 # Test environment
 [tool.hatch.envs.test]
 dependencies = [
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0", 
-    "pytest-cov>=4.0.0",
+    "pytest>=8.4.0",
+    "pytest-asyncio>=1.1.0", 
+    "pytest-cov>=6.2.0",
     "pytest-benchmark>=4.0.0",
     # Core runtime dependencies needed for tests
-    "fastapi>=0.100.0",
-    "pydantic>=2.0.0",
+    "fastapi>=0.115.0",
+    "pydantic>=2.11.0",
     "pydantic-settings>=2.0.0",
     "httpx>=0.24.0",
     "orjson>=3.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,10 +151,11 @@ test-benchmark = "pytest --benchmark-only {args:tests}"
 lint = "ruff check {args:src tests}"
 format = "ruff format {args:src tests}"
 typecheck = "mypy {args:src}"
-pre-commit = "pre-commit run --all-files"
+check = "pre-commit run --all-files"
 
 # Lint environment
 [tool.hatch.envs.lint]
+detached = true
 dependencies = [
     "ruff>=0.1.0",
 ]
@@ -165,6 +166,7 @@ format = "ruff format src tests"
 
 # Type checking environment  
 [tool.hatch.envs.typecheck]
+detached = true
 dependencies = [
     "mypy>=1.5.0",
     "types-requests",
@@ -176,6 +178,7 @@ typecheck = "mypy src"
 
 # Test environment
 [tool.hatch.envs.test]
+detached = true
 dependencies = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,6 +281,10 @@ warn_unreachable = false
 strict_equality = false
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["fapilog.core.settings"]
+warn_unused_ignores = false  # Pydantic field_validator decorators vary between MyPy versions
+
 [tool.coverage.run]
 source = ["src"]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ test-cov = "pytest --cov=src/fapilog --cov-report=html --cov-report=term {args:t
 test-benchmark = "pytest --benchmark-only {args:tests}"
 lint = "ruff check {args:src tests}"
 format = "ruff format {args:src tests}"
-typecheck = "mypy {args:src}"
+typecheck = "mypy {args:src tests examples}"
 check = "pre-commit run --all-files"
 
 # Lint environment
@@ -174,7 +174,7 @@ dependencies = [
 ]
 
 [tool.hatch.envs.typecheck.scripts]
-typecheck = "mypy src"
+typecheck = "mypy src tests examples"
 
 # Test environment
 [tool.hatch.envs.test]
@@ -245,6 +245,11 @@ warn_unused_ignores = true
 warn_no_return = true
 warn_unreachable = true
 strict_equality = true
+# Package resolution
+explicit_package_bases = true
+namespace_packages = true
+mypy_path = "src"
+packages = ["fapilog"]
 
 [[tool.mypy.overrides]]
 module = [
@@ -258,6 +263,7 @@ warn_return_any = false
 warn_unused_ignores = false
 warn_unreachable = false
 strict_equality = false
+ignore_missing_imports = true
 
 [tool.coverage.run]
 source = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,12 +155,47 @@ dependencies = [
 
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
-test-cov = "pytest --cov=fapilog --cov-report=html --cov-report=term {args:tests}"
+test-cov = "pytest --cov=src/fapilog --cov-report=html --cov-report=term {args:tests}"
 test-benchmark = "pytest --benchmark-only {args:tests}"
 lint = "ruff check {args:src tests}"
 format = "ruff format {args:src tests}"
 typecheck = "mypy {args:src}"
 pre-commit = "pre-commit run --all-files"
+
+# Lint environment
+[tool.hatch.envs.lint]
+dependencies = [
+    "ruff>=0.1.0",
+]
+
+[tool.hatch.envs.lint.scripts]
+lint = "ruff check src tests"
+format = "ruff format src tests"
+
+# Type checking environment  
+[tool.hatch.envs.typecheck]
+dependencies = [
+    "mypy>=1.5.0",
+    "types-requests",
+    "types-PyYAML",
+]
+
+[tool.hatch.envs.typecheck.scripts]
+typecheck = "mypy src"
+
+# Test environment
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0", 
+    "pytest-cov>=4.0.0",
+    "pytest-benchmark>=4.0.0",
+]
+
+[tool.hatch.envs.test.scripts]
+test = "pytest tests"
+test-cov = "pytest --cov=src/fapilog --cov-report=html --cov-report=term tests"
+test-benchmark = "pytest --benchmark-only tests"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,17 +53,6 @@ dependencies = [
     
     # Optional: System metrics
     "psutil>=5.9.0; sys_platform != 'win32'",
-    
-    # Development and testing
-    "pytest>=7.0.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=4.0.0",
-    "pytest-benchmark>=4.0.0",
-    
-    # Code quality
-    "ruff>=0.1.0",
-    "mypy>=1.5.0",
-    "pre-commit>=3.3.0",
 ]
 
 [project.optional-dependencies]
@@ -93,6 +82,7 @@ siem = [
 
 # Development tools
 dev = [
+    "hatch>=1.7.0",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
@@ -144,6 +134,7 @@ include = [
 
 [tool.hatch.envs.default]
 dependencies = [
+    "hatch>=1.7.0",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,9 @@ dependencies = [
     "ruff>=0.1.0",
 ]
 
+[tool.hatch.envs.lint.env-vars]
+PYTHONPATH = "src"
+
 [tool.hatch.envs.lint.scripts]
 lint = "ruff check src tests"
 format = "ruff format src tests"
@@ -173,23 +176,36 @@ dependencies = [
     "types-PyYAML",
 ]
 
+[tool.hatch.envs.typecheck.env-vars]
+PYTHONPATH = "src"
+
 [tool.hatch.envs.typecheck.scripts]
 typecheck = "mypy src tests examples"
 
 # Test environment
 [tool.hatch.envs.test]
-detached = true
 dependencies = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0", 
     "pytest-cov>=4.0.0",
     "pytest-benchmark>=4.0.0",
+    # Core runtime dependencies needed for tests
+    "fastapi>=0.100.0",
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "httpx>=0.24.0",
+    "orjson>=3.9.0",
+    "prometheus-client>=0.17.0",
+    "psutil>=5.9.0; sys_platform != 'win32'",
 ]
 
+[tool.hatch.envs.test.env-vars]
+PYTHONPATH = "src"
+
 [tool.hatch.envs.test.scripts]
-test = "pytest tests"
-test-cov = "pytest --cov=src/fapilog --cov-report=html --cov-report=term tests"
-test-benchmark = "pytest --benchmark-only tests"
+test = "python -m pytest tests"
+test-cov = "python -m pytest --cov=src/fapilog --cov-report=html --cov-report=term tests"
+test-benchmark = "python -m pytest --benchmark-only tests"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -5,7 +5,7 @@ Unit tests for AsyncLoggingContainer.
 import pytest
 
 from fapilog.containers.container import AsyncLoggingContainer
-from fapilog.core.settings import UniversalSettings
+from fapilog.core.settings import LogLevel, UniversalSettings
 
 
 class TestAsyncLoggingContainer:
@@ -14,7 +14,7 @@ class TestAsyncLoggingContainer:
     @pytest.fixture  # type: ignore[misc]
     def container_settings(self) -> UniversalSettings:
         """Create test settings."""
-        return UniversalSettings(level="INFO", sinks=["stdout"], max_workers=2)
+        return UniversalSettings(level=LogLevel.INFO, sinks=["stdout"], max_workers=2)
 
     @pytest.fixture  # type: ignore[misc]
     def container(self, container_settings: UniversalSettings) -> AsyncLoggingContainer:

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -10,7 +10,7 @@ import pytest
 
 from fapilog.core.events import EventCategory, LogEvent
 from fapilog.core.logger import AsyncLogger
-from fapilog.core.settings import UniversalSettings
+from fapilog.core.settings import LogLevel, UniversalSettings
 
 
 class TestAsyncLogger:
@@ -20,7 +20,7 @@ class TestAsyncLogger:
     async def logger_settings(self) -> UniversalSettings:
         """Create test settings."""
         return UniversalSettings(
-            level="DEBUG",
+            level=LogLevel.DEBUG,
             sinks=["stdout"],
             async_processing=True,
             zero_copy_operations=True,

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ isolated_build = True
 
 [testenv]
 deps =
-    pytest>=7.0.0
-    pytest-cov>=4.0.0
-    pytest-asyncio>=0.21.0
-    ruff>=0.1.0
+    pytest>=8.4.0
+    pytest-cov>=6.2.0
+    pytest-asyncio>=1.1.0
+    ruff>=0.12.0
     mypy>=1.17.1
     psutil>=5.9
     jsonschema==4.25.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     pytest-cov>=4.0.0
     pytest-asyncio>=0.21.0
     ruff>=0.1.0
-    mypy>=1.0.0
+    mypy>=1.17.1
     psutil>=5.9
     jsonschema==4.25.0
 extras = 


### PR DESCRIPTION
- Remove exit-non-zero flags from Ruff to allow auto-fixing without failures
- Add lenient MyPy settings for tests/ directory:
  - Disable untyped decorators, strict equality, unreachable warnings
  - Allow test-specific patterns while maintaining basic type safety
- Add pre-commit configuration with default stages
- Enable smoother workflow: auto-fix → re-stage → commit successfully