### PR TITLE
feat: story 2.4d - Plugin Performance and Tools

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -1,5 +1,37 @@
 # 📌 Fapilog Milestone Tracker
 
+## Prometheus Exporter Integration Example (FastAPI)
+
+Expose Prometheus metrics from the collector's isolated registry via FastAPI:
+
+```python
+from fastapi import FastAPI, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from fapilog.core.observability import (
+    ObservabilitySettings,
+    create_metrics_collector_from_settings,
+)
+
+app = FastAPI()
+metrics = create_metrics_collector_from_settings(
+    ObservabilitySettings(metrics={"enabled": True, "exporter": "prometheus"})
+)
+
+@app.get("/metrics")
+async def metrics_endpoint() -> Response:
+    registry = metrics.registry
+    if registry is None:
+        return Response(status_code=204)
+    data = generate_latest(registry)
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)
+```
+
+Notes:
+
+- The collector is container-scoped; this example wires a process-level instance for demonstration.
+- For production, create the collector from your container settings and inject it where needed.
+
 This document outlines the prioritized roadmap for `fapilog`, including core development, FastAPI integration, enterprise plugin support, and documentation milestones.
 
 ---

--- a/docs/prd/epic-3-plugin-ecosystem-foundation.md
+++ b/docs/prd/epic-3-plugin-ecosystem-foundation.md
@@ -4,6 +4,27 @@
 
 **Integration Requirements**: Plugin architecture must recreate all v2 extensibility patterns while adding ecosystem support and marketplace integration.
 
+Distribution & Install Model (Non-negotiables)
+Base package: fapilog installs core only (pip install fapilog).
+
+Extras: optional feature sets and first-party plugins are installable via extras, e.g. pip install fapilog[fastapi,opentelemetry].
+
+External plugins: community/enterprise plugins are separate PyPI packages using the fapilog-\* naming convention (e.g. fapilog-fastapi, fapilog-splunk), and are also exposed via fapilog extras where applicable.
+
+Discovery: plugins are registered via Python entry points (group="fapilog.plugins"), resolved with importlib.metadata.entry_points.
+
+Version gates: each plugin declares a Requires-Dist: fapilog>=X,<Y range; the core enforces compatibility at load time with a clear error message.
+
+Namespacing: all public plugin APIs live under fapilog.plugins.\* (import path) and expose a minimal, stable interface contract.
+
+Install examples (must be in README and marketplace):
+
+Core only: pip install fapilog
+
+Core + FastAPI integration (first-party extra): pip install fapilog[fastapi]
+
+Community plugin (separate dist): pip install fapilog-splunk
+
 ## Story 3.1: Universal Plugin Architecture
 
 As a developer,
@@ -20,6 +41,12 @@ so that I can extend the library's functionality with my own custom logic.
 6. Plugin documentation standards recreating clarity
 7. Plugin CI/CD pipeline recreating quality gates
 8. Plugin marketplace infrastructure for ecosystem growth
+9. Plugin packaging spec:
+   1. First-party features exposed as extras via [project.optional-dependencies] in pyproject.toml.
+   2. Third-party plugins published as separate fapilog-\* packages.
+10. Entry point contract: plugins must register via entry_points={"fapilog.plugins": ["name=package.module:PluginClass"]}.
+11. Semantic versioning & compatibility matrix: documented policy and automated check on load.
+12. Fallback behavior: safe no-op when an extra isn’t installed; actionable error when a declared plugin can’t be loaded.
 
 ## Story 3.2: Plugin Marketplace Infrastructure
 
@@ -37,6 +64,10 @@ so that I can easily find and use community-developed plugins for common use cas
 6. Plugin monetization for community developers
 7. Compliance validation for enterprise plugins
 8. Security scanning for all plugins
+9. Marketplace surfaces install commands for both models (extras and separate packages).
+10. Automated compatibility badges (CI-generated) showing tested fapilog core versions per plugin.
+11. “Health signals” (downloads, CI status, supported Python versions) and security scan badges.
+12. One-click copy for pip and uv commands; guidance for constraints files/lockers.
 
 ## Story 3.3: Developer Plugin Experience
 
@@ -54,6 +85,11 @@ so that I can contribute to the ecosystem and share my solutions with the commun
 6. Plugin development environment with hot reloading
 7. Plugin debugging tools and error reporting
 8. Plugin performance profiling and optimization tools
+9. fapilog plugin new <name> scaffolds:
+   1. pyproject.toml with fapilog.plugins entry point
+   2. tests, type hints, pre-commit, and example PluginClass
+10. Template for first-party extras wiring (showing [project.optional-dependencies] and import guards).
+11. Local dev docs for verifying extras: pip install -e .[dev,fastapi] and python -c "import fapilog; fapilog.debug_plugins()".
 
 ## Story 3.4: Enterprise Plugin Ecosystem
 
@@ -71,3 +107,39 @@ so that I can meet regulatory requirements and integrate with enterprise observa
 6. Enterprise plugin support and consulting services
 7. Enterprise plugin marketplace with compliance validation
 8. Enterprise plugin performance benchmarks and guarantees
+9. Supply-chain requirements: signed wheels (Sigstore or similar), SBOM generation, and vulnerability scans in release CI.
+10. Enterprise distribution patterns: support for private indexes (Artifactory/Nexus) and constraints files; docs for mirroring extras into internal repos.
+11. Long-term support policy indicating minimum overlap of supported core/plugin versions (e.g., N–2).
+
+## Apendix
+
+```python
+# fapilog/plugin_api.py
+from typing import Protocol, Mapping, Any
+
+class Processor(Protocol):
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+    async def process(self, record: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+class Sink(Protocol):
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+    async def write(self, record: Mapping[str, Any]) -> None: ...
+```
+
+```toml
+# pyproject.toml (plugin package or core extras provider)
+[project]
+name = "fapilog-fastapi"
+dependencies = ["fapilog>=3.0,<4.0", "fastapi>=0.115"]
+
+[project.entry-points."fapilog.plugins"]
+fastapi = "fapilog_fastapi:FastAPIPlugin"
+```
+
+```toml
+# pyproject.toml (core package exposing extras)
+[project.optional-dependencies]
+fastapi = ["fapilog-fastapi>=1.0,<2.0", "fastapi>=0.115"]
+```

--- a/examples/fastapi_metrics/main.py
+++ b/examples/fastapi_metrics/main.py
@@ -1,0 +1,50 @@
+"""
+Minimal FastAPI example exposing Fapilog's Prometheus metrics.
+
+Run:
+    pip install fastapi uvicorn
+    uvicorn examples.fastapi_metrics.main:app --reload
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import FastAPI, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from fapilog.core.observability import (
+    ObservabilitySettings,
+    create_metrics_collector_from_settings,
+)
+from fapilog.metrics.metrics import plugin_timer
+
+app = FastAPI(title="Fapilog Metrics Example")
+
+# Enable Prometheus exporter in the collector's isolated registry
+metrics = create_metrics_collector_from_settings(
+    ObservabilitySettings(metrics={"enabled": True, "exporter": "prometheus"})
+)
+
+
+@app.get("/metrics")
+async def metrics_endpoint() -> Response:
+    """Expose Prometheus metrics for scraping (e.g., by Prometheus server)."""
+    registry = metrics.registry
+    if registry is None:
+        return Response(status_code=204)
+    payload = generate_latest(registry)
+    return Response(content=payload, media_type=CONTENT_TYPE_LATEST)
+
+
+@app.get("/simulate")
+async def simulate_work() -> dict[str, bool]:
+    """Simulate a single plugin execution and record an event metric.
+
+    Use the reusable plugin_timer context to automatically record latency and
+    error metrics for a synthetic plugin call.
+    """
+    async with plugin_timer(metrics, "DemoPlugin"):
+        await asyncio.sleep(0.01)
+    await metrics.record_event_processed()
+    return {"ok": True}

--- a/src/fapilog/plugins/processors/__init__.py
+++ b/src/fapilog/plugins/processors/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from typing import Iterable
 
 from ...core.processing import process_in_parallel
-from ...metrics.metrics import MetricsCollector
+from ...metrics.metrics import MetricsCollector, plugin_timer
 
 
 class BaseProcessor:
@@ -43,10 +43,9 @@ async def process_parallel(
         out: list[memoryview] = []
         for v in current_views:
             try:
-                processed = await p.process(v)
+                async with plugin_timer(metrics, p.__class__.__name__):
+                    processed = await p.process(v)
             except Exception:
-                if metrics is not None:
-                    await metrics.record_plugin_error(plugin_name=p.__class__.__name__)
                 raise
             else:
                 out.append(processed)


### PR DESCRIPTION
Summary
Implements GitHub Issue #36 (Story 2.4d: Plugin Performance & Tools). Adds per-plugin profiling with centralized timing, instruments plugin execution paths, and provides a minimal FastAPI exporter example.
What’s changed
Metrics
Added per-plugin profiling APIs in MetricsCollector:
record_plugin_execution(plugin_name, duration_seconds, success)
get_plugin_stats(plugin_name), all_plugin_stats()
Added Prometheus histogram fapilog_plugin_exec_seconds{plugin=...}
Introduced reusable async context manager plugin_timer(...) for centralized timing/error metrics
Plugin pipeline
Refactored enrich_parallel and process_parallel to use plugin_timer (removes try/except timing duplication; preserves error isolation)
Examples
New examples/fastapi_metrics/main.py: FastAPI endpoint exposing /metrics using the collector’s isolated CollectorRegistry
Docs
Added Prometheus exporter snippet to docs/milestones.md