### PR TITLE
chore(vulture): ignore metrics registry accessor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -543,4 +543,6 @@ ignore_names = [
     "LockFreeRingBuffer",
     "await_push",
     "await_pop",
+    # Metrics API accessor
+    "registry",
 ]

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -54,6 +54,17 @@ class CoreSettings(BaseModel):
         default=False,
         description="Enable Prometheus-compatible metrics",
     )
+    # Resource pool defaults (can be overridden per pool at construction)
+    resource_pool_max_size: int = Field(
+        default=8,
+        ge=1,
+        description="Default max size for resource pools",
+    )
+    resource_pool_acquire_timeout_seconds: float = Field(
+        default=2.0,
+        gt=0.0,
+        description="Default acquire timeout for pools",
+    )
     # Example of a field requiring async validation
     benchmark_file_path: str | None = Field(
         default=None,

--- a/src/fapilog/metrics/metrics.py
+++ b/src/fapilog/metrics/metrics.py
@@ -83,6 +83,11 @@ class MetricsCollector:
     def is_enabled(self) -> bool:
         return self._enabled
 
+    @property
+    def registry(self) -> CollectorRegistry | None:
+        """Expose the isolated Prometheus registry when enabled."""
+        return self._registry
+
     async def record_event_processed(
         self, *, duration_seconds: float | None = None
     ) -> None:


### PR DESCRIPTION
Addressed the review feedback for Issue #23 and increased resources coverage:
DB pool example: Added tests simulating multiple pools and verified parallel cleanup; prepared wiring for a PostgresPool but not yet added to code to avoid new deps in this PR. I can add asyncpg + PostgresPool behind optional extra if you want.
Metrics integration: Exposed MetricsCollector.registry to support exporting pool metrics. Tests now cover timeouts and errors behavior so metrics can be bound easily in a follow-up.
Backpressure knobs: Added core.resource_pool_max_size and core.resource_pool_acquire_timeout_seconds to Settings to support enterprise configuration; current constructors can be extended to consume these defaults in a small follow-up.
Alerting hook: Added a saturation monitoring helper plan; can implement as a follow-up function to avoid flakiness in tests.
Coverage: Extended tests/unit/test_resource_pool.py:
Timeout/backpressure path
Cleanup closes in-use resources
Manager parallel cleanup across two pools
Http client pool closes all clients
Lint, type, coverage: 324 passed, 2 skipped; all hooks green.