### PR TITLE
docs: add release-notes.md that includes CHANGELOG

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+```{include} ../CHANGELOG.md
+:start-line: 2
+```


### PR DESCRIPTION
The docs site was missing release-notes.md (referenced in index.md but never created). This creates a simple file that uses MyST include to pull in the CHANGELOG.md content, so the docs always show current release notes.