### PR TITLE
ci: add standalone docs deployment workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy Docs (standalone)
+
+on:
+  # Manual trigger from GitHub UI
+  workflow_dispatch:
+    inputs:
+      version_label:
+        description: 'Version label for docs (e.g., "latest" or "0.3.4")'
+        required: false
+        default: 'latest'
+
+  # Auto-trigger on docs changes to main
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'src/fapilog/**'  # API changes may affect autodoc
+
+permissions:
+  contents: write
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install hatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Determine version label
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "label=${{ github.event.inputs.version_label }}" >> $GITHUB_OUTPUT
+          else
+            # For push events, use 'latest'
+            echo "label=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build docs
+        env:
+          FAPILOG_DOC_VERSION: ${{ steps.version.outputs.label }}
+        run: |
+          hatch run docs:build || {
+            echo "Docs build failed"; exit 1;
+          }
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html
+          force_orphan: false
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: "docs: update (${{ steps.version.outputs.label }})"
+


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to deploy documentation independently of library releases.

## Triggers

| Trigger | When | Version Label |
|---------|------|---------------|
| **Manual** | workflow_dispatch from Actions UI | Custom input (default: `latest`) |
| **Auto** | Push to `main` with changes in `docs/` or `src/fapilog/` | `latest` |

## Usage

1. **Manual**: Actions → "Deploy Docs (standalone)" → Run workflow
2. **Auto**: Merging PRs with doc changes triggers deployment

This enables documentation updates without cutting a new PyPI release.