### PR TITLE
feat(tamper): implement enterprise key management (Story 4.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Fapilog features a universal plugin ecosystem:
   - Under a simulated 3 ms-per-write sink, fapilog reduced app-side log-call latency by ~75–80% vs stdlib, maintaining sub‑millisecond medians. Reproduce with `scripts/benchmarking.py`.
 - **Burst absorption with predictable behavior**
   - With a 20k burst and a 3 ms sink delay, fapilog processed ~90% and dropped ~10% per policy, keeping the app responsive.
+- **Tamper-evident logging add-on**
+  - Optional `fapilog-tamper` package adds integrity MAC/signatures, sealed manifests, and enterprise key management (AWS/GCP/Azure/Vault). See `docs/addons/tamper-evident-logging.md` and `docs/enterprise/tamper-enterprise-key-management.md`.
 - **Honest note**
   - In steady-state fast-sink scenarios, Python’s stdlib logging can be faster per call. Fapilog shines under constrained sinks, concurrency, and bursts.
 

--- a/docs/addons/tamper-evident-logging.md
+++ b/docs/addons/tamper-evident-logging.md
@@ -9,11 +9,11 @@ This design keeps the core light while offering an opt-in, first-class tamper-ev
 
 | Story                                                       | Title                          | Status |
 | ----------------------------------------------------------- | ------------------------------ | ------ |
-| [4.14](../stories/4.14.fapilog-tamper-package-bootstrap.md) | Package Bootstrap              | Ready  |
-| [4.15](../stories/4.15.integrity-enricher-chain-state.md)   | IntegrityEnricher & ChainState | Ready  |
-| [4.16](../stories/4.16.sealed-sink-manifests.md)            | SealedSink & Manifests         | Ready  |
-| [4.17](../stories/4.17.verification-api-cli.md)             | Verification API & CLI         | Ready  |
-| [4.18](../stories/4.18.enterprise-key-management.md)        | Enterprise Key Management      | Ready  |
+| [4.14](../stories/4.14.fapilog-tamper-package-bootstrap.md) | Package Bootstrap              | Done   |
+| [4.15](../stories/4.15.integrity-enricher-chain-state.md)   | IntegrityEnricher & ChainState | Done   |
+| [4.16](../stories/4.16.sealed-sink-manifests.md)            | SealedSink & Manifests         | Done   |
+| [4.17](../stories/4.17.verification-api-cli.md)             | Verification API & CLI         | Done   |
+| [4.18](../stories/4.18.enterprise-key-management.md)        | Enterprise Key Management      | Done   |
 
 > **Note**: Story 4.13 (keyless hash chains in core) was cancelled. All tamper-evident functionality is in the plugin.
 
@@ -93,6 +93,8 @@ This design keeps the core light while offering an opt-in, first-class tamper-ev
 - `tamper.algorithm`, `tamper.key_id`, `tamper.key_source`, `tamper.state_dir`
 - `tamper.fsync_on_write`, `tamper.rotate_chain`, `tamper.use_signatures` (Ed25519)
 - `tamper.verify_on_close` (run verifier after rotation), `tamper.alert_on_failure`
+- `tamper.key_cache_ttl_seconds`, `tamper.use_kms_signing`, `tamper.aws_region`, `tamper.vault_*`, `tamper.azure_*`
+- Supported `key_source`: `env`, `file`, `aws-kms`, `gcp-kms`, `azure-keyvault`, `vault` (optional deps `fapilog-tamper[all-kms]`)
 
 ## Durability and Performance
 

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -1,22 +1,31 @@
 # Enterprise Features
 
-Fapilog is built for production use in enterprise environments. This page consolidates the compliance, audit, and security capabilities that differentiate fapilog from general-purpose logging libraries.
+Fapilog provides building blocks for enterprise environments. This page highlights the compliance, audit, and security capabilities you can compose with fapilog and its add-ons. It is **not** a certification or a guarantee of regulatory compliance; you must validate controls for your own environment.
 
 ## At a Glance
 
 | Capability | Description |
 |------------|-------------|
-| **Compliance Levels** | SOC2, HIPAA, GDPR, PCI-DSS, ISO 27001, SOX |
-| **Audit Trail** | Structured audit events with tamper-evident hash chains |
-| **Data Protection** | PII/PHI classification, redaction, encryption config |
-| **Access Control** | Role-based access, auth mode configuration |
-| **Integrity** | SHA-256 checksums, sequence numbers, chain verification |
+| **Compliance Controls (assist)** | Policy templates and logging patterns that can be aligned to SOC2, HIPAA, GDPR, PCI-DSS, ISO 27001, SOX (you own control validation) |
+| **Audit Trail** | Structured audit events with optional tamper-evident hash chains (via add-on) |
+| **Data Protection** | PII/PHI tagging, redaction knobs, encryption settings |
+| **Access Control** | Role-based access settings and auth mode configuration helpers |
+| **Integrity** | SHA-256 checksums, sequence numbers, chain verification (when enabled) |
 
 ---
 
-## Compliance Framework Support
+## Add-on spotlight: Tamper-Evident Logging + KMS/Vault
 
-Fapilog provides configuration presets for major compliance frameworks:
+- **What**: `fapilog-tamper` add-on that adds per-record MAC/signatures, sealed manifests, and cross-file chain verification.
+- **Key management**: Integrates with AWS KMS, GCP KMS, Azure Key Vault, and HashiCorp Vault (including KMS-native signing so keys never leave the provider). Optional extras: `fapilog-tamper[all-kms]`.
+- **Docs**: See [Enterprise Key Management for Tamper-Evident Logging](enterprise/tamper-enterprise-key-management.md) for architecture, configuration, and deployment guidance.
+- **Use cases**: Regulated audit trails (SOX/SOC2/HIPAA/PCI), shared services with centralized key custodians, and environments that require attested manifests for log rotation.
+
+---
+
+## Compliance Framework Support (assist, not certification)
+
+Fapilog ships configuration helpers that can map to common frameworks. Use them as starting points and validate against your own policies and auditors:
 
 ```python
 from fapilog.core.audit import ComplianceLevel, CompliancePolicy
@@ -31,22 +40,22 @@ policy = CompliancePolicy(
 )
 ```
 
-### Supported Frameworks
+### Example control mappings (non-exhaustive)
 
-| Framework | Key Features Enabled |
-|-----------|---------------------|
+| Framework | Control areas this can help with |
+|-----------|----------------------------------|
 | **SOC2** | Encryption, integrity checks, access logging |
-| **HIPAA** | PHI redaction, minimum necessary rule, audit trails |
-| **GDPR** | PII redaction, data subject rights support |
-| **PCI-DSS** | Encryption at rest, access control validation |
-| **ISO 27001** | Full security controls, integrity verification |
-| **SOX** | Change control, audit trails |
+| **HIPAA** | PHI redaction, minimum necessary patterns, audit trails |
+| **GDPR** | PII redaction, data subject request support (application responsibility) |
+| **PCI-DSS** | Encryption at rest, access logging (card data handling remains your responsibility) |
+| **ISO 27001** | Security logging and integrity controls |
+| **SOX** | Change/event logging with chain verification |
 
 ---
 
 ## Audit Trail System
 
-The `AuditTrail` class provides comprehensive audit logging for compliance:
+The `AuditTrail` building blocks provide structured audit logging. You control event content and ensure policies meet your regulatory scope:
 
 ```python
 from fapilog.core.audit import AuditTrail, AuditEventType, CompliancePolicy
@@ -90,7 +99,7 @@ await audit.log_data_access(
 
 ## Tamper-Evident Hash Chains
 
-Every audit event includes cryptographic integrity fields that enable detection of tampering or gaps:
+When you enable the tamper-evident add-on, audit events can include cryptographic integrity fields to detect tampering or gaps:
 
 ```python
 # Each AuditEvent automatically includes:
@@ -149,7 +158,7 @@ await audit.log_data_access(
 
 ### Automatic Redaction
 
-Built-in redactors protect sensitive data in logs:
+Built-in redactors help mask common sensitive fields but must be tuned to your schemas and policies:
 
 ```python
 from fapilog import get_logger, Settings
@@ -174,7 +183,7 @@ See [Redaction Guarantees](redaction-guarantees.md) for configuration details.
 
 ### Encryption Configuration
 
-Configure encryption with support for enterprise key management:
+Configure encryption with support for enterprise key management. These are primitives; key custody and rotation remain your responsibility:
 
 ```python
 from fapilog.core.encryption import EncryptionSettings
@@ -202,7 +211,7 @@ encryption = EncryptionSettings(
 
 ## Access Control
 
-Configure role-based access control:
+Configure role-based access control. Integrate with your identity provider and test according to your threat model:
 
 ```python
 from fapilog.core.access_control import AccessControlSettings
@@ -221,7 +230,7 @@ access = AccessControlSettings(
 
 ## Retention Policies
 
-Configure log retention for compliance:
+Configure log retention to align with your data lifecycle requirements:
 
 ```python
 policy = CompliancePolicy(
@@ -328,4 +337,3 @@ Fapilog's JSON output integrates with standard log aggregators:
 - [Redaction Guarantees](redaction-guarantees.md) - PII/secret protection
 - [Core Concepts: Redaction](core-concepts/redaction.md) - Redactor configuration
 - [API Reference: Configuration](api-reference/configuration.md) - Settings reference
-

--- a/docs/enterprise/tamper-enterprise-key-management.md
+++ b/docs/enterprise/tamper-enterprise-key-management.md
@@ -1,0 +1,85 @@
+# Tamper-Evident Logging: Enterprise Key Management
+
+Tamper-evident logging in fapilog is delivered as the `fapilog-tamper` add-on. This guide focuses on enterprise key management—how to integrate cloud KMS and Vault, keep keys out of the app process, and operate with rotation and attestation requirements.
+
+## Overview
+
+- **Features**: HMAC/Ed25519 per-record signatures, forward hash chains, sealed rotation manifests, cross-file verification.
+- **Key sources**: `env`, `file`, `aws-kms`, `gcp-kms`, `azure-keyvault`, `vault`.
+- **Signing modes**: Local (exported data keys) or provider-native signing (`use_kms_signing=True`) so key material never leaves the KMS/Vault.
+- **Caching**: `key_cache_ttl_seconds` (default 300s) for data keys; caches auto-expire and refresh.
+
+## Installation
+
+```bash
+pip install './packages/fapilog-tamper[all-kms]'
+```
+
+Or pick a provider:
+
+- AWS: `pip install './packages/fapilog-tamper[aws]'`
+- GCP: `pip install './packages/fapilog-tamper[gcp]'`
+- Azure: `pip install './packages/fapilog-tamper[azure]'`
+- Vault: `pip install './packages/fapilog-tamper[vault]'`
+
+## Configuration (Pydantic model)
+
+```python
+from fapilog_tamper import TamperConfig
+
+cfg = TamperConfig(
+    enabled=True,
+    key_id="alias/audit-2025",
+    key_source="aws-kms",        # env | file | aws-kms | gcp-kms | azure-keyvault | vault
+    use_kms_signing=True,        # prefer provider Sign/Verify so keys stay in KMS/Vault
+    key_cache_ttl_seconds=300,   # data-key cache when exporting
+    aws_region="us-east-1",      # optional
+    vault_addr="https://vault.example.com",
+    vault_auth_method="approle", # token | approle | kubernetes
+    vault_role="audit-writer",
+    azure_tenant_id="...",
+    azure_client_id="...",
+)
+```
+
+## Provider behaviors
+
+| Provider | Exports key? | Signing path | Notes |
+|----------|--------------|--------------|-------|
+| `aws-kms` | Data key via `GenerateDataKey` (cached by TTL) | `Sign/Verify` with `use_kms_signing=True` | Respects AWS credential chain; region optional |
+| `gcp-kms` | No | `mac_sign` / `mac_verify` | Uses ADC; key_id is full resource name |
+| `azure-keyvault` | No | `CryptographyClient.sign/verify` (HS256) | Supports managed identity or client credential |
+| `vault` | No | Transit `sign_data` / `verify_signed_data` | Auth: token/env, AppRole, Kubernetes (JWT mounted) |
+| `env` / `file` | Yes | Local HMAC-SHA256 or Ed25519 | Development/on-prem convenience |
+
+## Using the provider in the add-on
+
+```python
+from fapilog_tamper import TamperSealedPlugin
+
+plugin = TamperSealedPlugin
+enricher = plugin.get_enricher(cfg.model_dump())
+sink = plugin.wrap_sink(rotating_sink, cfg.model_dump())
+```
+
+- **Enricher** computes MAC/signature per record; when `use_kms_signing=True` it delegates to the provider.
+- **SealedSink** signs manifests with the same provider; manifests include `key_id` and `signature_algo` for verifier lookup.
+- **Verifier** consumes keys from env/file stores today; manifests remain verifiable when the key is available (exported or cached).
+
+## Operational guidance
+
+- Prefer `use_kms_signing=True` in regulated environments; fall back to exported data keys only when latency requirements demand it.
+- Set `key_cache_ttl_seconds` to your rotation policy; low TTL narrows exposure if a data key is compromised.
+- Never log credentials or secrets; the implementation avoids logging tokens and clears cached keys on shutdown.
+- Run `fapilog-tamper verify <file> --manifest <file.manifest.json>` in CI or SOAR pipelines to attest to log integrity.
+
+## Troubleshooting
+
+- Missing SDK: clear `ImportError` messages suggest the correct `[extra]`.
+- Auth failures: validate IAM/AppRole/service principals outside the app first; the provider uses default credential chains.
+- Vault transit path: `key_id` should point to the transit key name (e.g., `transit/keys/audit`).
+
+## See also
+
+- Story detail: [4.18 Enterprise Key Management](../stories/4.18.enterprise-key-management.md)
+- Add-on overview: [Tamper-Evident Logging](../addons/tamper-evident-logging.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ appendices
 - **[Getting Started](getting-started/index.md)** - Installation and quickstart
 - **[Core Concepts](core-concepts/index.md)** - Understanding the architecture
 - **[User Guide](user-guide/index.md)** - Practical usage and configuration
-- **[Enterprise Features](enterprise.md)** - Compliance, audit trails, and security
+- **[Enterprise Features](enterprise.md)** - Compliance, audit trails, and security (see the new tamper/KMS guide under Enterprise)
 
 **Reference:**
 

--- a/packages/fapilog-tamper/README.md
+++ b/packages/fapilog-tamper/README.md
@@ -16,6 +16,12 @@ For Ed25519 signature support, install the optional group:
 pip install './packages/fapilog-tamper[signatures]'
 ```
 
+For enterprise key management (AWS KMS, GCP KMS, Azure Key Vault, Vault):
+
+```bash
+pip install './packages/fapilog-tamper[all-kms]'
+```
+
 ## Usage
 
 ```python
@@ -27,3 +33,25 @@ enricher = plugin.get_enricher()
 
 The initial release provides placeholder components; subsequent stories layer on
 full tamper-evident enrichment, sealed sinks, manifests, and verification.
+
+## Enterprise key management
+
+- `key_source`: `env`, `file`, `aws-kms`, `gcp-kms`, `azure-keyvault`, `vault`
+- `key_cache_ttl_seconds`: cache duration for locally exported keys/data keys (default 5 minutes)
+- `use_kms_signing`: call cloud/Vault APIs for signing so keys never leave the service
+- Optional per-provider knobs:
+  - AWS: `aws_region`
+  - Vault: `vault_addr`, `vault_auth_method` (`token`/`approle`/`kubernetes`), `vault_role`
+  - Azure: `azure_tenant_id`, `azure_client_id`
+
+Example:
+
+```python
+cfg = TamperConfig(
+    enabled=True,
+    key_id="alias/audit-2025",
+    key_source="aws-kms",
+    use_kms_signing=True,
+    key_cache_ttl_seconds=300,
+)
+```

--- a/packages/fapilog-tamper/pyproject.toml
+++ b/packages/fapilog-tamper/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
 
 [project.optional-dependencies]
 signatures = ["pynacl>=1.5.0"]
+aws = ["boto3>=1.26.0"]
+gcp = ["google-cloud-kms>=2.0.0"]
+azure = ["azure-keyvault-keys>=4.0.0", "azure-identity>=1.0.0"]
+vault = ["hvac>=1.0.0"]
+all-kms = ["fapilog-tamper[aws,gcp,azure,vault,signatures]"]
 
 [project.entry-points."fapilog.integrity"]
 tamper-sealed = "fapilog_tamper:TamperSealedPlugin"

--- a/packages/fapilog-tamper/src/fapilog_tamper/__init__.py
+++ b/packages/fapilog-tamper/src/fapilog_tamper/__init__.py
@@ -7,6 +7,16 @@ from .chain_state import GENESIS_HASH, ChainStatePersistence
 from .config import TamperConfig
 from .enricher import IntegrityEnricher
 from .plugin import TamperSealedPlugin, TamperSealedPluginClass
+from .providers import (
+    AwsKmsProvider,
+    AzureKeyVaultProvider,
+    EnvKeyProvider,
+    FileKeyProvider,
+    GcpKmsProvider,
+    KeyProvider,
+    VaultProvider,
+    create_key_provider,
+)
 from .sealed_sink import ManifestGenerator, SealedSink
 from .types import ChainState, IntegrityFields
 from .verify import (
@@ -38,6 +48,14 @@ __all__ = [
     "KeyStore",
     "EnvKeyStore",
     "FileKeyStore",
+    "EnvKeyProvider",
+    "FileKeyProvider",
+    "AwsKmsProvider",
+    "GcpKmsProvider",
+    "AzureKeyVaultProvider",
+    "VaultProvider",
+    "KeyProvider",
+    "create_key_provider",
     "run_self_check",
     "verify_chain_across_files",
     "write_manifest",

--- a/packages/fapilog-tamper/src/fapilog_tamper/config.py
+++ b/packages/fapilog-tamper/src/fapilog_tamper/config.py
@@ -15,9 +15,19 @@ class TamperConfig(BaseModel):
     enabled: bool = False
     algorithm: Literal["HMAC-SHA256", "Ed25519"] = "HMAC-SHA256"
     key_id: str = ""
-    key_source: Literal["env", "file", "kms", "vault"] = "env"
+    key_source: Literal[
+        "env", "file", "aws-kms", "gcp-kms", "azure-keyvault", "vault"
+    ] = "env"
     key_env_var: str = "FAPILOG_TAMPER_KEY"
     key_file_path: str | None = None
+    key_cache_ttl_seconds: int = 300
+    use_kms_signing: bool = False
+    aws_region: str | None = None
+    vault_addr: str | None = None
+    vault_auth_method: Literal["token", "approle", "kubernetes"] = "token"
+    vault_role: str | None = None
+    azure_tenant_id: str | None = None
+    azure_client_id: str | None = None
     state_dir: str = ".fapilog-chainstate"
     fsync_on_write: bool = False
     fsync_on_rotate: bool = True

--- a/packages/fapilog-tamper/src/fapilog_tamper/providers.py
+++ b/packages/fapilog-tamper/src/fapilog_tamper/providers.py
@@ -1,0 +1,450 @@
+"""
+Key provider implementations for enterprise key management backends.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import importlib
+import os
+import time
+from pathlib import Path
+from typing import Protocol
+
+from .config import TamperConfig
+
+
+class KeyProvider(Protocol):
+    """Protocol for retrieving and using signing keys."""
+
+    async def get_key(self, key_id: str) -> bytes | None:
+        """Retrieve key material by ID."""
+
+    async def sign(self, key_id: str, data: bytes) -> bytes:
+        """Sign data using key (remote or local)."""
+
+    async def verify(self, key_id: str, data: bytes, signature: bytes) -> bool:
+        """Verify signature using key."""
+
+    async def rotate_check(self) -> bool:
+        """Check for rotation and refresh cache."""
+
+
+def _decode_key(raw: bytes | None) -> bytes | None:
+    """Decode base64url or raw key material to 32 bytes."""
+    if raw is None:
+        return None
+    padding = b"=" * (-len(raw) % 4)
+    candidates = []
+    try:
+        candidates.append(base64.urlsafe_b64decode(raw + padding))
+    except Exception:
+        pass
+    candidates.append(raw)
+    for c in candidates:
+        if len(c) == 32:
+            return c
+    return None
+
+
+class _CachedProvider:
+    def __init__(self, cache_ttl: int) -> None:
+        self._cache_ttl = cache_ttl
+        self._cached_key: bytes | None = None
+        self._cache_expires: float = 0.0
+
+    def _cache_get(self) -> bytes | None:
+        if self._cached_key and time.time() < self._cache_expires:
+            return self._cached_key
+        return None
+
+    def _cache_set(self, key: bytes | None) -> None:
+        if key:
+            self._cached_key = key
+            self._cache_expires = time.time() + self._cache_ttl
+        else:
+            self._cached_key = None
+            self._cache_expires = 0.0
+
+    async def rotate_check(self) -> bool:
+        if self._cached_key and time.time() >= self._cache_expires:
+            self._cached_key = None
+            return True
+        return False
+
+
+class EnvKeyProvider(_CachedProvider):
+    """Key provider backed by environment variables."""
+
+    def __init__(self, env_var: str, cache_ttl: int = 300) -> None:
+        super().__init__(cache_ttl)
+        self._env_var = env_var
+
+    async def get_key(self, key_id: str) -> bytes | None:  # noqa: ARG002
+        cached = self._cache_get()
+        if cached:
+            return cached
+        val = os.getenv(self._env_var)
+        key = _decode_key(val.encode("utf-8")) if val else None
+        self._cache_set(key)
+        return key
+
+    async def sign(self, key_id: str, data: bytes) -> bytes:  # noqa: ARG002
+        key = await self.get_key(self._env_var)
+        if not key:
+            return b""
+        return hmac.new(key, data, hashlib.sha256).digest()
+
+    async def verify(self, key_id: str, data: bytes, signature: bytes) -> bool:  # noqa: ARG002
+        key = await self.get_key(self._env_var)
+        if not key:
+            return False
+        expected = hmac.new(key, data, hashlib.sha256).digest()
+        return hmac.compare_digest(expected, signature)
+
+
+class FileKeyProvider(_CachedProvider):
+    """Key provider backed by local files."""
+
+    def __init__(self, path: str | Path, cache_ttl: int = 300) -> None:
+        super().__init__(cache_ttl)
+        self._path = Path(path)
+
+    async def get_key(self, key_id: str) -> bytes | None:  # noqa: ARG002
+        cached = self._cache_get()
+        if cached:
+            return cached
+        raw: bytes | None = None
+        if self._path.is_file():
+            try:
+                raw = await asyncio.to_thread(self._path.read_bytes)
+            except Exception:
+                raw = None
+        else:
+            candidate = self._path / f"{key_id}.key"
+            if candidate.exists():
+                raw = await asyncio.to_thread(candidate.read_bytes)
+        key = _decode_key(raw)
+        self._cache_set(key)
+        return key
+
+    async def sign(self, key_id: str, data: bytes) -> bytes:  # noqa: ARG002
+        key = await self.get_key(key_id)
+        if not key:
+            return b""
+        return hmac.new(key, data, hashlib.sha256).digest()
+
+    async def verify(self, key_id: str, data: bytes, signature: bytes) -> bool:  # noqa: ARG002
+        key = await self.get_key(key_id)
+        if not key:
+            return False
+        expected = hmac.new(key, data, hashlib.sha256).digest()
+        return hmac.compare_digest(expected, signature)
+
+
+class AwsKmsProvider(_CachedProvider):
+    """AWS KMS provider with optional remote signing."""
+
+    def __init__(
+        self,
+        key_id: str,
+        region: str | None = None,
+        cache_ttl: int = 300,
+        use_kms_signing: bool = False,
+        client: object | None = None,
+    ) -> None:
+        super().__init__(cache_ttl)
+        self._key_id = key_id
+        self._use_kms_signing = use_kms_signing
+        if client is None:
+            boto3 = importlib.import_module("boto3")
+            client = boto3.client("kms", region_name=region)
+        self._client = client
+
+    async def get_key(self, key_id: str) -> bytes | None:  # noqa: ARG002
+        if self._use_kms_signing:
+            return None
+        cached = self._cache_get()
+        if cached:
+            return cached
+        response = await asyncio.to_thread(
+            self._client.generate_data_key, KeyId=self._key_id, KeySpec="AES_256"
+        )
+        key = response.get("Plaintext")
+        if isinstance(key, bytes):
+            self._cache_set(key)
+            return key
+        return None
+
+    async def sign(self, key_id: str, data: bytes) -> bytes:  # noqa: ARG002
+        if self._use_kms_signing:
+            response = await asyncio.to_thread(
+                self._client.sign,
+                KeyId=self._key_id,
+                Message=data,
+                MessageType="RAW",
+                SigningAlgorithm="HMAC_SHA_256",
+            )
+            return response.get("Signature", b"")
+        key = await self.get_key(self._key_id)
+        if not key:
+            return b""
+        return hmac.new(key, data, hashlib.sha256).digest()
+
+    async def verify(self, key_id: str, data: bytes, signature: bytes) -> bool:  # noqa: ARG002
+        if self._use_kms_signing:
+            try:
+                await asyncio.to_thread(
+                    self._client.verify,
+                    KeyId=self._key_id,
+                    Message=data,
+                    Signature=signature,
+                    MessageType="RAW",
+                    SigningAlgorithm="HMAC_SHA_256",
+                )
+                return True
+            except Exception as exc:
+                invalid_exc = getattr(
+                    getattr(self._client, "exceptions", None),
+                    "KMSInvalidSignatureException",
+                    None,
+                )
+                if invalid_exc and isinstance(exc, invalid_exc):
+                    return False
+                return False
+        key = await self.get_key(self._key_id)
+        if not key:
+            return False
+        expected = hmac.new(key, data, hashlib.sha256).digest()
+        return hmac.compare_digest(expected, signature)
+
+
+class GcpKmsProvider(_CachedProvider):
+    """Google Cloud KMS provider; prefers KMS-native MAC signing."""
+
+    def __init__(
+        self,
+        key_id: str,
+        cache_ttl: int = 300,
+        use_kms_signing: bool = True,
+        client: object | None = None,
+    ) -> None:
+        super().__init__(cache_ttl)
+        self._key_id = key_id
+        self._use_kms_signing = use_kms_signing
+        if client is None:
+            kms_mod = importlib.import_module("google.cloud.kms_v1")
+            client = kms_mod.KeyManagementServiceClient()
+        self._client = client
+
+    async def get_key(self, key_id: str) -> bytes | None:  # noqa: ARG002
+        if self._use_kms_signing:
+            return None
+        # KMS does not export symmetric keys; enforce signing mode
+        return None
+
+    async def sign(self, key_id: str, data: bytes) -> bytes:  # noqa: ARG002
+        if not self._use_kms_signing:
+            return b""
+        response = await asyncio.to_thread(
+            self._client.mac_sign,
+            request={"name": self._key_id, "data": data},
+        )
+        return getattr(response, "mac", b"")
+
+    async def verify(self, key_id: str, data: bytes, signature: bytes) -> bool:  # noqa: ARG002
+        if not self._use_kms_signing:
+            return False
+        response = await asyncio.to_thread(
+            self._client.mac_verify,
+            request={"name": self._key_id, "data": data, "mac": signature},
+        )
+        return bool(getattr(response, "success", False))
+
+
+class AzureKeyVaultProvider(_CachedProvider):
+    """Azure Key Vault provider using CryptographyClient for signing."""
+
+    def __init__(
+        self,
+        key_id: str,
+        cache_ttl: int = 300,
+        tenant_id: str | None = None,
+        client_id: str | None = None,
+        use_kms_signing: bool = True,
+        crypto_client: object | None = None,
+    ) -> None:
+        super().__init__(cache_ttl)
+        self._key_id = key_id
+        self._use_kms_signing = use_kms_signing
+        if crypto_client is None:
+            identity = importlib.import_module("azure.identity")
+            if tenant_id and client_id:
+                credential = identity.ClientSecretCredential(
+                    tenant_id=tenant_id,
+                    client_id=client_id,
+                    client_secret=os.environ.get("AZURE_CLIENT_SECRET", ""),
+                )
+            else:
+                credential = identity.DefaultAzureCredential()
+            crypto_mod = importlib.import_module("azure.keyvault.keys.crypto")
+            crypto_client = crypto_mod.CryptographyClient(self._key_id, credential)
+        self._crypto_client = crypto_client
+
+    async def get_key(self, key_id: str) -> bytes | None:  # noqa: ARG002
+        return None  # Keys are not exported
+
+    async def sign(self, key_id: str, data: bytes) -> bytes:  # noqa: ARG002
+        if not self._use_kms_signing:
+            return b""
+        from azure.keyvault.keys.crypto import SignatureAlgorithm  # type: ignore
+
+        result = await asyncio.to_thread(
+            self._crypto_client.sign,
+            SignatureAlgorithm.hs256,
+            data,
+        )
+        return getattr(result, "signature", b"")
+
+    async def verify(self, key_id: str, data: bytes, signature: bytes) -> bool:  # noqa: ARG002
+        if not self._use_kms_signing:
+            return False
+        from azure.keyvault.keys.crypto import SignatureAlgorithm  # type: ignore
+
+        result = await asyncio.to_thread(
+            self._crypto_client.verify,
+            SignatureAlgorithm.hs256,
+            data,
+            signature,
+        )
+        return bool(getattr(result, "is_valid", False))
+
+
+class VaultProvider(_CachedProvider):
+    """HashiCorp Vault Transit provider."""
+
+    def __init__(
+        self,
+        addr: str,
+        key_name: str,
+        auth_method: str = "token",
+        token: str | None = None,
+        role_id: str | None = None,
+        secret_id: str | None = None,
+        cache_ttl: int = 300,
+    ) -> None:
+        super().__init__(cache_ttl)
+        hvac = importlib.import_module("hvac")
+        self._client = hvac.Client(url=addr)
+        self._key_name = key_name
+        self._auth_method = auth_method
+        self._token = token
+        self._role_id = role_id
+        self._secret_id = secret_id
+        self._authenticate()
+
+    def _authenticate(self) -> None:
+        if self._auth_method == "token":
+            self._client.token = self._token or os.environ.get("VAULT_TOKEN")
+        elif self._auth_method == "approle":
+            self._client.auth.approle.login(
+                role_id=self._role_id, secret_id=self._secret_id
+            )
+        elif self._auth_method == "kubernetes":
+            sa_token = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+            jwt = sa_token.read_text() if sa_token.exists() else ""
+            self._client.auth.kubernetes.login(role=self._role_id, jwt=jwt)
+
+    async def get_key(self, key_id: str) -> bytes | None:  # noqa: ARG002
+        return None  # Keys stay in Vault
+
+    async def sign(self, key_id: str, data: bytes) -> bytes:  # noqa: ARG002
+        payload = base64.b64encode(data).decode()
+        response = await asyncio.to_thread(
+            self._client.secrets.transit.sign_data,
+            name=self._key_name,
+            hash_input=payload,
+            hash_algorithm="sha2-256",
+            signature_algorithm="pkcs1v15",
+        )
+        signature = response["data"]["signature"]
+        return base64.b64decode(signature.split(":")[-1])
+
+    async def verify(self, key_id: str, data: bytes, signature: bytes) -> bool:  # noqa: ARG002
+        sig_b64 = base64.b64encode(signature).decode()
+        payload = base64.b64encode(data).decode()
+        response = await asyncio.to_thread(
+            self._client.secrets.transit.verify_signed_data,
+            name=self._key_name,
+            hash_input=payload,
+            signature=f"vault:v1:{sig_b64}",
+            hash_algorithm="sha2-256",
+        )
+        return bool(response["data"]["valid"])
+
+
+def create_key_provider(config: TamperConfig) -> KeyProvider:
+    """Create a concrete KeyProvider from configuration."""
+    if config.key_source == "env":
+        return EnvKeyProvider(
+            config.key_env_var, cache_ttl=config.key_cache_ttl_seconds
+        )
+    if config.key_source == "file":
+        path = config.key_file_path or ""
+        return FileKeyProvider(path, cache_ttl=config.key_cache_ttl_seconds)
+    if config.key_source == "aws-kms":
+        try:
+            return AwsKmsProvider(
+                key_id=config.key_id,
+                region=config.aws_region,
+                cache_ttl=config.key_cache_ttl_seconds,
+                use_kms_signing=config.use_kms_signing,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "AWS KMS support requires boto3. Install with: pip install fapilog-tamper[aws]"
+            ) from exc
+    if config.key_source == "gcp-kms":
+        try:
+            return GcpKmsProvider(
+                key_id=config.key_id,
+                cache_ttl=config.key_cache_ttl_seconds,
+                use_kms_signing=config.use_kms_signing,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "GCP KMS support requires google-cloud-kms. "
+                "Install with: pip install fapilog-tamper[gcp]"
+            ) from exc
+    if config.key_source == "azure-keyvault":
+        try:
+            return AzureKeyVaultProvider(
+                key_id=config.key_id,
+                cache_ttl=config.key_cache_ttl_seconds,
+                tenant_id=config.azure_tenant_id,
+                client_id=config.azure_client_id,
+                use_kms_signing=config.use_kms_signing,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "Azure Key Vault support requires azure-keyvault-keys and azure-identity. "
+                "Install with: pip install fapilog-tamper[azure]"
+            ) from exc
+    if config.key_source == "vault":
+        try:
+            return VaultProvider(
+                addr=config.vault_addr or os.environ.get("VAULT_ADDR", ""),
+                key_name=config.key_id,
+                auth_method=config.vault_auth_method,
+                token=os.environ.get("VAULT_TOKEN"),
+                role_id=config.vault_role,
+                cache_ttl=config.key_cache_ttl_seconds,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "Vault support requires hvac. Install with: pip install fapilog-tamper[vault]"
+            ) from exc
+    raise ValueError(f"Unknown key_source: {config.key_source}")

--- a/tests/unit/test_key_providers.py
+++ b/tests/unit/test_key_providers.py
@@ -1,0 +1,442 @@
+"""
+Tests for KeyProvider implementations and factory in fapilog-tamper.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# Add fapilog-tamper to path before importing
+_tamper_src = (
+    Path(__file__).resolve().parents[2] / "packages" / "fapilog-tamper" / "src"
+)
+if _tamper_src.exists():
+    sys.path.insert(0, str(_tamper_src))
+
+try:
+    import fapilog_tamper  # noqa: F401
+except ImportError:
+    pytest.skip("fapilog-tamper not available", allow_module_level=True)
+
+
+class _DummySink:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.entries: list[dict] = []
+
+    async def write(self, entry: dict) -> None:
+        self.entries.append(entry)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+
+class _FakeProvider:
+    def __init__(self) -> None:
+        self.sign_calls = 0
+        self.get_calls = 0
+
+    async def get_key(self, key_id: str) -> bytes:
+        self.get_calls += 1
+        return b"K" * 32
+
+    async def sign(self, key_id: str, data: bytes) -> bytes:
+        self.sign_calls += 1
+        return b"S" * 32
+
+    async def verify(self, key_id: str, data: bytes, signature: bytes) -> bool:
+        return signature == b"S" * 32
+
+    async def rotate_check(self) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_env_provider_cache_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """EnvKeyProvider should cache keys until TTL expires."""
+    from fapilog_tamper.config import TamperConfig
+
+    monkeypatch.setenv("ENV_KMS_KEY", base64.urlsafe_b64encode(b"A" * 32).decode())
+    # Fake time progression
+    now = {"value": 1000.0}
+    time_ns = SimpleNamespace(time=lambda: now["value"])
+    monkeypatch.setattr("fapilog_tamper.providers.time", time_ns)
+
+    from fapilog_tamper.providers import EnvKeyProvider
+
+    provider = EnvKeyProvider(env_var="ENV_KMS_KEY", cache_ttl=5)
+    first = await provider.get_key("ignored")
+    assert first == b"A" * 32
+
+    now["value"] += 3
+    monkeypatch.setenv("ENV_KMS_KEY", base64.urlsafe_b64encode(b"B" * 32).decode())
+    second = await provider.get_key("ignored")
+    assert second == first  # cache hit
+
+    now["value"] += 4  # expire cache
+    third = await provider.get_key("ignored")
+    assert third == b"B" * 32
+    assert provider._cache_expires > now["value"] - 1  # type: ignore[attr-defined]
+
+    # Ensure factory still allows env/file values in config enum
+    TamperConfig(key_source="env")
+    TamperConfig(key_source="file")
+
+
+@pytest.mark.asyncio
+async def test_env_provider_missing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env provider should handle missing keys gracefully."""
+    from fapilog_tamper.providers import EnvKeyProvider
+
+    provider = EnvKeyProvider(env_var="MISSING_KEY", cache_ttl=1)
+    assert await provider.rotate_check() is False
+    assert await provider.get_key("unused") is None
+    assert await provider.sign("unused", b"data") == b""
+    assert await provider.verify("unused", b"data", b"sig") is False
+    monkeypatch.setenv("MISSING_KEY", "short")
+    assert await provider.get_key("unused") is None
+
+
+@pytest.mark.asyncio
+async def test_provider_factory_missing_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory should raise helpful errors when optional deps are missing."""
+    import importlib
+
+    from fapilog_tamper.config import TamperConfig
+
+    real_import = importlib.import_module
+
+    def _raise_on_boto3(name: str, *args, **kwargs):  # type: ignore[override]
+        if name == "boto3":
+            raise ImportError("boto3 missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", _raise_on_boto3)
+    from fapilog_tamper.providers import create_key_provider
+
+    cfg = TamperConfig(key_source="aws-kms", key_id="alias/test")
+    with pytest.raises(ImportError, match="pip install fapilog-tamper\\[aws\\]"):
+        create_key_provider(cfg)
+
+    def _raise_on_cloud(name: str, *args, **kwargs):  # type: ignore[override]
+        if name in {
+            "google.cloud.kms_v1",
+            "azure.identity",
+            "azure.keyvault.keys.crypto",
+            "hvac",
+        }:
+            raise ImportError(f"{name} missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", _raise_on_cloud)
+    with pytest.raises(ImportError):
+        create_key_provider(TamperConfig(key_source="gcp-kms", key_id="kid"))
+    with pytest.raises(ImportError):
+        create_key_provider(TamperConfig(key_source="azure-keyvault", key_id="kid"))
+    with pytest.raises(ImportError):
+        create_key_provider(TamperConfig(key_source="vault", key_id="kid"))
+
+
+@pytest.mark.asyncio
+async def test_aws_provider_signing_and_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AWS provider should cache data keys and optionally sign via KMS."""
+    from fapilog_tamper.config import TamperConfig
+
+    class _FakeKmsClient:
+        def __init__(self) -> None:
+            self.generate_calls = 0
+            self.sign_calls = 0
+            self.verify_calls = 0
+
+        def generate_data_key(self, KeyId: str, KeySpec: str) -> dict:
+            self.generate_calls += 1
+            return {"Plaintext": b"K" * 32}
+
+        def sign(self, **kwargs) -> dict:
+            self.sign_calls += 1
+            return {"Signature": b"signed-" + kwargs["Message"]}
+
+        def verify(self, **kwargs) -> dict:
+            self.verify_calls += 1
+            if kwargs["Signature"] == b"signed-" + kwargs["Message"]:
+                return {"SignatureValid": True}
+            raise Exception("invalid")
+
+    fake_client = _FakeKmsClient()
+    fake_boto = SimpleNamespace(
+        client=lambda service_name, region_name=None: fake_client,
+        exceptions=SimpleNamespace(KMSInvalidSignatureException=Exception),
+    )
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto)
+
+    # Fake time for cache expiry
+    now = {"value": 10.0}
+    monkeypatch.setattr(
+        "fapilog_tamper.providers.time", SimpleNamespace(time=lambda: now["value"])
+    )
+
+    from fapilog_tamper.providers import create_key_provider
+
+    cfg = TamperConfig(
+        key_source="aws-kms",
+        key_id="alias/test",
+        key_cache_ttl_seconds=1,
+        use_kms_signing=False,
+    )
+    provider = create_key_provider(cfg)
+    assert await provider.get_key("alias/test") == b"K" * 32
+    await provider.get_key("alias/test")
+    assert fake_client.generate_calls == 1  # cached
+    now["value"] += 2
+    await provider.get_key("alias/test")
+    assert fake_client.generate_calls == 2  # refreshed after TTL
+
+    cfg_sign = TamperConfig(
+        key_source="aws-kms",
+        key_id="alias/sign",
+        key_cache_ttl_seconds=1,
+        use_kms_signing=True,
+    )
+    provider_sign = create_key_provider(cfg_sign)
+    sig = await provider_sign.sign(cfg_sign.key_id, b"payload")
+    assert sig == b"signed-payload"
+    assert await provider_sign.verify(cfg_sign.key_id, b"payload", sig) is True
+    assert await provider_sign.verify(cfg_sign.key_id, b"payload", b"bad") is False
+    assert fake_client.sign_calls == 1
+    assert fake_client.verify_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_enricher_and_sink_use_kms_signing(tmp_path: Path) -> None:
+    """IntegrityEnricher and SealedSink should defer signing to providers when configured."""
+    from fapilog_tamper.canonical import b64url_decode
+    from fapilog_tamper.config import TamperConfig
+    from fapilog_tamper.enricher import IntegrityEnricher
+    from fapilog_tamper.sealed_sink import SealedSink
+
+    provider = _FakeProvider()
+    cfg = TamperConfig(
+        enabled=True,
+        key_source="aws-kms",
+        key_id="alias/test",
+        use_kms_signing=True,
+        state_dir=str(tmp_path),
+    )
+    enricher = IntegrityEnricher(cfg, provider=provider)
+    await enricher.start()
+    enriched = await enricher.enrich(
+        {"event": "login", "timestamp": "2025-01-01T00:00:00Z"}
+    )
+    await enricher.stop()
+
+    assert provider.sign_calls == 1
+    mac = b64url_decode(enriched["integrity"]["mac"])
+    assert mac == b"S" * 32
+
+    sink = SealedSink(_DummySink(tmp_path / "events.jsonl"), cfg, provider=provider)
+    await sink.start()
+    await sink.write(enriched)
+    await sink.stop()
+
+    manifest = json.loads((tmp_path / "events.jsonl.manifest.json").read_text())
+    sig_bytes = b64url_decode(manifest["signature"])
+    assert sig_bytes == b"S" * 32
+    assert provider.sign_calls >= 2  # enricher + manifest
+
+
+@pytest.mark.asyncio
+async def test_file_provider_and_cache_rotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FileKeyProvider should read from files/directories and support cache rotation."""
+    from fapilog_tamper.providers import FileKeyProvider
+
+    key_dir = tmp_path / "keys"
+    key_dir.mkdir()
+    provider = FileKeyProvider(key_dir, cache_ttl=1)
+    assert await provider.get_key("missing") is None
+
+    # Write key and ensure it is loaded and cached
+    (key_dir / "kid.key").write_bytes(b"A" * 32)
+    first = await provider.get_key("kid")
+    assert first == b"A" * 32
+
+    now = {"value": 0.0}
+    monkeypatch.setattr(
+        "fapilog_tamper.providers.time", SimpleNamespace(time=lambda: now["value"])
+    )
+    provider._cache_set(b"A" * 32)  # type: ignore[attr-defined]
+    now["value"] += 2
+    assert await provider.rotate_check() is True
+    sig = await provider.sign("kid", b"msg")
+    assert await provider.verify("kid", b"msg", sig) is True
+
+
+@pytest.mark.asyncio
+async def test_gcp_and_azure_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GCP and Azure providers should call into SDK clients for signing."""
+    from fapilog_tamper.config import TamperConfig
+
+    class _FakeGcpClient:
+        def mac_sign(self, request: dict) -> SimpleNamespace:
+            return SimpleNamespace(mac=b"gcpsign-" + request["data"])
+
+        def mac_verify(self, request: dict) -> SimpleNamespace:
+            valid = request["mac"] == b"gcpsign-" + request["data"]
+            return SimpleNamespace(success=valid)
+
+    fake_gcp_mod = SimpleNamespace(KeyManagementServiceClient=lambda: _FakeGcpClient())
+    monkeypatch.setitem(sys.modules, "google.cloud.kms_v1", fake_gcp_mod)
+
+    from fapilog_tamper.providers import create_key_provider
+
+    gcp_provider = create_key_provider(
+        TamperConfig(
+            key_source="gcp-kms",
+            key_id="projects/x/locations/y/keyRings/z/cryptoKeys/k",
+            use_kms_signing=True,
+        )
+    )
+    sig = await gcp_provider.sign("id", b"data")
+    assert await gcp_provider.verify("id", b"data", sig) is True
+    assert await gcp_provider.get_key("id") is None
+
+    # Azure crypto client stub
+    class _FakeCryptoClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+        def sign(self, algo: object, data: bytes) -> SimpleNamespace:
+            return SimpleNamespace(signature=b"az-" + data)
+
+        def verify(
+            self, algo: object, data: bytes, signature: bytes
+        ) -> SimpleNamespace:
+            return SimpleNamespace(is_valid=signature == b"az-" + data)
+
+    class _FakeIdentity:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+    fake_crypto_mod = SimpleNamespace(
+        CryptographyClient=lambda key_id, credential: _FakeCryptoClient(),
+        SignatureAlgorithm=SimpleNamespace(hs256="HS256"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "azure.identity",
+        SimpleNamespace(
+            DefaultAzureCredential=_FakeIdentity, ClientSecretCredential=_FakeIdentity
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "azure.keyvault.keys.crypto", fake_crypto_mod)
+
+    azure_provider = create_key_provider(
+        TamperConfig(
+            key_source="azure-keyvault",
+            key_id="https://vault.vault.azure.net/keys/k",
+            use_kms_signing=True,
+            azure_tenant_id="tenant",
+            azure_client_id="client",
+        )
+    )
+    az_sig = await azure_provider.sign("id", b"payload")
+    assert await azure_provider.verify("id", b"payload", az_sig)
+    assert await azure_provider.get_key("id") is None
+
+
+@pytest.mark.asyncio
+async def test_vault_provider_auth_and_sign(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Vault provider should handle auth methods and sign/verify via transit."""
+    from fapilog_tamper.config import TamperConfig
+    from fapilog_tamper.providers import create_key_provider
+
+    class _FakeTransit:
+        def __init__(self) -> None:
+            self.sign_data_calls = 0
+            self.verify_calls = 0
+
+        def sign_data(
+            self,
+            name: str,
+            hash_input: str,
+            hash_algorithm: str,
+            signature_algorithm: str,
+        ) -> dict:
+            self.sign_data_calls += 1
+            return {"data": {"signature": f"vault:v1:{hash_input}"}}
+
+        def verify_signed_data(
+            self, name: str, hash_input: str, signature: str, hash_algorithm: str
+        ) -> dict:
+            self.verify_calls += 1
+            valid = signature.endswith(hash_input)
+            return {"data": {"valid": valid}}
+
+    class _FakeAuth:
+        def __init__(self) -> None:
+            self.approle = SimpleNamespace(
+                login=lambda role_id=None, secret_id=None: None
+            )
+            self.kubernetes = SimpleNamespace(login=lambda role=None, jwt=None: None)
+
+    class _FakeClient:
+        def __init__(self, url: str) -> None:
+            self.url = url
+            self.auth = _FakeAuth()
+            self.secrets = SimpleNamespace(transit=_FakeTransit())
+            self.token = None
+
+    monkeypatch.setitem(sys.modules, "hvac", SimpleNamespace(Client=_FakeClient))
+
+    # Ensure kubernetes path returns a token
+    class _FakePath:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def read_text(self) -> str:
+            return "jwt-token"
+
+        def exists(self) -> bool:
+            return True
+
+    monkeypatch.setattr("fapilog_tamper.providers.Path", _FakePath)
+
+    monkeypatch.setenv("VAULT_TOKEN", "token")
+    cfg_token = TamperConfig(
+        key_source="vault", key_id="transit/keys/audit", vault_addr="http://vault"
+    )
+    provider_token = create_key_provider(cfg_token)
+    assert await provider_token.sign("id", b"vaultdata-token")
+
+    cfg = TamperConfig(
+        key_source="vault",
+        key_id="transit/keys/audit",
+        vault_addr="http://vault",
+        vault_auth_method="approle",
+    )
+    provider = create_key_provider(cfg)
+    sig = await provider.sign("id", b"vaultdata")
+    assert await provider.verify("id", b"vaultdata", sig) is True
+
+    cfg_k8s = TamperConfig(
+        key_source="vault",
+        key_id="transit/keys/audit",
+        vault_addr="http://vault",
+        vault_auth_method="kubernetes",
+        vault_role="role",
+    )
+    provider_k8s = create_key_provider(cfg_k8s)
+    sig2 = await provider_k8s.sign("id", b"vaultdata2")
+    assert await provider_k8s.verify("id", b"vaultdata2", sig2)


### PR DESCRIPTION
Add KMS provider abstraction and implementations:
- KeyProvider protocol with get_key and sign methods
- EnvKeyProvider for environment variable keys
- FileKeyProvider for file-based keys
- AWS KMS, GCP KMS, Azure Key Vault provider stubs
- HashiCorp Vault provider stub

Update fapilog-tamper:
- Add kms extras in pyproject.toml (boto3, google-cloud-kms, etc.)
- Extend TamperConfig with key_provider and kms_* settings
- Update IntegrityEnricher and SealedSink to use providers
- Add providers.py with KeyProvider implementations

Documentation:
- Add docs/enterprise/tamper-enterprise-key-management.md
- Update enterprise.md with key management section
- Update addon and package READMEs