### PR TITLE
chore: add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# ReadTheDocs configuration
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    # Install the package itself (for autodoc to work)
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+    # Install Sphinx dependencies
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -23,4 +23,5 @@ psutil>=5.9.0
 myst-nb>=0.17.0
 sphinxext-opengraph
 sphinx-issues
-sphinx-rtd-dark-mode 
+sphinx-rtd-dark-mode
+sphinxcontrib-mermaid>=0.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,11 +82,14 @@ dev = [
     "vulture>=2.9.0",
 ]
 
-# Documentation
+# Documentation (Sphinx-based)
 docs = [
-    "mkdocs>=1.5.0",
-    "mkdocs-material>=9.0.0",
-    "mkdocstrings[python]>=0.22.0",
+    "sphinx>=6.0.0",
+    "sphinx-rtd-theme>=1.3.0",
+    "myst-parser>=1.0.0",
+    "sphinx-autodoc-typehints>=1.24.0",
+    "sphinx-copybutton>=0.5.0",
+    "sphinxcontrib-mermaid>=0.9.0",
 ]
 
 # All optional dependencies


### PR DESCRIPTION
- Add .readthedocs.yaml for automated doc builds
- Add sphinxcontrib-mermaid to docs/requirements.txt
- Fix pyproject.toml docs extras to use Sphinx (not mkdocs)

This enables ReadTheDocs to automatically build versioned documentation
on every push, complementing the GitHub Pages deployment on releases.