### PR TITLE
feat(testing): add fapilog.testing module with plugin testing utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -371,6 +371,7 @@ exclude = [
     "src/fapilog/plugins/discovery.py",  # Plugin discovery API methods
     "src/fapilog/plugins/lifecycle.py",  # Component lifecycle API methods
     "src/fapilog/plugins/metadata.py",  # Plugin metadata models with Pydantic fields
+    "src/fapilog/testing/",  # Testing utilities with public API for plugin authors
     "tests/",  # Test files have expected unused imports and mocks
 ]
 

--- a/src/fapilog/testing/__init__.py
+++ b/src/fapilog/testing/__init__.py
@@ -1,0 +1,63 @@
+"""
+Testing utilities for fapilog plugins.
+
+This module provides mocks, fixtures, and validators for testing
+custom plugins.
+
+Example:
+    from fapilog.testing import MockSink, validate_sink
+
+    def test_my_sink():
+        sink = MockSink()
+        result = validate_sink(sink)
+        assert result.valid
+"""
+
+from .factories import (
+    create_batch_events,
+    create_log_event,
+    create_sensitive_event,
+    generate_correlation_id,
+)
+from .mocks import (
+    MockEnricher,
+    MockEnricherConfig,
+    MockProcessor,
+    MockRedactor,
+    MockRedactorConfig,
+    MockSink,
+    MockSinkConfig,
+)
+from .validators import (
+    ProtocolViolationError,
+    ValidationResult,
+    validate_enricher,
+    validate_plugin_lifecycle,
+    validate_processor,
+    validate_redactor,
+    validate_sink,
+)
+
+__all__ = [
+    # Mocks
+    "MockSink",
+    "MockSinkConfig",
+    "MockEnricher",
+    "MockEnricherConfig",
+    "MockRedactor",
+    "MockRedactorConfig",
+    "MockProcessor",
+    # Validators
+    "validate_sink",
+    "validate_enricher",
+    "validate_redactor",
+    "validate_processor",
+    "validate_plugin_lifecycle",
+    "ValidationResult",
+    "ProtocolViolationError",
+    # Factories
+    "create_log_event",
+    "create_batch_events",
+    "create_sensitive_event",
+    "generate_correlation_id",
+]

--- a/src/fapilog/testing/factories.py
+++ b/src/fapilog/testing/factories.py
@@ -1,0 +1,104 @@
+"""
+Test data factories for testing fapilog plugins.
+
+Provides utilities to generate test data for log events.
+"""
+
+from __future__ import annotations
+
+import random
+import string
+from datetime import datetime, timezone
+from typing import Any
+
+
+def create_log_event(
+    level: str = "INFO",
+    message: str | None = None,
+    **metadata: Any,
+) -> dict[str, Any]:
+    """Create a log event with sensible defaults.
+
+    Args:
+        level: Log level (DEBUG, INFO, WARNING, ERROR)
+        message: Log message (auto-generated if None)
+        **metadata: Additional metadata fields
+
+    Returns:
+        Complete log event dict
+    """
+    if message is None:
+        message = f"Test message {random.randint(1000, 9999)}"
+
+    return {
+        "level": level,
+        "message": message,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "logger": "test",
+        "correlation_id": generate_correlation_id(),
+        "metadata": metadata,
+    }
+
+
+def create_batch_events(
+    count: int,
+    level: str = "INFO",
+    **metadata: Any,
+) -> list[dict[str, Any]]:
+    """Create a batch of log events.
+
+    Args:
+        count: Number of events to create
+        level: Log level for all events
+        **metadata: Metadata to include in all events
+
+    Returns:
+        List of log events
+    """
+    return [
+        create_log_event(
+            level=level,
+            message=f"Batch message {i}",
+            **metadata,
+        )
+        for i in range(count)
+    ]
+
+
+def generate_correlation_id() -> str:
+    """Generate a random correlation ID."""
+    return "".join(random.choices(string.hexdigits.lower()[:16], k=32))
+
+
+def create_sensitive_event() -> dict[str, Any]:
+    """Create an event with various sensitive fields for redaction testing."""
+    return {
+        "level": "INFO",
+        "message": "User action",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "user": {
+            "id": "user_123",
+            "email": "test@example.com",
+            "password": "supersecret123",
+            "ssn": "123-45-6789",
+        },
+        "payment": {
+            "card_number": "4111111111111111",
+            "cvv": "123",
+            "expiry": "12/25",
+        },
+        "auth": {
+            "api_key": "sk-abcdef123456",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+        },
+        "url": "https://user:pass@api.example.com/data",
+    }
+
+
+# Mark as used for static analysis
+_VULTURE_USED: tuple[object, ...] = (
+    create_log_event,
+    create_batch_events,
+    create_sensitive_event,
+    generate_correlation_id,
+)

--- a/src/fapilog/testing/mocks.py
+++ b/src/fapilog/testing/mocks.py
@@ -1,0 +1,248 @@
+"""
+Mock implementations for testing fapilog plugins.
+
+Provides configurable mocks for sinks, enrichers, redactors, and processors.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class MockSinkConfig:
+    """Configuration for mock sink."""
+
+    fail_after: int | None = None  # Fail after N writes
+    fail_with: Exception | None = None  # Exception to raise
+    latency_seconds: float = 0.0  # Simulated latency
+    health_status: bool = True
+
+
+class MockSink:
+    """Mock sink for testing that captures written events.
+
+    Features:
+    - Captures all written events for inspection
+    - Configurable failure behavior
+    - Configurable latency
+    - Tracks lifecycle calls
+    """
+
+    name = "mock"
+
+    def __init__(self, config: MockSinkConfig | None = None) -> None:
+        self._config = config or MockSinkConfig()
+        self.events: list[dict[str, Any]] = []
+        self.write_count: int = 0
+        self.start_called: bool = False
+        self.stop_called: bool = False
+        self.health_check_count: int = 0
+
+    async def start(self) -> None:
+        self.start_called = True
+
+    async def stop(self) -> None:
+        self.stop_called = True
+
+    async def write(self, entry: dict[str, Any]) -> None:
+        if self._config.latency_seconds > 0:
+            await asyncio.sleep(self._config.latency_seconds)
+
+        self.write_count += 1
+
+        if self._config.fail_after is not None:
+            if self.write_count > self._config.fail_after:
+                raise self._config.fail_with or RuntimeError("Mock failure")
+
+        self.events.append(entry.copy())
+
+    async def health_check(self) -> bool:
+        self.health_check_count += 1
+        return self._config.health_status
+
+    def reset(self) -> None:
+        """Reset state for reuse in multiple tests."""
+        self.events.clear()
+        self.write_count = 0
+        self.start_called = False
+        self.stop_called = False
+        self.health_check_count = 0
+
+    def assert_event_count(self, expected: int) -> None:
+        """Assert number of events written."""
+        assert len(self.events) == expected, (
+            f"Expected {expected} events, got {len(self.events)}"
+        )
+
+    def assert_event_contains(self, index: int, **kwargs: Any) -> None:
+        """Assert event at index contains specified fields."""
+        if index >= len(self.events):
+            raise AssertionError(f"No event at index {index}")
+
+        event = self.events[index]
+        for key, value in kwargs.items():
+            assert key in event, f"Event missing field: {key}"
+            assert event[key] == value, (
+                f"Event[{key}] expected {value!r}, got {event[key]!r}"
+            )
+
+
+@dataclass
+class MockEnricherConfig:
+    """Configuration for mock enricher."""
+
+    fields_to_add: dict[str, Any] = field(default_factory=dict)
+    fail_on_call: int | None = None  # Fail on Nth call
+    latency_seconds: float = 0.0
+
+
+class MockEnricher:
+    """Mock enricher for testing that adds configurable fields.
+
+    Features:
+    - Adds configured fields to events
+    - Tracks all enriched events
+    - Configurable failure behavior
+    """
+
+    name = "mock"
+
+    def __init__(self, config: MockEnricherConfig | None = None) -> None:
+        self._config = config or MockEnricherConfig()
+        self.enriched_events: list[dict[str, Any]] = []
+        self.call_count: int = 0
+        self.start_called: bool = False
+        self.stop_called: bool = False
+
+    async def start(self) -> None:
+        self.start_called = True
+
+    async def stop(self) -> None:
+        self.stop_called = True
+
+    async def enrich(self, event: dict[str, Any]) -> dict[str, Any]:
+        self.call_count += 1
+
+        if self._config.fail_on_call is not None:
+            if self.call_count == self._config.fail_on_call:
+                raise RuntimeError("Mock enricher failure")
+
+        if self._config.latency_seconds > 0:
+            await asyncio.sleep(self._config.latency_seconds)
+
+        self.enriched_events.append(event.copy())
+        return self._config.fields_to_add.copy()
+
+    async def health_check(self) -> bool:
+        return True
+
+    def reset(self) -> None:
+        self.enriched_events.clear()
+        self.call_count = 0
+        self.start_called = False
+        self.stop_called = False
+
+
+@dataclass
+class MockRedactorConfig:
+    """Configuration for mock redactor."""
+
+    fields_to_mask: list[str] = field(default_factory=list)
+    mask_string: str = "***MOCK***"
+
+
+class MockRedactor:
+    """Mock redactor for testing that masks configured fields."""
+
+    name = "mock"
+
+    def __init__(self, config: MockRedactorConfig | None = None) -> None:
+        self._config = config or MockRedactorConfig()
+        self.redacted_events: list[dict[str, Any]] = []
+        self.call_count: int = 0
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def redact(self, event: dict[str, Any]) -> dict[str, Any]:
+        self.call_count += 1
+        result: dict[str, Any] = self._deep_copy_dict(event)
+
+        for field_path in self._config.fields_to_mask:
+            self._mask_field(result, field_path.split("."))
+
+        self.redacted_events.append(result)
+        return result
+
+    def _deep_copy_dict(self, obj: dict[str, Any]) -> dict[str, Any]:
+        """Deep copy a dict structure."""
+        return {k: self._deep_copy_value(v) for k, v in obj.items()}
+
+    def _deep_copy_value(self, obj: Any) -> Any:
+        """Deep copy a value (dict/list or primitive)."""
+        if isinstance(obj, dict):
+            return {k: self._deep_copy_value(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._deep_copy_value(item) for item in obj]
+        return obj
+
+    def _mask_field(self, obj: dict[str, Any], path: list[str]) -> None:
+        if not path:
+            return
+
+        key = path[0]
+        if len(path) == 1:
+            if key in obj:
+                obj[key] = self._config.mask_string
+        else:
+            if key in obj and isinstance(obj[key], dict):
+                self._mask_field(obj[key], path[1:])
+
+    async def health_check(self) -> bool:
+        return True
+
+
+class MockProcessor:
+    """Mock processor for testing."""
+
+    name = "mock"
+
+    def __init__(self) -> None:
+        self.processed_views: list[memoryview] = []
+        self.call_count: int = 0
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def process(self, view: memoryview) -> memoryview:
+        self.call_count += 1
+        self.processed_views.append(view)
+        return view
+
+    async def health_check(self) -> bool:
+        return True
+
+
+# Mark as used for static analysis (public API used by tests)
+_VULTURE_USED: tuple[object, ...] = (
+    MockSink,
+    MockSink.reset,
+    MockSink.assert_event_count,
+    MockSink.assert_event_contains,
+    MockSinkConfig,
+    MockEnricher,
+    MockEnricher.reset,
+    MockEnricherConfig,
+    MockRedactor,
+    MockRedactorConfig,
+    MockProcessor,
+)

--- a/src/fapilog/testing/validators.py
+++ b/src/fapilog/testing/validators.py
@@ -1,0 +1,219 @@
+"""
+Protocol validators for testing fapilog plugins.
+
+Provides utilities to validate that plugins correctly implement their protocols.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ValidationResult:
+    """Result of protocol validation."""
+
+    valid: bool
+    plugin_type: str
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def raise_if_invalid(self) -> None:
+        if not self.valid:
+            raise ProtocolViolationError(
+                f"Plugin violates {self.plugin_type} protocol: "
+                + "; ".join(self.errors)
+            )
+
+
+class ProtocolViolationError(Exception):
+    """Raised when a plugin violates its protocol."""
+
+    pass
+
+
+def validate_sink(sink: Any) -> ValidationResult:
+    """Validate that a sink implements BaseSink protocol correctly.
+
+    Checks:
+    - Required methods exist and are async
+    - Methods have correct signatures
+    - Lifecycle methods don't raise on call
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # Check required methods
+    required_methods = ["start", "stop", "write"]
+    for method_name in required_methods:
+        if not hasattr(sink, method_name):
+            errors.append(f"Missing required method: {method_name}")
+            continue
+
+        method = getattr(sink, method_name)
+        if not asyncio.iscoroutinefunction(method):
+            errors.append(f"{method_name} must be async")
+
+    # Check optional methods
+    if hasattr(sink, "health_check"):
+        if not asyncio.iscoroutinefunction(sink.health_check):
+            warnings.append("health_check should be async")
+
+    # Check write signature
+    if hasattr(sink, "write"):
+        sig = inspect.signature(sink.write)
+        params = list(sig.parameters.keys())
+        if len(params) < 1 or (len(params) == 1 and params[0] == "self"):
+            errors.append("write must accept entry parameter")
+
+    return ValidationResult(
+        valid=len(errors) == 0,
+        plugin_type="BaseSink",
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+def validate_enricher(enricher: Any) -> ValidationResult:
+    """Validate that an enricher implements BaseEnricher protocol correctly."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    required_methods = ["start", "stop", "enrich"]
+    for method_name in required_methods:
+        if not hasattr(enricher, method_name):
+            errors.append(f"Missing required method: {method_name}")
+            continue
+
+        method = getattr(enricher, method_name)
+        if not asyncio.iscoroutinefunction(method):
+            errors.append(f"{method_name} must be async")
+
+    # Check enrich signature
+    if hasattr(enricher, "enrich"):
+        sig = inspect.signature(enricher.enrich)
+        params = list(sig.parameters.keys())
+        if "event" not in params and "entry" not in params:
+            # Allow any parameter name
+            pass
+
+    return ValidationResult(
+        valid=len(errors) == 0,
+        plugin_type="BaseEnricher",
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+def validate_redactor(redactor: Any) -> ValidationResult:
+    """Validate that a redactor implements BaseRedactor protocol correctly."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # Check name attribute
+    if not hasattr(redactor, "name"):
+        errors.append("Redactor must have 'name' attribute")
+
+    required_methods = ["start", "stop", "redact"]
+    for method_name in required_methods:
+        if not hasattr(redactor, method_name):
+            errors.append(f"Missing required method: {method_name}")
+            continue
+
+        method = getattr(redactor, method_name)
+        if not asyncio.iscoroutinefunction(method):
+            errors.append(f"{method_name} must be async")
+
+    return ValidationResult(
+        valid=len(errors) == 0,
+        plugin_type="BaseRedactor",
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+def validate_processor(processor: Any) -> ValidationResult:
+    """Validate that a processor implements BaseProcessor protocol correctly."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    required_methods = ["start", "stop", "process"]
+    for method_name in required_methods:
+        if not hasattr(processor, method_name):
+            errors.append(f"Missing required method: {method_name}")
+            continue
+
+        method = getattr(processor, method_name)
+        if not asyncio.iscoroutinefunction(method):
+            errors.append(f"{method_name} must be async")
+
+    return ValidationResult(
+        valid=len(errors) == 0,
+        plugin_type="BaseProcessor",
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+async def validate_plugin_lifecycle(plugin: Any) -> ValidationResult:
+    """Validate that a plugin's lifecycle methods work correctly.
+
+    Actually calls start() and stop() to verify they don't raise.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+    plugin_type = "unknown"
+
+    # Detect type
+    if hasattr(plugin, "write"):
+        plugin_type = "sink"
+    elif hasattr(plugin, "enrich"):
+        plugin_type = "enricher"
+    elif hasattr(plugin, "redact"):
+        plugin_type = "redactor"
+    elif hasattr(plugin, "process"):
+        plugin_type = "processor"
+
+    # Test start
+    if hasattr(plugin, "start"):
+        try:
+            await plugin.start()
+        except Exception as e:
+            errors.append(f"start() raised: {e}")
+
+    # Test stop
+    if hasattr(plugin, "stop"):
+        try:
+            await plugin.stop()
+        except Exception as e:
+            errors.append(f"stop() raised: {e}")
+
+    # Test stop is idempotent
+    if hasattr(plugin, "stop"):
+        try:
+            await plugin.stop()  # Second call should not raise
+        except Exception as e:
+            warnings.append(f"stop() not idempotent: {e}")
+
+    return ValidationResult(
+        valid=len(errors) == 0,
+        plugin_type=plugin_type,
+        errors=errors,
+        warnings=warnings,
+    )
+
+
+# Mark as used for static analysis
+_VULTURE_USED: tuple[object, ...] = (
+    ValidationResult,
+    ValidationResult.raise_if_invalid,
+    ProtocolViolationError,
+    validate_sink,
+    validate_enricher,
+    validate_redactor,
+    validate_processor,
+    validate_plugin_lifecycle,
+)

--- a/tests/unit/test_testing_factories.py
+++ b/tests/unit/test_testing_factories.py
@@ -1,0 +1,159 @@
+"""
+TDD tests for Story 4.27: Plugin Testing Utilities - Factories.
+
+Tests for create_log_event, create_batch_events, create_sensitive_event.
+"""
+
+from __future__ import annotations
+
+
+class TestCreateLogEvent:
+    """Tests for create_log_event factory."""
+
+    def test_create_log_event_defaults(self) -> None:
+        """create_log_event should create valid event with defaults."""
+        from fapilog.testing import create_log_event
+
+        event = create_log_event()
+
+        assert "level" in event
+        assert event["level"] == "INFO"
+        assert "message" in event
+        assert "timestamp" in event
+        assert "logger" in event
+        assert "correlation_id" in event
+
+    def test_create_log_event_custom_level(self) -> None:
+        """create_log_event should accept custom level."""
+        from fapilog.testing import create_log_event
+
+        event = create_log_event(level="ERROR")
+        assert event["level"] == "ERROR"
+
+    def test_create_log_event_custom_message(self) -> None:
+        """create_log_event should accept custom message."""
+        from fapilog.testing import create_log_event
+
+        event = create_log_event(message="Custom message")
+        assert event["message"] == "Custom message"
+
+    def test_create_log_event_with_metadata(self) -> None:
+        """create_log_event should include metadata kwargs."""
+        from fapilog.testing import create_log_event
+
+        event = create_log_event(user_id="123", request_id="abc")
+
+        assert event["metadata"]["user_id"] == "123"
+        assert event["metadata"]["request_id"] == "abc"
+
+    def test_create_log_event_timestamp_is_iso(self) -> None:
+        """create_log_event timestamp should be ISO format."""
+        from fapilog.testing import create_log_event
+
+        event = create_log_event()
+
+        # Should be parseable as ISO
+        from datetime import datetime
+
+        datetime.fromisoformat(event["timestamp"].replace("Z", "+00:00"))
+
+
+class TestCreateBatchEvents:
+    """Tests for create_batch_events factory."""
+
+    def test_create_batch_events_count(self) -> None:
+        """create_batch_events should create specified number of events."""
+        from fapilog.testing import create_batch_events
+
+        events = create_batch_events(5)
+        assert len(events) == 5
+
+    def test_create_batch_events_unique_messages(self) -> None:
+        """create_batch_events should have unique messages."""
+        from fapilog.testing import create_batch_events
+
+        events = create_batch_events(3)
+        messages = [e["message"] for e in events]
+
+        assert len(set(messages)) == 3  # All unique
+
+    def test_create_batch_events_shared_level(self) -> None:
+        """create_batch_events should apply level to all events."""
+        from fapilog.testing import create_batch_events
+
+        events = create_batch_events(3, level="WARNING")
+
+        for event in events:
+            assert event["level"] == "WARNING"
+
+    def test_create_batch_events_with_metadata(self) -> None:
+        """create_batch_events should include metadata in all events."""
+        from fapilog.testing import create_batch_events
+
+        events = create_batch_events(2, service="test")
+
+        for event in events:
+            assert event["metadata"]["service"] == "test"
+
+
+class TestCreateSensitiveEvent:
+    """Tests for create_sensitive_event factory."""
+
+    def test_create_sensitive_event_has_user_data(self) -> None:
+        """create_sensitive_event should have user section."""
+        from fapilog.testing import create_sensitive_event
+
+        event = create_sensitive_event()
+
+        assert "user" in event
+        assert "password" in event["user"]
+        assert "email" in event["user"]
+
+    def test_create_sensitive_event_has_payment_data(self) -> None:
+        """create_sensitive_event should have payment section."""
+        from fapilog.testing import create_sensitive_event
+
+        event = create_sensitive_event()
+
+        assert "payment" in event
+        assert "card_number" in event["payment"]
+        assert "cvv" in event["payment"]
+
+    def test_create_sensitive_event_has_auth_data(self) -> None:
+        """create_sensitive_event should have auth section."""
+        from fapilog.testing import create_sensitive_event
+
+        event = create_sensitive_event()
+
+        assert "auth" in event
+        assert "api_key" in event["auth"]
+        assert "token" in event["auth"]
+
+    def test_create_sensitive_event_has_url_with_creds(self) -> None:
+        """create_sensitive_event should have URL with credentials."""
+        from fapilog.testing import create_sensitive_event
+
+        event = create_sensitive_event()
+
+        assert "url" in event
+        assert "user:pass@" in event["url"]
+
+
+class TestGenerateCorrelationId:
+    """Tests for generate_correlation_id factory."""
+
+    def test_generate_correlation_id_format(self) -> None:
+        """generate_correlation_id should return hex string."""
+        from fapilog.testing import generate_correlation_id
+
+        cid = generate_correlation_id()
+
+        assert len(cid) == 32
+        assert all(c in "0123456789abcdef" for c in cid)
+
+    def test_generate_correlation_id_unique(self) -> None:
+        """generate_correlation_id should return unique IDs."""
+        from fapilog.testing import generate_correlation_id
+
+        ids = [generate_correlation_id() for _ in range(100)]
+        assert len(set(ids)) == 100

--- a/tests/unit/test_testing_mocks.py
+++ b/tests/unit/test_testing_mocks.py
@@ -1,0 +1,297 @@
+"""
+TDD tests for Story 4.27: Plugin Testing Utilities - Mock implementations.
+
+Tests for MockSink, MockEnricher, MockRedactor, MockProcessor.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestMockSink:
+    """Tests for MockSink test utility."""
+
+    @pytest.mark.asyncio
+    async def test_mock_sink_captures_events(self) -> None:
+        """MockSink should capture all written events."""
+        from fapilog.testing import MockSink
+
+        sink = MockSink()
+        await sink.start()
+
+        await sink.write({"level": "INFO", "message": "test1"})
+        await sink.write({"level": "ERROR", "message": "test2"})
+
+        assert len(sink.events) == 2
+        assert sink.events[0]["message"] == "test1"
+        assert sink.events[1]["message"] == "test2"
+        assert sink.write_count == 2
+
+    @pytest.mark.asyncio
+    async def test_mock_sink_tracks_lifecycle(self) -> None:
+        """MockSink should track start/stop calls."""
+        from fapilog.testing import MockSink
+
+        sink = MockSink()
+        assert not sink.start_called
+        assert not sink.stop_called
+
+        await sink.start()
+        assert sink.start_called
+
+        await sink.stop()
+        assert sink.stop_called
+
+    @pytest.mark.asyncio
+    async def test_mock_sink_fails_after_configured(self) -> None:
+        """MockSink should fail after configured number of writes."""
+        from fapilog.testing import MockSink, MockSinkConfig
+
+        sink = MockSink(MockSinkConfig(fail_after=2))
+
+        await sink.write({"n": 1})
+        await sink.write({"n": 2})
+
+        with pytest.raises(RuntimeError, match="Mock failure"):
+            await sink.write({"n": 3})
+
+    @pytest.mark.asyncio
+    async def test_mock_sink_fails_with_custom_exception(self) -> None:
+        """MockSink should raise configured exception."""
+        from fapilog.testing import MockSink, MockSinkConfig
+
+        sink = MockSink(
+            MockSinkConfig(fail_after=0, fail_with=ConnectionError("Timeout"))
+        )
+
+        with pytest.raises(ConnectionError, match="Timeout"):
+            await sink.write({"n": 1})
+
+    @pytest.mark.asyncio
+    async def test_mock_sink_simulates_latency(self) -> None:
+        """MockSink should add configured latency."""
+        import time
+
+        from fapilog.testing import MockSink, MockSinkConfig
+
+        sink = MockSink(MockSinkConfig(latency_seconds=0.05))
+
+        start = time.monotonic()
+        await sink.write({"test": True})
+        elapsed = time.monotonic() - start
+
+        assert elapsed >= 0.05
+
+    @pytest.mark.asyncio
+    async def test_mock_sink_health_check(self) -> None:
+        """MockSink should return configured health status."""
+        from fapilog.testing import MockSink, MockSinkConfig
+
+        healthy_sink = MockSink(MockSinkConfig(health_status=True))
+        unhealthy_sink = MockSink(MockSinkConfig(health_status=False))
+
+        assert await healthy_sink.health_check() is True
+        assert await unhealthy_sink.health_check() is False
+        assert healthy_sink.health_check_count == 1
+
+    @pytest.mark.asyncio
+    async def test_mock_sink_reset(self) -> None:
+        """MockSink.reset() should clear all state."""
+        from fapilog.testing import MockSink
+
+        sink = MockSink()
+        await sink.start()
+        await sink.write({"test": True})
+        await sink.health_check()
+
+        sink.reset()
+
+        assert len(sink.events) == 0
+        assert sink.write_count == 0
+        assert not sink.start_called
+        assert sink.health_check_count == 0
+
+    def test_mock_sink_has_name(self) -> None:
+        """MockSink should have name attribute."""
+        from fapilog.testing import MockSink
+
+        assert MockSink.name == "mock"
+
+    def test_mock_sink_assert_event_count(self) -> None:
+        """MockSink.assert_event_count should verify event count."""
+        from fapilog.testing import MockSink
+
+        sink = MockSink()
+        sink.events = [{"a": 1}, {"b": 2}]
+
+        sink.assert_event_count(2)  # Should pass
+
+        with pytest.raises(AssertionError, match="Expected 5 events"):
+            sink.assert_event_count(5)
+
+    def test_mock_sink_assert_event_contains(self) -> None:
+        """MockSink.assert_event_contains should verify event fields."""
+        from fapilog.testing import MockSink
+
+        sink = MockSink()
+        sink.events = [{"level": "INFO", "message": "test"}]
+
+        sink.assert_event_contains(0, level="INFO")  # Should pass
+
+        with pytest.raises(AssertionError, match="expected 'ERROR'"):
+            sink.assert_event_contains(0, level="ERROR")
+
+        with pytest.raises(AssertionError, match="No event at index"):
+            sink.assert_event_contains(5, level="INFO")
+
+
+class TestMockEnricher:
+    """Tests for MockEnricher test utility."""
+
+    @pytest.mark.asyncio
+    async def test_mock_enricher_adds_fields(self) -> None:
+        """MockEnricher should return configured fields."""
+        from fapilog.testing import MockEnricher, MockEnricherConfig
+
+        enricher = MockEnricher(
+            MockEnricherConfig(fields_to_add={"env": "test", "service": "app"})
+        )
+
+        event = {"level": "INFO"}
+        result = await enricher.enrich(event)
+
+        assert result == {"env": "test", "service": "app"}
+        assert len(enricher.enriched_events) == 1
+        assert enricher.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_mock_enricher_tracks_lifecycle(self) -> None:
+        """MockEnricher should track start/stop."""
+        from fapilog.testing import MockEnricher
+
+        enricher = MockEnricher()
+        assert not enricher.start_called
+
+        await enricher.start()
+        assert enricher.start_called
+
+        await enricher.stop()
+        assert enricher.stop_called
+
+    @pytest.mark.asyncio
+    async def test_mock_enricher_fails_on_call(self) -> None:
+        """MockEnricher should fail on configured call number."""
+        from fapilog.testing import MockEnricher, MockEnricherConfig
+
+        enricher = MockEnricher(MockEnricherConfig(fail_on_call=2))
+
+        await enricher.enrich({})  # Call 1 - OK
+        with pytest.raises(RuntimeError, match="Mock enricher failure"):
+            await enricher.enrich({})  # Call 2 - Fail
+
+    @pytest.mark.asyncio
+    async def test_mock_enricher_reset(self) -> None:
+        """MockEnricher.reset() should clear state."""
+        from fapilog.testing import MockEnricher
+
+        enricher = MockEnricher()
+        await enricher.start()
+        await enricher.enrich({})
+
+        enricher.reset()
+
+        assert len(enricher.enriched_events) == 0
+        assert enricher.call_count == 0
+        assert not enricher.start_called
+
+
+class TestMockRedactor:
+    """Tests for MockRedactor test utility."""
+
+    @pytest.mark.asyncio
+    async def test_mock_redactor_masks_fields(self) -> None:
+        """MockRedactor should mask configured fields."""
+        from fapilog.testing import MockRedactor, MockRedactorConfig
+
+        redactor = MockRedactor(MockRedactorConfig(fields_to_mask=["password"]))
+
+        event = {"user": "alice", "password": "secret123"}
+        result = await redactor.redact(event)
+
+        assert result["user"] == "alice"
+        assert result["password"] == "***MOCK***"
+
+    @pytest.mark.asyncio
+    async def test_mock_redactor_masks_nested_fields(self) -> None:
+        """MockRedactor should mask nested fields using dot notation."""
+        from fapilog.testing import MockRedactor, MockRedactorConfig
+
+        redactor = MockRedactor(MockRedactorConfig(fields_to_mask=["user.password"]))
+
+        event = {"user": {"name": "alice", "password": "secret"}}
+        result = await redactor.redact(event)
+
+        assert result["user"]["name"] == "alice"
+        assert result["user"]["password"] == "***MOCK***"
+
+    @pytest.mark.asyncio
+    async def test_mock_redactor_custom_mask(self) -> None:
+        """MockRedactor should use custom mask string."""
+        from fapilog.testing import MockRedactor, MockRedactorConfig
+
+        redactor = MockRedactor(
+            MockRedactorConfig(fields_to_mask=["secret"], mask_string="[REDACTED]")
+        )
+
+        result = await redactor.redact({"secret": "value"})
+        assert result["secret"] == "[REDACTED]"
+
+    @pytest.mark.asyncio
+    async def test_mock_redactor_tracks_calls(self) -> None:
+        """MockRedactor should track call count."""
+        from fapilog.testing import MockRedactor
+
+        redactor = MockRedactor()
+        await redactor.redact({})
+        await redactor.redact({})
+
+        assert redactor.call_count == 2
+        assert len(redactor.redacted_events) == 2
+
+
+class TestMockProcessor:
+    """Tests for MockProcessor test utility."""
+
+    @pytest.mark.asyncio
+    async def test_mock_processor_returns_view(self) -> None:
+        """MockProcessor should return the same memoryview."""
+        from fapilog.testing import MockProcessor
+
+        processor = MockProcessor()
+        data = b"test data"
+        view = memoryview(data)
+
+        result = await processor.process(view)
+
+        assert result is view
+        assert processor.call_count == 1
+        assert len(processor.processed_views) == 1
+
+    @pytest.mark.asyncio
+    async def test_mock_processor_tracks_lifecycle(self) -> None:
+        """MockProcessor should implement start/stop."""
+        from fapilog.testing import MockProcessor
+
+        processor = MockProcessor()
+        await processor.start()
+        await processor.stop()
+        # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_mock_processor_health_check(self) -> None:
+        """MockProcessor should return True for health check."""
+        from fapilog.testing import MockProcessor
+
+        processor = MockProcessor()
+        assert await processor.health_check() is True

--- a/tests/unit/test_testing_validators.py
+++ b/tests/unit/test_testing_validators.py
@@ -1,0 +1,245 @@
+"""
+TDD tests for Story 4.27: Plugin Testing Utilities - Validators.
+
+Tests for validate_sink, validate_enricher, validate_redactor, validate_processor.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestValidateSink:
+    """Tests for validate_sink validator."""
+
+    def test_validate_sink_valid(self) -> None:
+        """Valid sink should pass validation."""
+        from fapilog.testing import validate_sink
+
+        class ValidSink:
+            name = "valid"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+        result = validate_sink(ValidSink())
+        assert result.valid
+        assert result.plugin_type == "BaseSink"
+        assert len(result.errors) == 0
+
+    def test_validate_sink_missing_method(self) -> None:
+        """Sink missing required method should fail."""
+        from fapilog.testing import validate_sink
+
+        class MissingWrite:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+        result = validate_sink(MissingWrite())
+        assert not result.valid
+        assert "Missing required method: write" in result.errors
+
+    def test_validate_sink_sync_method(self) -> None:
+        """Sink with sync method should fail."""
+        from fapilog.testing import validate_sink
+
+        class SyncWrite:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            def write(self, entry: dict) -> None:  # Not async!
+                pass
+
+        result = validate_sink(SyncWrite())
+        assert not result.valid
+        assert "write must be async" in result.errors
+
+    def test_validate_sink_raise_if_invalid(self) -> None:
+        """ValidationResult.raise_if_invalid should raise on errors."""
+        from fapilog.testing import ProtocolViolationError, validate_sink
+
+        class Invalid:
+            pass
+
+        result = validate_sink(Invalid())
+        with pytest.raises(ProtocolViolationError, match="BaseSink protocol"):
+            result.raise_if_invalid()
+
+
+class TestValidateEnricher:
+    """Tests for validate_enricher validator."""
+
+    def test_validate_enricher_valid(self) -> None:
+        """Valid enricher should pass validation."""
+        from fapilog.testing import validate_enricher
+
+        class ValidEnricher:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def enrich(self, event: dict) -> dict:
+                return {}
+
+        result = validate_enricher(ValidEnricher())
+        assert result.valid
+        assert result.plugin_type == "BaseEnricher"
+
+    def test_validate_enricher_missing_method(self) -> None:
+        """Enricher missing enrich method should fail."""
+        from fapilog.testing import validate_enricher
+
+        class MissingEnrich:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+        result = validate_enricher(MissingEnrich())
+        assert not result.valid
+        assert "Missing required method: enrich" in result.errors
+
+
+class TestValidateRedactor:
+    """Tests for validate_redactor validator."""
+
+    def test_validate_redactor_valid(self) -> None:
+        """Valid redactor should pass validation."""
+        from fapilog.testing import validate_redactor
+
+        class ValidRedactor:
+            name = "valid"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def redact(self, event: dict) -> dict:
+                return event
+
+        result = validate_redactor(ValidRedactor())
+        assert result.valid
+        assert result.plugin_type == "BaseRedactor"
+
+    def test_validate_redactor_missing_name(self) -> None:
+        """Redactor without name should fail."""
+        from fapilog.testing import validate_redactor
+
+        class NoName:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def redact(self, event: dict) -> dict:
+                return event
+
+        result = validate_redactor(NoName())
+        assert not result.valid
+        assert "Redactor must have 'name' attribute" in result.errors
+
+
+class TestValidateProcessor:
+    """Tests for validate_processor validator."""
+
+    def test_validate_processor_valid(self) -> None:
+        """Valid processor should pass validation."""
+        from fapilog.testing import validate_processor
+
+        class ValidProcessor:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def process(self, view: memoryview) -> memoryview:
+                return view
+
+        result = validate_processor(ValidProcessor())
+        assert result.valid
+        assert result.plugin_type == "BaseProcessor"
+
+
+class TestValidatePluginLifecycle:
+    """Tests for validate_plugin_lifecycle validator."""
+
+    @pytest.mark.asyncio
+    async def test_validate_lifecycle_valid(self) -> None:
+        """Plugin with working lifecycle should pass."""
+        from fapilog.testing import validate_plugin_lifecycle
+
+        class GoodPlugin:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+        result = await validate_plugin_lifecycle(GoodPlugin())
+        assert result.valid
+        assert result.plugin_type == "sink"
+
+    @pytest.mark.asyncio
+    async def test_validate_lifecycle_start_raises(self) -> None:
+        """Plugin with failing start should fail validation."""
+        from fapilog.testing import validate_plugin_lifecycle
+
+        class BadStart:
+            async def start(self) -> None:
+                raise RuntimeError("Start failed")
+
+            async def stop(self) -> None:
+                pass
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+        result = await validate_plugin_lifecycle(BadStart())
+        assert not result.valid
+        assert any("start() raised" in e for e in result.errors)
+
+    @pytest.mark.asyncio
+    async def test_validate_lifecycle_stop_not_idempotent(self) -> None:
+        """Non-idempotent stop should generate warning."""
+        from fapilog.testing import validate_plugin_lifecycle
+
+        class NonIdempotentStop:
+            _stopped = False
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                if self._stopped:
+                    raise RuntimeError("Already stopped")
+                self._stopped = True
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+        result = await validate_plugin_lifecycle(NonIdempotentStop())
+        # Still valid, but has warning
+        assert result.valid
+        assert any("not idempotent" in w for w in result.warnings)


### PR DESCRIPTION
## Story 4.27: Create Plugin Testing Utilities

### Problem Statement
Plugin authors had no guidance or utilities for testing their plugins:
- No test fixtures for common plugin testing patterns
- No mock sinks/enrichers for integration testing
- No validation utilities for testing protocol compliance

### Changes

#### New `fapilog.testing` Module

**Mock Implementations:**
| Class | Purpose |
|-------|---------|
| `MockSink` | Captures events, configurable failures/latency/health |
| `MockEnricher` | Returns configured fields, tracks enriched events |
| `MockRedactor` | Masks configured fields with custom mask string |
| `MockProcessor` | Pass-through processor tracking processed views |

**Protocol Validators:**
| Function | Purpose |
|----------|---------|
| `validate_sink()` | Validates BaseSink protocol compliance |
| `validate_enricher()` | Validates BaseEnricher protocol compliance |
| `validate_redactor()` | Validates BaseRedactor protocol compliance |
| `validate_processor()` | Validates BaseProcessor protocol compliance |
| `validate_plugin_lifecycle()` | Tests start/stop behavior and idempotency |

**Test Data Factories:**
| Function | Purpose |
|----------|---------|
| `create_log_event()` | Create events with sensible defaults |
| `create_batch_events()` | Create multiple events for batch testing |
| `create_sensitive_event()` | Event with PII/secrets for redaction tests |
| `generate_correlation_id()` | Random 32-char hex ID |

### Usage Example

```python
from fapilog.testing import MockSink, validate_sink, create_log_event

# Validate protocol compliance
result = validate_sink(MySink())
result.raise_if_invalid()

# Test with mock sink
async def test_my_enricher():
    sink = MockSink()
    await sink.write(create_log_event(level="INFO"))
    sink.assert_event_count(1)
```

### Testing (TDD Approach)
- **RED phase**: 48 tests failed initially  
- **GREEN phase**: All 48 new tests pass
- **1123 total tests pass**, **91% coverage**

### Acceptance Criteria
- [x] `fapilog.testing` module with public exports
- [x] `MockSink` with configurable behavior
- [x] `MockEnricher` with configurable fields
- [x] `MockRedactor` with configurable masking
- [x] `validate_sink()`, `validate_enricher()`, `validate_redactor()`, `validate_processor()`
- [x] `create_log_event()` factory function
- [x] Tests for the testing utilities themselves