### PR TITLE
fix: remove placeholder links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,6 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 - [GitHub Repository](https://github.com/chris-haste/fapilog)
 - [Documentation](https://fapilog.readthedocs.io/)
-- [Plugin Marketplace](https://plugins.fapilog.dev/)
-- [Community Discord](https://discord.gg/fapilog)
 
 ---
 


### PR DESCRIPTION
Removed Plugin Marketplace and Community Discord links from README since these resources don't exist yet.