### PR TITLE
feat(plugins): complete PLUGIN_METADATA for all built-in plugins

### DIFF
--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -5,8 +5,11 @@
 |------|------|---------|-----|--------|-------------|
 | context-vars-enricher | enricher | 1.0.0 | 1.0 | Fapilog Core | Adds context variables like request_id and user_id when available. |
 | field-mask | redactor | 1.0.0 | 1.0 | Fapilog Core | Masks configured fields in structured events. |
+| http | sink | 1.0.0 | 1.0 | Fapilog Core | Async HTTP sink that POSTs JSON to a configured endpoint. |
 | regex-mask | redactor | 1.0.0 | 1.0 | Fapilog Core | Masks values for fields whose dot-paths match configured regex patterns. |
-| rotating-file-sink | sink | 0.1.0 | 1.0 | Fapilog Core | Async rotating file sink with size/time rotation and retention |
+| rotating-file | sink | 1.0.0 | 1.0 | Fapilog Core | Async rotating file sink with size/time rotation and retention |
 | runtime-info-enricher | enricher | 1.0.0 | 1.0 | Fapilog Core | Adds runtime/system information such as host, pid, and python version. |
-| stdout-json-sink | sink | 1.0.0 | 1.0 | Fapilog Core | Async stdout JSONL sink |
+| stdout-json | sink | 1.0.0 | 1.0 | Fapilog Core | Async stdout JSONL sink |
 | url-credentials | redactor | 1.0.0 | 1.0 | Fapilog Core | Strips user:pass@ credentials from URL-like strings. |
+| webhook | sink | 1.0.0 | 1.0 | Fapilog Core | Webhook sink that POSTs JSON with optional signing. |
+| zero-copy | processor | 1.0.0 | 1.0 | Fapilog Core | Zero-copy pass-through processor for performance benchmarking. |

--- a/src/fapilog/plugins/processors/zero_copy.py
+++ b/src/fapilog/plugins/processors/zero_copy.py
@@ -60,3 +60,16 @@ class ZeroCopyProcessor:
                 _ = await self.process(v)
                 count += 1
         return count
+
+
+# Plugin metadata for discovery
+PLUGIN_METADATA = {
+    "name": "zero-copy",
+    "version": "1.0.0",
+    "plugin_type": "processor",
+    "entry_point": "fapilog.plugins.processors.zero_copy:ZeroCopyProcessor",
+    "description": "Zero-copy pass-through processor for performance benchmarking.",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.3.0"},
+    "api_version": "1.0",
+}

--- a/src/fapilog/plugins/redactors/url_credentials.py
+++ b/src/fapilog/plugins/redactors/url_credentials.py
@@ -87,14 +87,15 @@ class UrlCredentialsRedactor:
         return value
 
 
-# Minimal PLUGIN_METADATA for discovery
+# Plugin metadata for discovery
 PLUGIN_METADATA = {
     "name": "url-credentials",
     "version": "1.0.0",
     "author": "Fapilog Core",
     "plugin_type": "redactor",
-    "entry_point": ("fapilog.plugins.redactors.url_credentials:UrlCredentialsRedactor"),
-    "description": ("Strips user:pass@ credentials from URL-like strings."),
+    "entry_point": "fapilog.plugins.redactors.url_credentials:UrlCredentialsRedactor",
+    "description": "Strips user:pass@ credentials from URL-like strings.",
+    "compatibility": {"min_fapilog_version": "0.3.0"},
     "api_version": "1.0",
 }
 

--- a/src/fapilog/plugins/sinks/http_client.py
+++ b/src/fapilog/plugins/sinks/http_client.py
@@ -164,3 +164,15 @@ class HttpSink:
 
 # Mark public API methods for tooling
 _ = HttpSink.health_check  # pragma: no cover
+
+# Plugin metadata for discovery
+PLUGIN_METADATA = {
+    "name": "http",
+    "version": "1.0.0",
+    "plugin_type": "sink",
+    "entry_point": "fapilog.plugins.sinks.http_client:HttpSink",
+    "description": "Async HTTP sink that POSTs JSON to a configured endpoint.",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.3.0"},
+    "api_version": "1.0",
+}

--- a/src/fapilog/plugins/sinks/rotating_file.py
+++ b/src/fapilog/plugins/sinks/rotating_file.py
@@ -459,12 +459,13 @@ class RotatingFileSink:
 
 # Minimal plugin metadata for discovery compatibility (local/entry-point)
 PLUGIN_METADATA = {
-    "name": "rotating-file-sink",
-    "version": "0.1.0",
+    "name": "rotating-file",
+    "version": "1.0.0",
     "plugin_type": "sink",
-    "entry_point": __name__,
-    "description": ("Async rotating file sink with size/time rotation and retention"),
+    "entry_point": "fapilog.plugins.sinks.rotating_file:RotatingFileSink",
+    "description": "Async rotating file sink with size/time rotation and retention",
     "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.3.0"},
     "api_version": "1.0",
 }
 

--- a/src/fapilog/plugins/sinks/stdout_json.py
+++ b/src/fapilog/plugins/sinks/stdout_json.py
@@ -138,11 +138,12 @@ _VULTURE_USED: tuple[object, ...] = (
 
 # Minimal plugin metadata for discovery compatibility
 PLUGIN_METADATA = {
-    "name": "stdout-json-sink",
+    "name": "stdout-json",
     "version": "1.0.0",
     "plugin_type": "sink",
-    "entry_point": __name__,
+    "entry_point": "fapilog.plugins.sinks.stdout_json:StdoutJsonSink",
     "description": "Async stdout JSONL sink",
     "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.3.0"},
     "api_version": "1.0",
 }

--- a/src/fapilog/plugins/sinks/webhook.py
+++ b/src/fapilog/plugins/sinks/webhook.py
@@ -139,3 +139,15 @@ class WebhookSink:
 
 # Mark public API methods for tooling
 _ = WebhookSink.health_check  # pragma: no cover
+
+# Plugin metadata for discovery
+PLUGIN_METADATA = {
+    "name": "webhook",
+    "version": "1.0.0",
+    "plugin_type": "sink",
+    "entry_point": "fapilog.plugins.sinks.webhook:WebhookSink",
+    "description": "Webhook sink that POSTs JSON with optional signing.",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.3.0"},
+    "api_version": "1.0",
+}

--- a/tests/unit/test_plugin_metadata_completeness.py
+++ b/tests/unit/test_plugin_metadata_completeness.py
@@ -1,0 +1,115 @@
+"""
+TDD tests for Story 4.23: Complete Plugin Metadata for All Built-in Plugins.
+
+These tests verify all built-in plugins have complete PLUGIN_METADATA.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+# All built-in plugin modules that should have PLUGIN_METADATA
+BUILTIN_PLUGIN_MODULES = [
+    # Sinks
+    "fapilog.plugins.sinks.stdout_json",
+    "fapilog.plugins.sinks.rotating_file",
+    "fapilog.plugins.sinks.http_client",
+    "fapilog.plugins.sinks.webhook",
+    # Enrichers
+    "fapilog.plugins.enrichers.runtime_info",
+    "fapilog.plugins.enrichers.context_vars",
+    # Redactors
+    "fapilog.plugins.redactors.field_mask",
+    "fapilog.plugins.redactors.regex_mask",
+    "fapilog.plugins.redactors.url_credentials",
+    # Processors
+    "fapilog.plugins.processors.zero_copy",
+]
+
+REQUIRED_FIELDS = {
+    "name",
+    "version",
+    "plugin_type",
+    "entry_point",
+    "description",
+    "author",
+    "compatibility",
+    "api_version",
+}
+
+
+@pytest.mark.parametrize("module_path", BUILTIN_PLUGIN_MODULES)
+def test_plugin_has_metadata(module_path: str) -> None:
+    """Each plugin module must export PLUGIN_METADATA."""
+    module = importlib.import_module(module_path)
+    assert hasattr(module, "PLUGIN_METADATA"), f"{module_path} missing PLUGIN_METADATA"
+
+
+@pytest.mark.parametrize("module_path", BUILTIN_PLUGIN_MODULES)
+def test_plugin_metadata_has_required_fields(module_path: str) -> None:
+    """Each PLUGIN_METADATA must have all required fields."""
+    module = importlib.import_module(module_path)
+    metadata: dict[str, Any] = getattr(module, "PLUGIN_METADATA", {})
+
+    missing = REQUIRED_FIELDS - set(metadata.keys())
+    assert not missing, f"{module_path} PLUGIN_METADATA missing fields: {missing}"
+
+
+@pytest.mark.parametrize("module_path", BUILTIN_PLUGIN_MODULES)
+def test_plugin_metadata_compatibility_valid(module_path: str) -> None:
+    """compatibility must have min_fapilog_version."""
+    module = importlib.import_module(module_path)
+    metadata: dict[str, Any] = getattr(module, "PLUGIN_METADATA", {})
+
+    compat = metadata.get("compatibility", {})
+    assert "min_fapilog_version" in compat, (
+        f"{module_path} compatibility missing min_fapilog_version"
+    )
+
+
+@pytest.mark.parametrize("module_path", BUILTIN_PLUGIN_MODULES)
+def test_plugin_metadata_api_version_format(module_path: str) -> None:
+    """api_version must be in 'X.Y' format."""
+    from fapilog.plugins.versioning import parse_api_version
+
+    module = importlib.import_module(module_path)
+    metadata: dict[str, Any] = getattr(module, "PLUGIN_METADATA", {})
+
+    api_version = metadata.get("api_version", "1.0")
+    # Should not raise
+    major, minor = parse_api_version(api_version)
+    assert major >= 1, f"{module_path} api_version major must be >= 1"
+
+
+@pytest.mark.parametrize("module_path", BUILTIN_PLUGIN_MODULES)
+def test_plugin_type_is_valid(module_path: str) -> None:
+    """plugin_type must be one of the valid types."""
+    module = importlib.import_module(module_path)
+    metadata: dict[str, Any] = getattr(module, "PLUGIN_METADATA", {})
+
+    valid_types = {"sink", "processor", "enricher", "redactor", "alerting"}
+    plugin_type = metadata.get("plugin_type")
+    assert plugin_type in valid_types, (
+        f"{module_path} has invalid plugin_type: {plugin_type}"
+    )
+
+
+@pytest.mark.parametrize("module_path", BUILTIN_PLUGIN_MODULES)
+def test_plugin_entry_point_format(module_path: str) -> None:
+    """entry_point must match 'module.path:ClassName' format."""
+    module = importlib.import_module(module_path)
+    metadata: dict[str, Any] = getattr(module, "PLUGIN_METADATA", {})
+
+    entry_point = metadata.get("entry_point", "")
+    assert ":" in entry_point, f"{module_path} entry_point missing colon separator"
+
+    ep_module, ep_class = entry_point.split(":", 1)
+    assert ep_module == module_path, (
+        f"{module_path} entry_point module mismatch: {ep_module}"
+    )
+    assert hasattr(module, ep_class), (
+        f"{module_path} entry_point class {ep_class} not found in module"
+    )


### PR DESCRIPTION
## Story 4.23: Complete Plugin Metadata for All Built-in Plugins

### Problem Statement
The plugin audit revealed inconsistent `PLUGIN_METADATA` across built-in plugins:
- `ZeroCopyProcessor` had no metadata at all
- `HttpSink` and `WebhookSink` had no metadata at all
- `UrlCredentialsRedactor` was missing `compatibility` key
- `StdoutJsonSink` and `RotatingFileSink` were missing `compatibility` and had incorrect `entry_point` format

### Changes

#### Added/Updated PLUGIN_METADATA

| Plugin | Change |
|--------|--------|
| `StdoutJsonSink` | Added `compatibility`, fixed `entry_point` format |
| `RotatingFileSink` | Added `compatibility`, fixed `entry_point`, version -> 1.0.0 |
| `HttpSink` | Added complete metadata (was missing) |
| `WebhookSink` | Added complete metadata (was missing) |
| `UrlCredentialsRedactor` | Added `compatibility` field |
| `ZeroCopyProcessor` | Added complete metadata (was missing) |

#### Required Metadata Fields (all present now)
- `name`, `version`, `plugin_type`, `entry_point`
- `description`, `author`, `api_version`
- `compatibility.min_fapilog_version`

### Testing (TDD Approach)
- Added `tests/unit/test_plugin_metadata_completeness.py` with **60 tests**
- Tests validate: presence, required fields, compatibility format, api_version format, plugin_type validity, entry_point format
- **RED phase**: 23 tests failed initially
- **GREEN phase**: All 60 tests pass after fixes
- All **1026 unit tests** pass, **91% coverage**

### Acceptance Criteria
- [x] All 10 built-in plugins have `PLUGIN_METADATA` export
- [x] All metadata includes `compatibility.min_fapilog_version`
- [x] All metadata includes valid `api_version` in "X.Y" format
- [x] Automated test validates metadata completeness
- [x] All existing tests pass