### PR TITLE
feat(audit): add hash-chain integrity to AuditTrail

### DIFF
--- a/docs/api-reference/audit-trail.md
+++ b/docs/api-reference/audit-trail.md
@@ -1,0 +1,22 @@
+# Audit Trail
+
+The `AuditTrail` class provides structured compliance/audit logging. It queues events asynchronously and flushes them to disk with integrity metadata.
+
+## Key Methods
+
+- `start()` / `stop()` - Begin/terminate processing. `stop()` now drains pending events to storage.
+- `drain()` - Manually flush queued events without stopping the worker.
+- `log_security_event(event_type, message, **metadata)` - Record security events (e.g., authentication/authorization failures).
+- `log_data_access(resource, operation, *, user_id=None, data_classification=None, contains_pii=False, contains_phi=False, **metadata)` - Record data access/modification events.
+- `verify_chain(events)` - Validate hash-chain integrity for a collection of `AuditEvent` objects.
+- `verify_chain_from_storage()` - Load events from `storage_path` and validate the chain.
+
+## Hash Chain Fields
+
+Each `AuditEvent` now includes:
+
+- `sequence_number` - Monotonic counter for gap detection
+- `previous_hash` - SHA-256 of the prior event
+- `checksum` - SHA-256 of the current event payload
+
+These are populated automatically when events are stored; use `verify_chain`/`verify_chain_from_storage` to validate integrity.

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -10,6 +10,7 @@ Complete API reference for fapilog, organized by functionality.
 top-level-functions
 logger-methods
 context-binding
+audit-trail
 configuration
 plugins/index
 lifecycle-results

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -83,6 +83,9 @@ await audit.log_data_access(
     data_classification="confidential",
     contains_pii=True,
 )
+
+# Ensure queued audit events are flushed before shutdown
+await audit.stop()  # stop() drains pending events; use audit.drain() for manual flush
 ```
 
 ### Audit Event Types
@@ -99,7 +102,7 @@ await audit.log_data_access(
 
 ## Tamper-Evident Hash Chains
 
-When you enable the tamper-evident add-on, audit events can include cryptographic integrity fields to detect tampering or gaps:
+Audit events include integrity fields to detect tampering or gaps:
 
 ```python
 # Each AuditEvent automatically includes:
@@ -123,6 +126,8 @@ events = await audit.get_events(
 
 # Verify chain integrity
 result = AuditTrail.verify_chain(events)
+# Or verify directly from disk:
+# result = await audit.verify_chain_from_storage()
 
 if result.valid:
     print(f"✓ {result.events_checked} events verified")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,11 +412,19 @@ ignore_names = [
     "signature",
     "model_config",
     
+    # Audit chain verification result fields
+    "valid",
+    "events_checked",
+    "first_invalid_sequence",
+    "error_message",
+    
     # Audit public API methods
     "log_data_access",
     "get_events",
     "get_statistics", 
     "cleanup",
+    "verify_chain_from_storage",
+    "drain",
     
     # Circuit breaker public API
     "call",

--- a/tests/unit/test_audit_trail_chain.py
+++ b/tests/unit/test_audit_trail_chain.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from fapilog.core.audit import (
+    AuditEvent,
+    AuditEventType,
+    AuditTrail,
+    CompliancePolicy,
+)
+
+
+@pytest.mark.asyncio
+async def test_audit_stop_drains_queue(tmp_path) -> None:
+    audit = AuditTrail(policy=CompliancePolicy(), storage_path=tmp_path)
+    await audit.start()
+    await audit.log_security_event(
+        AuditEventType.AUTHENTICATION_FAILED,
+        "login failed",
+        user_id="user@example.com",
+    )
+
+    await audit.stop()
+
+    files = list(tmp_path.glob("audit_*.jsonl"))
+    assert files, "Expected audit file to be written after stop() drains the queue"
+    content = files[0].read_text().strip().splitlines()
+    assert content, "Audit file should contain at least one event"
+
+
+@pytest.mark.asyncio
+async def test_audit_chain_fields_and_verify(tmp_path) -> None:
+    audit_dir = tmp_path / "chain"
+    audit = AuditTrail(policy=CompliancePolicy(), storage_path=audit_dir)
+    await audit.start()
+    await audit.log_data_access(
+        resource="customers",
+        operation="read",
+        user_id="admin@example.com",
+        contains_pii=True,
+    )
+    await audit.log_security_event(
+        AuditEventType.SECURITY_VIOLATION, "violation", user_id="attacker"
+    )
+    await audit.stop()
+
+    files = sorted(audit_dir.glob("audit_*.jsonl"))
+    assert files, "Expected persisted audit log files"
+    lines = []
+    for f in files:
+        lines.extend([ln for ln in f.read_text().splitlines() if ln.strip()])
+    events = [json.loads(line) for line in lines]
+    assert all("sequence_number" in e for e in events)
+    assert all("previous_hash" in e for e in events)
+    assert all(e.get("checksum") for e in events)
+
+    verify_result = await audit.verify_chain_from_storage()
+    assert verify_result.valid
+    assert verify_result.events_checked == len(events)
+
+    # Tamper with checksum to ensure verification fails
+    tampered_events = [AuditEvent(**e) for e in events]
+    tampered_events[0].checksum = "deadbeef"
+    tampered = AuditTrail.verify_chain(tampered_events)
+    assert not tampered.valid


### PR DESCRIPTION
## Summary

Add built-in hash-chain integrity to `AuditTrail` for tamper detection without requiring the enterprise plugin.

## Changes

### AuditEvent Enhancements
- `sequence_number` - Monotonic counter for gap detection
- `previous_hash` - SHA-256 of the prior event's checksum
- `checksum` - SHA-256 of the current event payload (canonical JSON)

### New Methods
- `verify_chain(events)` - Class method to validate integrity of an event sequence
- `verify_chain_from_storage()` - Instance method to load and verify events from disk
- `drain()` - Flush queued events without stopping the worker

### Behavior Changes
- `stop()` now calls `drain()` before canceling the worker task, ensuring queued events are persisted

### Documentation
- Added `docs/api-reference/audit-trail.md` with method reference and field descriptions
- Updated `docs/enterprise.md` with usage examples

### Tests
- `tests/unit/test_audit_trail_chain.py` covers chain integrity verification and tamper detection