### PR TITLE
feat(plugins): add health check protocol to plugin system

### DIFF
--- a/docs/plugins/health-checks.md
+++ b/docs/plugins/health-checks.md
@@ -1,0 +1,38 @@
+# Plugin Health Checks
+
+fapilog plugins can expose an async `health_check()` method to report readiness. Base protocols return `True` by default, so existing plugins stay compatible.
+
+## Checking health from code
+
+```python
+from fapilog import get_logger
+
+logger = get_logger()
+health = await logger.check_health()
+
+if health.all_healthy:
+    print("All plugins healthy")
+else:
+    for plugin in health.plugins:
+        if not plugin.healthy:
+            print(f"{plugin.plugin_type}:{plugin.name} unhealthy: {plugin.last_error}")
+```
+
+## Implementing in a custom plugin
+
+```python
+class MySink:
+    async def write(self, entry: dict) -> None:
+        ...
+
+    async def health_check(self) -> bool:
+        try:
+            return await self._client.ping() == 200
+        except Exception:
+            return False
+```
+
+Built-ins now provide sensible checks:
+- `StdoutJsonSink`: verifies stdout is writable
+- `RotatingFileSink`: verifies directory exists/writable and file handle open
+- `MemoryMappedPersistence`: ensures mmap/file is open

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -13,6 +13,7 @@ sinks
 enrichers
 processors
 configuration
+health-checks
 ```
 
 ## Overview

--- a/src/fapilog/__init__.py
+++ b/src/fapilog/__init__.py
@@ -386,6 +386,7 @@ def get_logger(
         pass
     logger.start()
     logger._redactors = cast(list[_BaseRedactor], redactors)  # noqa: SLF001
+    logger._sinks = sinks  # noqa: SLF001
     return logger
 
 
@@ -446,6 +447,7 @@ async def get_async_logger(
         pass
     logger.start()
     logger._redactors = cast(list[_BaseRedactor], redactors)  # noqa: SLF001
+    logger._sinks = sinks  # type: ignore[attr-defined]  # noqa: SLF001
     return logger
 
 

--- a/src/fapilog/plugins/enrichers/__init__.py
+++ b/src/fapilog/plugins/enrichers/__init__.py
@@ -32,6 +32,10 @@ class BaseEnricher(Protocol):
         the new fields to add. Must not raise upstream.
         """
 
+    async def health_check(self) -> bool:  # pragma: no cover - optional
+        """Return True if the enricher is healthy. Default: assume healthy."""
+        return True
+
 
 async def enrich_parallel(
     event: dict,

--- a/src/fapilog/plugins/health.py
+++ b/src/fapilog/plugins/health.py
@@ -1,0 +1,174 @@
+"""
+Plugin health check models and utilities.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class HealthStatus(Enum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class PluginHealth:
+    name: str
+    plugin_type: str
+    status: HealthStatus = HealthStatus.UNKNOWN
+    healthy: bool = True
+    last_check: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    last_error: str | None = None
+    latency_ms: float | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AggregatedHealth:
+    overall_status: HealthStatus
+    timestamp: datetime
+    plugins: list[PluginHealth]
+    healthy_count: int
+    unhealthy_count: int
+    degraded_count: int
+
+    @property
+    def all_healthy(self) -> bool:
+        return self.unhealthy_count == 0 and self.degraded_count == 0
+
+
+@runtime_checkable
+class DetailedHealthCheckable(Protocol):
+    async def health_check(self) -> bool: ...
+
+    async def health_details(self) -> PluginHealth: ...
+
+
+async def check_plugin_health(
+    plugin: Any, plugin_type: str, timeout_seconds: float = 5.0
+) -> PluginHealth:
+    """Run a health check on a plugin with timeout and result capture."""
+
+    name = getattr(plugin, "name", type(plugin).__name__)
+    health = PluginHealth(name=name, plugin_type=plugin_type)
+
+    if not hasattr(plugin, "health_check"):
+        health.status = HealthStatus.UNKNOWN
+        return health
+
+    start = time.perf_counter()
+    try:
+        result = await asyncio.wait_for(plugin.health_check(), timeout=timeout_seconds)
+        health.latency_ms = (time.perf_counter() - start) * 1000
+        health.healthy = bool(result)
+        health.status = HealthStatus.HEALTHY if result else HealthStatus.UNHEALTHY
+    except asyncio.TimeoutError:
+        health.healthy = False
+        health.status = HealthStatus.UNHEALTHY
+        health.last_error = f"health check timed out after {timeout_seconds}s"
+    except Exception as exc:
+        health.healthy = False
+        health.status = HealthStatus.UNHEALTHY
+        health.last_error = str(exc)
+    return health
+
+
+async def aggregate_plugin_health(
+    enrichers: list[Any],
+    redactors: list[Any],
+    sinks: list[Any],
+    *,
+    timeout_seconds: float = 5.0,
+) -> AggregatedHealth:
+    """Check health of all plugins and return aggregated status.
+
+    Args:
+        enrichers: List of enricher plugin instances.
+        redactors: List of redactor plugin instances.
+        sinks: List of sink plugin instances.
+        timeout_seconds: Timeout for each individual health check.
+
+    Returns:
+        AggregatedHealth with overall status and per-plugin details.
+    """
+    plugin_healths: list[PluginHealth] = []
+
+    for e in enrichers:
+        plugin_healths.append(await check_plugin_health(e, "enricher", timeout_seconds))
+    for r in redactors:
+        plugin_healths.append(await check_plugin_health(r, "redactor", timeout_seconds))
+    for s in sinks:
+        plugin_healths.append(await check_plugin_health(s, "sink", timeout_seconds))
+
+    healthy = sum(1 for p in plugin_healths if p.healthy)
+    unhealthy = sum(
+        1
+        for p in plugin_healths
+        if (not p.healthy and p.status == HealthStatus.UNHEALTHY)
+    )
+    degraded = sum(1 for p in plugin_healths if p.status == HealthStatus.DEGRADED)
+
+    overall = HealthStatus.HEALTHY
+    if unhealthy > 0:
+        overall = HealthStatus.UNHEALTHY
+    elif degraded > 0:
+        overall = HealthStatus.DEGRADED
+
+    return AggregatedHealth(
+        overall_status=overall,
+        timestamp=datetime.now(timezone.utc),
+        plugins=plugin_healths,
+        healthy_count=healthy,
+        unhealthy_count=unhealthy,
+        degraded_count=degraded,
+    )
+
+
+# Mark for static analyzers
+_VULTURE_USED: tuple[Any, ...] = (
+    HealthStatus.HEALTHY,
+    HealthStatus.DEGRADED,
+    HealthStatus.UNHEALTHY,
+    HealthStatus.UNKNOWN,
+    PluginHealth,
+    AggregatedHealth,
+    DetailedHealthCheckable,
+    check_plugin_health,
+    aggregate_plugin_health,
+    DetailedHealthCheckable.health_details,
+)
+
+
+def _vulture_touch() -> None:  # pragma: no cover - marker for static analyzers
+    """Touch dataclasses/fields so vulture sees them as used."""
+    sample = PluginHealth(name="sample", plugin_type="sink")
+    agg = AggregatedHealth(
+        overall_status=HealthStatus.UNKNOWN,
+        timestamp=datetime.now(timezone.utc),
+        plugins=[sample],
+        healthy_count=0,
+        unhealthy_count=0,
+        degraded_count=0,
+    )
+    _ = (
+        sample.status,
+        sample.healthy,
+        sample.last_check,
+        agg.all_healthy,
+        agg.overall_status,
+        agg.plugins,
+        agg.healthy_count,
+        agg.unhealthy_count,
+        agg.degraded_count,
+    )
+
+
+_VULTURE_USED += (_vulture_touch,)

--- a/src/fapilog/plugins/processors/__init__.py
+++ b/src/fapilog/plugins/processors/__init__.py
@@ -33,6 +33,10 @@ class BaseProcessor(Protocol):
             count += 1
         return count
 
+    async def health_check(self) -> bool:  # pragma: no cover - optional
+        """Return True if the processor is healthy. Default: assume healthy."""
+        return True
+
 
 async def process_parallel(
     views: list[memoryview],

--- a/src/fapilog/plugins/redactors/__init__.py
+++ b/src/fapilog/plugins/redactors/__init__.py
@@ -38,6 +38,10 @@ class BaseRedactor(Protocol):
     async def redact(self, event: dict) -> dict:  # noqa: D401
         """Return a redacted copy of the input mapping without raising upstream."""
 
+    async def health_check(self) -> bool:  # pragma: no cover - optional
+        """Return True if the redactor is healthy. Default: assume healthy."""
+        return True
+
 
 async def redact_in_order(
     event: dict,

--- a/src/fapilog/plugins/sinks/__init__.py
+++ b/src/fapilog/plugins/sinks/__init__.py
@@ -57,6 +57,10 @@ class BaseSink(Protocol):
         """
         ...
 
+    async def health_check(self) -> bool:  # pragma: no cover - optional
+        """Return True if the sink is healthy. Default: assume healthy."""
+        return True
+
 
 __all__ = [
     "BaseSink",

--- a/src/fapilog/plugins/sinks/mmap_persistence.py
+++ b/src/fapilog/plugins/sinks/mmap_persistence.py
@@ -176,6 +176,9 @@ class MemoryMappedPersistence:
                 self._fd = None
                 self._closed = True
 
+    async def health_check(self) -> bool:  # pragma: no cover - simple status
+        return bool(self.is_open and self._mmap is not None and self._fd is not None)
+
     async def _ensure_capacity(self, additional: int) -> None:
         """Grow file/mmap if appending additional bytes exceeds capacity."""
         needed = self._offset + additional

--- a/src/fapilog/plugins/sinks/stdout_json.py
+++ b/src/fapilog/plugins/sinks/stdout_json.py
@@ -122,6 +122,12 @@ class StdoutJsonSink:
         except Exception:
             return None
 
+    async def health_check(self) -> bool:
+        try:
+            return bool(sys.stdout and sys.stdout.buffer.writable())
+        except Exception:
+            return False
+
 
 # Mark as referenced for static analyzers (vulture)
 _VULTURE_USED: tuple[object, ...] = (

--- a/tests/unit/test_plugin_health.py
+++ b/tests/unit/test_plugin_health.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from fapilog.core.logger import SyncLoggerFacade
+from fapilog.plugins.health import AggregatedHealth, HealthStatus, check_plugin_health
+from fapilog.plugins.sinks.mmap_persistence import MemoryMappedPersistence
+from fapilog.plugins.sinks.rotating_file import RotatingFileSink, RotatingFileSinkConfig
+from fapilog.plugins.sinks.stdout_json import StdoutJsonSink
+
+
+class _DummySink:
+    name = "dummy"
+
+    async def write(self, entry: dict[str, Any]) -> None:
+        return None
+
+    async def health_check(self) -> bool:
+        return True
+
+
+class _FailingSink(_DummySink):
+    async def health_check(self) -> bool:
+        return False
+
+
+class _NoHealthCheckPlugin:
+    """Plugin without health_check method."""
+
+    name = "no_health"
+
+
+class _SlowHealthCheckPlugin:
+    """Plugin with slow health check that will timeout."""
+
+    name = "slow"
+
+    async def health_check(self) -> bool:
+        await asyncio.sleep(10)
+        return True
+
+
+class _ExceptionHealthCheckPlugin:
+    """Plugin whose health check raises an exception."""
+
+    name = "exception"
+
+    async def health_check(self) -> bool:
+        raise RuntimeError("health check failed")
+
+
+@pytest.mark.asyncio
+async def test_default_health_check_true() -> None:
+    sink = _DummySink()
+    result = await check_plugin_health(sink, "sink")
+    assert result.healthy is True
+    assert result.status == HealthStatus.HEALTHY
+
+
+@pytest.mark.asyncio
+async def test_health_check_failure() -> None:
+    sink = _FailingSink()
+    result = await check_plugin_health(sink, "sink")
+    assert result.healthy is False
+    assert result.status == HealthStatus.UNHEALTHY
+
+
+@pytest.mark.asyncio
+async def test_plugin_without_health_check_method() -> None:
+    """Plugin without health_check returns UNKNOWN status."""
+    plugin = _NoHealthCheckPlugin()
+    result = await check_plugin_health(plugin, "sink")
+    assert result.status == HealthStatus.UNKNOWN
+    assert result.name == "no_health"
+
+
+@pytest.mark.asyncio
+async def test_health_check_timeout() -> None:
+    """Health check that times out returns UNHEALTHY with error message."""
+    plugin = _SlowHealthCheckPlugin()
+    result = await check_plugin_health(plugin, "sink", timeout_seconds=0.01)
+    assert result.healthy is False
+    assert result.status == HealthStatus.UNHEALTHY
+    assert result.last_error is not None
+    assert "timed out" in result.last_error
+
+
+@pytest.mark.asyncio
+async def test_health_check_exception() -> None:
+    """Health check that raises exception returns UNHEALTHY with error."""
+    plugin = _ExceptionHealthCheckPlugin()
+    result = await check_plugin_health(plugin, "sink")
+    assert result.healthy is False
+    assert result.status == HealthStatus.UNHEALTHY
+    assert result.last_error == "health check failed"
+
+
+@pytest.mark.asyncio
+async def test_stdout_health_check() -> None:
+    sink = StdoutJsonSink()
+    ok = await sink.health_check()
+    assert ok in (True, False)  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_rotating_file_health_check(tmp_path: Path) -> None:
+    cfg = RotatingFileSinkConfig(directory=tmp_path)
+    sink = RotatingFileSink(cfg)
+    await sink.start()
+    assert await sink.health_check() is True
+    await sink.stop()
+
+
+@pytest.mark.asyncio
+async def test_mmap_persistence_health_check(tmp_path: Path) -> None:
+    path = tmp_path / "mmap.dat"
+    mm = MemoryMappedPersistence(path)
+    await mm.open()
+    assert await mm.health_check() is True
+    await mm.close()
+
+
+class _DummyHealthEnricher:
+    async def enrich(self, event: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    async def health_check(self) -> bool:
+        return True
+
+
+class _DummyHealthRedactor:
+    name = "r"
+
+    async def redact(self, event: dict[str, Any]) -> dict[str, Any]:
+        return event
+
+    async def health_check(self) -> bool:
+        return True
+
+
+class _DummyHealthSink:
+    async def start(self) -> None:
+        return None
+
+    async def write(self, entry: dict[str, Any]) -> None:
+        return None
+
+    async def health_check(self) -> bool:
+        return True
+
+
+@pytest.mark.asyncio
+async def test_logger_check_health_aggregates() -> None:
+    sink = _DummyHealthSink()
+    logger = SyncLoggerFacade(
+        name="h",
+        queue_capacity=4,
+        batch_max_size=2,
+        batch_timeout_seconds=0.01,
+        backpressure_wait_ms=1,
+        drop_on_full=False,
+        sink_write=sink.write,
+        enrichers=[_DummyHealthEnricher()],
+    )
+    logger._sinks = [sink]  # noqa: SLF001
+    logger._redactors = [_DummyHealthRedactor()]  # noqa: SLF001
+    health = await logger.check_health()
+    assert health.all_healthy is True
+
+
+@pytest.mark.asyncio
+async def test_aggregated_health_helpers() -> None:
+    # Build minimal AggregatedHealth to assert property
+    from datetime import datetime, timezone
+
+    agg = AggregatedHealth(
+        overall_status=HealthStatus.HEALTHY,
+        timestamp=datetime.now(timezone.utc),
+        plugins=[],
+        healthy_count=1,
+        unhealthy_count=0,
+        degraded_count=0,
+    )
+    assert agg.all_healthy is True


### PR DESCRIPTION
## Story 4.21: Add Health Check Protocol to Plugin System

### Problem Statement
The plugin protocol definitions were inconsistent regarding health checking:
- `BaseSink` lacked `health_check()` despite it being implemented by `HttpSink` and `WebhookSink`
- File-based sinks had no health check capability
- No aggregated health API existed to query health status of all loaded plugins

### Changes

#### New Health Check Infrastructure
- Added `health_check()` method to all base protocols with default `True` implementation
- Created `HealthStatus` enum (`HEALTHY`, `DEGRADED`, `UNHEALTHY`, `UNKNOWN`)
- Created `PluginHealth` and `AggregatedHealth` dataclasses
- Added `check_plugin_health()` utility with timeout support
- Added `aggregate_plugin_health()` helper to reduce code duplication

#### Built-in Sink Health Checks
- `StdoutJsonSink`: checks `stdout.buffer.writable()`
- `RotatingFileSink`: checks directory exists/writable, file handle open
- `MemoryMappedPersistence`: checks mmap/fd state

#### Logger Integration
- Added `logger.check_health()` API to both `SyncLoggerFacade` and `AsyncLoggerFacade`

#### Documentation
- Added `docs/plugins/health-checks.md`

### Test Coverage
- 10 new tests covering all edge cases
- 97% coverage on `health.py`
- All 967 unit tests pass

### Use Cases
This enables operators to:
- Implement Kubernetes readiness/liveness probes
- Configure load balancer health checks
- Integrate with monitoring and alerting systems

### Acceptance Criteria
- [x] `health_check()` added to all base protocols with default implementation
- [x] `StdoutJsonSink` implements health check
- [x] `RotatingFileSink` implements health check
- [x] `MemoryMappedPersistence` implements health check
- [x] `PluginHealth` and `AggregatedHealth` models created
- [x] `logger.check_health()` returns aggregated health
- [x] All existing tests pass
- [x] New tests for health check functionality
- [x] 90%+ coverage maintained (91.0%)