### PR TITLE
fix: disable PDF/ePub in ReadTheDocs (LaTeX builder crash)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -27,10 +27,10 @@ python:
       extra_requirements:
         - docs
 
-# Optional: enable PDF generation
-formats:
-  - pdf
-  - epub
+# PDF/ePub disabled - causes Sphinx LaTeX builder crash with tables
+# formats:
+#   - pdf
+#   - epub
 
 # Optional: enable search
 search:


### PR DESCRIPTION
The Sphinx LaTeX builder crashes with a StopIteration error when processing tables for PDF output. HTML builds work fine.

This disables PDF/ePub generation for now. Can be re-enabled after fixing the problematic table(s) or when Sphinx fixes the bug.