### PR TITLE
chore: update CI configuration and improve pydantic v1 checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,21 @@ name: CI
 
 on:
   push:
-    branches: [ main, "feature/**" ]
+    branches: [main, "feature/**"]
+    paths-ignore:
+      - "*.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".readthedocs.yml"
   pull_request:
-    branches: [ main ]
+    branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - "docs/**"
+      - ".readthedocs.yml"
 
 permissions:
   contents: read
@@ -14,39 +26,39 @@ jobs:
     name: Build & Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
-    
-    - name: Install Hatch
-      run: |
-        python -m pip install --upgrade pip
-        pip install hatch
-    
-    - name: Run lint
-      run: hatch run lint:lint
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Hatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Run lint
+        run: hatch run lint:lint
 
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
-    
-    - name: Install Hatch
-      run: |
-        python -m pip install --upgrade pip
-        pip install hatch
-    
-    - name: Run type check
-      run: hatch run typecheck:typecheck
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Hatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Run type check
+        run: hatch run typecheck:typecheck
 
   test:
     name: Test & Coverage
@@ -55,29 +67,29 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    
-    - name: Install Hatch
-      run: |
-        python -m pip install --upgrade pip
-        pip install hatch
-    
-    - name: Run tests with coverage
-      run: hatch run test:test-cov
-    
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Hatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Run tests with coverage
+        run: hatch run test:test-cov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   tox:
     name: Tox (Compatibility)
@@ -86,17 +98,17 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    
-    - name: Install Tox
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
-    
-    - name: Run tox
-      run: tox -q 
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Run tox
+        run: tox -q

--- a/scripts/check_pydantic_v1.py
+++ b/scripts/check_pydantic_v1.py
@@ -31,8 +31,8 @@ PYDANTIC_V1_PATTERNS = [
     (r"\.parse_obj\s*\(", ".parse_obj should be .model_validate"),
     # parse_raw (should be model_validate_json)
     (r"\.parse_raw\s*\(", ".parse_raw should be .model_validate_json"),
-    # dict() method (should be model_dump)
-    (r"\.dict\s*\(", ".dict() should be .model_dump()"),
+    # dict() method (should be model_dump) - exclude patch.dict from unittest.mock
+    (r"(?<!patch)\.dict\s*\(", ".dict() should be .model_dump()"),
     # json() method (should be model_dump_json)
     (r"\.json\s*\(", ".json() should be .model_dump_json()"),
     # Config class with old syntax


### PR DESCRIPTION
- Modify CI workflow to ignore specific paths for push and pull request events, reducing unnecessary checks on documentation and license files.
- Enhance pydantic v1 compatibility check by excluding `patch.dict` from unittest.mock in the regex for the `.dict()` method, ensuring more accurate validation.