### PR TITLE
feat(plugins): standardize name attribute and add testing docs (Story 4.30)

### DIFF
--- a/docs/user-guide/context-enrichment.md
+++ b/docs/user-guide/context-enrichment.md
@@ -34,14 +34,74 @@ asyncio.run(handle("u-1"))
 - `runtime-info`: service/env/version/host/pid/python.
 - `context-vars`: request/user IDs from ContextVar when present.
 
-Toggle at runtime:
+## Runtime Enricher Control
+
+You can dynamically enable or disable enrichers at runtime.
+
+### Disabling an Enricher
 
 ```python
-from fapilog.plugins.enrichers.runtime_info import RuntimeInfoEnricher
+from fapilog import get_logger
 
+logger = get_logger()
+
+# Disable the context_vars enricher by name
 logger.disable_enricher("context_vars")
-logger.enable_enricher(RuntimeInfoEnricher())
+
+# Logs after this point won't include context variables
+logger.info("No context vars here")
 ```
+
+### Enabling an Enricher
+
+```python
+from fapilog import get_logger
+from fapilog.plugins.enrichers import RuntimeInfoEnricher
+
+logger = get_logger()
+
+# Add a new enricher instance at runtime
+logger.enable_enricher(RuntimeInfoEnricher())
+
+# Logs after this point include runtime info
+logger.info("Now with runtime info")
+```
+
+### Common Patterns
+
+**Conditional enrichment based on environment:**
+
+```python
+import os
+from fapilog import get_logger
+from fapilog.plugins.enrichers import RuntimeInfoEnricher
+
+logger = get_logger()
+
+if os.getenv("ENABLE_DETAILED_LOGGING"):
+    logger.enable_enricher(RuntimeInfoEnricher())
+```
+
+**Temporarily disable enrichers for performance:**
+
+```python
+def process_large_batch(items, logger):
+    # Disable verbose enrichers during high-volume processing
+    logger.disable_enricher("runtime_info")
+    
+    for item in items:
+        logger.debug("processing", item_id=item.id)
+    
+    # Re-enable after batch
+    logger.enable_enricher(RuntimeInfoEnricher())
+```
+
+### Important Notes
+
+- `enable_enricher()` adds the enricher if no enricher with the same `name` exists
+- `disable_enricher()` removes all enrichers matching the given name
+- Changes take effect for subsequent log calls (not retroactively)
+- Enrichers must have a `name` attribute to be enabled/disabled by name
 
 ## Tips
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -18,6 +18,7 @@ integration-guide
 fastapi
 comparisons
 reliability-defaults
+testing-plugins
 ```
 
 ## Overview

--- a/docs/user-guide/testing-plugins.md
+++ b/docs/user-guide/testing-plugins.md
@@ -1,0 +1,331 @@
+# Testing Plugins
+
+fapilog provides comprehensive testing utilities to help you develop and validate custom plugins.
+
+## Installation
+
+The testing utilities are included in the main `fapilog` package:
+
+```python
+from fapilog.testing import (
+    # Mock plugins
+    MockSink,
+    MockEnricher,
+    MockRedactor,
+    MockProcessor,
+    # Validators
+    validate_sink,
+    validate_enricher,
+    validate_redactor,
+    validate_processor,
+    validate_plugin_lifecycle,
+    # Factories
+    create_log_event,
+    create_batch_events,
+    create_sensitive_event,
+)
+```
+
+## Mock Plugins
+
+### MockSink
+
+A configurable mock sink that captures written events for inspection:
+
+```python
+from fapilog.testing import MockSink, MockSinkConfig
+
+# Basic usage
+sink = MockSink()
+await sink.start()
+await sink.write({"level": "INFO", "message": "test"})
+
+assert len(sink.events) == 1
+assert sink.events[0]["message"] == "test"
+
+# With failure simulation
+config = MockSinkConfig(
+    fail_after=5,  # Fail after 5 writes
+    fail_with=IOError("connection lost"),
+    latency_seconds=0.1,  # Simulate network latency
+)
+sink = MockSink(config)
+
+# Assertion helpers
+sink.assert_event_count(1)
+sink.assert_event_contains(0, level="INFO", message="test")
+
+# Reset for reuse
+sink.reset()
+```
+
+### MockEnricher
+
+A mock enricher that adds configurable fields:
+
+```python
+from fapilog.testing import MockEnricher, MockEnricherConfig
+
+config = MockEnricherConfig(
+    fields_to_add={"service": "test", "version": "1.0.0"},
+    latency_seconds=0.05,
+)
+enricher = MockEnricher(config)
+
+result = await enricher.enrich({"message": "hello"})
+assert result == {"service": "test", "version": "1.0.0"}
+```
+
+### MockRedactor
+
+A mock redactor that masks specified fields:
+
+```python
+from fapilog.testing import MockRedactor, MockRedactorConfig
+
+config = MockRedactorConfig(
+    fields_to_mask=["user.password", "auth.token"],
+    mask_string="***REDACTED***",
+)
+redactor = MockRedactor(config)
+
+event = {"user": {"name": "alice", "password": "secret"}}
+result = await redactor.redact(event)
+assert result["user"]["password"] == "***REDACTED***"
+```
+
+### MockProcessor
+
+A mock processor for testing memoryview operations:
+
+```python
+from fapilog.testing import MockProcessor
+
+processor = MockProcessor()
+view = memoryview(b'{"message": "test"}')
+result = await processor.process(view)
+
+assert processor.call_count == 1
+```
+
+## Protocol Validators
+
+Use validators to verify your plugins implement protocols correctly:
+
+```python
+from fapilog.testing import validate_sink, validate_enricher
+
+class MyCustomSink:
+    name = "my-sink"
+    
+    async def start(self) -> None:
+        pass
+    
+    async def stop(self) -> None:
+        pass
+    
+    async def write(self, entry: dict) -> None:
+        print(entry)
+
+
+def test_my_sink_protocol():
+    sink = MyCustomSink()
+    result = validate_sink(sink)
+    
+    assert result.valid, f"Validation failed: {result.errors}"
+    assert not result.warnings
+```
+
+### What Validators Check
+
+Each validator checks:
+
+1. **`name` attribute** - Must be present and be a string
+2. **Required methods** - Must exist and be async
+3. **Method signatures** - Must accept correct parameters
+
+### validate_plugin_lifecycle
+
+Test that lifecycle methods work correctly:
+
+```python
+import pytest
+from fapilog.testing import validate_plugin_lifecycle
+
+@pytest.mark.asyncio
+async def test_my_sink_lifecycle():
+    sink = MyCustomSink()
+    result = await validate_plugin_lifecycle(sink)
+    
+    assert result.valid
+    # Checks:
+    # - start() doesn't raise
+    # - stop() doesn't raise
+    # - stop() is idempotent (can be called twice)
+```
+
+## Test Data Factories
+
+Generate realistic test data for your tests:
+
+```python
+from fapilog.testing import (
+    create_log_event,
+    create_batch_events,
+    create_sensitive_event,
+)
+
+# Single event with defaults
+event = create_log_event()
+# {"level": "INFO", "message": "Test message 1234", ...}
+
+# With custom values
+event = create_log_event(
+    level="ERROR",
+    message="Something went wrong",
+    user_id="user-123",
+)
+
+# Batch of events
+events = create_batch_events(count=100, level="DEBUG")
+
+# Event with sensitive data (for redaction testing)
+sensitive = create_sensitive_event()
+# Contains: password, ssn, card_number, api_key, etc.
+```
+
+## Testing Patterns
+
+### Testing a Custom Sink
+
+```python
+import pytest
+from fapilog.testing import validate_sink, create_log_event
+
+
+class MyDatabaseSink:
+    name = "my-database"
+    
+    def __init__(self, connection_string: str):
+        self._conn_str = connection_string
+        self._client = None
+    
+    async def start(self) -> None:
+        self._client = await connect(self._conn_str)
+    
+    async def stop(self) -> None:
+        if self._client:
+            await self._client.close()
+    
+    async def write(self, entry: dict) -> None:
+        await self._client.insert(entry)
+    
+    async def health_check(self) -> bool:
+        return self._client is not None and self._client.is_connected()
+
+
+def test_protocol_compliance():
+    sink = MyDatabaseSink("sqlite:///:memory:")
+    result = validate_sink(sink)
+    result.raise_if_invalid()
+
+
+@pytest.mark.asyncio
+async def test_write_events():
+    sink = MyDatabaseSink("sqlite:///:memory:")
+    await sink.start()
+    
+    event = create_log_event(level="INFO", message="test")
+    await sink.write(event)
+    
+    # Verify event was written
+    # ...
+    
+    await sink.stop()
+```
+
+### Testing a Custom Enricher
+
+```python
+import time
+import pytest
+from fapilog.testing import validate_enricher, create_log_event
+
+
+class MyEnricher:
+    name = "my-enricher"
+    
+    async def start(self) -> None:
+        pass
+    
+    async def stop(self) -> None:
+        pass
+    
+    async def enrich(self, event: dict) -> dict:
+        return {"enriched_at": time.time()}
+
+
+def test_protocol_compliance():
+    enricher = MyEnricher()
+    result = validate_enricher(enricher)
+    assert result.valid
+
+
+@pytest.mark.asyncio
+async def test_enrichment():
+    enricher = MyEnricher()
+    event = create_log_event()
+    
+    additions = await enricher.enrich(event)
+    
+    assert "enriched_at" in additions
+    assert isinstance(additions["enriched_at"], float)
+```
+
+### Testing Redaction
+
+```python
+import pytest
+from fapilog.testing import create_sensitive_event
+
+
+@pytest.mark.asyncio
+async def test_redacts_sensitive_fields():
+    redactor = MyRedactor(fields=["password", "ssn"])
+    event = create_sensitive_event()
+    
+    result = await redactor.redact(event)
+    
+    assert result["user"]["password"] != "supersecret123"
+    assert result["user"]["ssn"] != "123-45-6789"
+```
+
+## Best Practices
+
+1. **Always validate protocol compliance** before testing behavior
+2. **Use mock plugins** to test integration without external dependencies
+3. **Use factories** for consistent, realistic test data
+4. **Test lifecycle methods** to ensure proper resource management
+5. **Test error handling** by configuring mocks to fail
+6. **Test idempotency** - call `stop()` twice to verify it doesn't break
+
+## Migration Notes
+
+As of fapilog 0.4.0, all plugin protocols require a `name` attribute:
+
+```python
+# Before (may fail validation)
+class MySink:
+    async def write(self, entry: dict) -> None:
+        ...
+
+# After (correct)
+class MySink:
+    name = "my-sink"  # Required!
+    
+    async def write(self, entry: dict) -> None:
+        ...
+```
+
+If you have existing plugins without `name`, add it as a class attribute with a unique identifier for your plugin.
+

--- a/src/fapilog/plugins/enrichers/__init__.py
+++ b/src/fapilog/plugins/enrichers/__init__.py
@@ -17,7 +17,12 @@ class BaseEnricher(Protocol):
     to be shallow-merged into the event. Implementations must be async and must
     not block the event loop. Failures should be contained; returning an empty
     mapping is acceptable on error.
+
+    Attributes:
+        name: Unique identifier for this enricher type (e.g., "runtime_info").
     """
+
+    name: str  # Plugin identifier for discovery and configuration
 
     async def start(self) -> None:  # Optional lifecycle hook
         """Initialize resources for the enricher (optional)."""

--- a/src/fapilog/plugins/processors/__init__.py
+++ b/src/fapilog/plugins/processors/__init__.py
@@ -15,7 +15,12 @@ class BaseProcessor(Protocol):
     Processors operate on memoryview slices of serialized payloads and return a
     new memoryview. Implementations must be async and should avoid copying where
     possible. Errors propagate to allow caller isolation/metrics to record them.
+
+    Attributes:
+        name: Unique identifier for this processor type (e.g., "zero_copy").
     """
+
+    name: str  # Plugin identifier for discovery and configuration
 
     async def start(self) -> None:  # Optional lifecycle hook
         """Initialize processor resources (optional)."""

--- a/src/fapilog/plugins/sinks/__init__.py
+++ b/src/fapilog/plugins/sinks/__init__.py
@@ -27,7 +27,12 @@ class BaseSink(Protocol):
     Lifecycle:
     - ``start`` and ``stop`` are optional hooks. If implemented, they should be
       idempotent and tolerate repeated calls.
+
+    Attributes:
+        name: Unique identifier for this sink type (e.g., "stdout_json").
     """
+
+    name: str  # Plugin identifier for discovery and configuration
 
     async def start(self) -> None:  # Optional lifecycle hook
         """Initialize resources for the sink.

--- a/src/fapilog/testing/validators.py
+++ b/src/fapilog/testing/validators.py
@@ -39,12 +39,19 @@ def validate_sink(sink: Any) -> ValidationResult:
     """Validate that a sink implements BaseSink protocol correctly.
 
     Checks:
+    - Required 'name' attribute exists and is a string
     - Required methods exist and are async
     - Methods have correct signatures
     - Lifecycle methods don't raise on call
     """
     errors: list[str] = []
     warnings: list[str] = []
+
+    # Check name attribute
+    if not hasattr(sink, "name"):
+        errors.append("Missing required 'name' attribute")
+    elif not isinstance(getattr(sink, "name", None), str):
+        errors.append("'name' attribute must be a string")
 
     # Check required methods
     required_methods = ["start", "stop", "write"]
@@ -81,6 +88,12 @@ def validate_enricher(enricher: Any) -> ValidationResult:
     """Validate that an enricher implements BaseEnricher protocol correctly."""
     errors: list[str] = []
     warnings: list[str] = []
+
+    # Check name attribute
+    if not hasattr(enricher, "name"):
+        errors.append("Missing required 'name' attribute")
+    elif not isinstance(getattr(enricher, "name", None), str):
+        errors.append("'name' attribute must be a string")
 
     required_methods = ["start", "stop", "enrich"]
     for method_name in required_methods:
@@ -139,6 +152,12 @@ def validate_processor(processor: Any) -> ValidationResult:
     """Validate that a processor implements BaseProcessor protocol correctly."""
     errors: list[str] = []
     warnings: list[str] = []
+
+    # Check name attribute
+    if not hasattr(processor, "name"):
+        errors.append("Missing required 'name' attribute")
+    elif not isinstance(getattr(processor, "name", None), str):
+        errors.append("'name' attribute must be a string")
 
     required_methods = ["start", "stop", "process"]
     for method_name in required_methods:

--- a/tests/unit/test_story430_protocol_name_attribute.py
+++ b/tests/unit/test_story430_protocol_name_attribute.py
@@ -1,0 +1,159 @@
+"""
+Verify all protocols require name attribute.
+
+Story 4.30: Plugin API Standardization and Testing Documentation
+"""
+
+from __future__ import annotations
+
+from fapilog.plugins import BaseEnricher, BaseProcessor, BaseRedactor, BaseSink
+
+
+class TestProtocolsHaveNameAttribute:
+    """Test that all plugin protocols require a name attribute."""
+
+    def test_base_sink_has_name_in_annotations(self) -> None:
+        """BaseSink protocol should require name attribute."""
+        assert "name" in getattr(BaseSink, "__annotations__", {})
+
+    def test_base_enricher_has_name_in_annotations(self) -> None:
+        """BaseEnricher protocol should require name attribute."""
+        assert "name" in getattr(BaseEnricher, "__annotations__", {})
+
+    def test_base_processor_has_name_in_annotations(self) -> None:
+        """BaseProcessor protocol should require name attribute."""
+        assert "name" in getattr(BaseProcessor, "__annotations__", {})
+
+    def test_base_redactor_has_name_in_annotations(self) -> None:
+        """BaseRedactor protocol should require name attribute (already had it)."""
+        assert "name" in getattr(BaseRedactor, "__annotations__", {})
+
+
+class TestIsinstanceChecksWithName:
+    """Test that isinstance checks work correctly with/without name."""
+
+    def test_sink_with_name_satisfies_protocol(self) -> None:
+        """Plugin with name should satisfy BaseSink protocol."""
+
+        class _SinkWithName:
+            name = "test"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+            async def health_check(self) -> bool:
+                return True
+
+        sink = _SinkWithName()
+        assert isinstance(sink, BaseSink)
+
+    def test_sink_without_name_fails_protocol(self) -> None:
+        """Plugin without name should NOT satisfy BaseSink protocol."""
+
+        class _SinkWithoutName:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+            async def health_check(self) -> bool:
+                return True
+
+        sink = _SinkWithoutName()
+        assert not isinstance(sink, BaseSink)
+
+    def test_enricher_with_name_satisfies_protocol(self) -> None:
+        """Plugin with name should satisfy BaseEnricher protocol."""
+
+        class _EnricherWithName:
+            name = "test"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def enrich(self, event: dict) -> dict:
+                return {}
+
+            async def health_check(self) -> bool:
+                return True
+
+        enricher = _EnricherWithName()
+        assert isinstance(enricher, BaseEnricher)
+
+    def test_enricher_without_name_fails_protocol(self) -> None:
+        """Plugin without name should NOT satisfy BaseEnricher protocol."""
+
+        class _EnricherWithoutName:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def enrich(self, event: dict) -> dict:
+                return {}
+
+            async def health_check(self) -> bool:
+                return True
+
+        enricher = _EnricherWithoutName()
+        assert not isinstance(enricher, BaseEnricher)
+
+    def test_processor_with_name_satisfies_protocol(self) -> None:
+        """Plugin with name should satisfy BaseProcessor protocol."""
+
+        class _ProcessorWithName:
+            name = "test"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def process(self, view: memoryview) -> memoryview:
+                return view
+
+            async def process_many(self, views) -> int:
+                return 0
+
+            async def health_check(self) -> bool:
+                return True
+
+        processor = _ProcessorWithName()
+        assert isinstance(processor, BaseProcessor)
+
+    def test_processor_without_name_fails_protocol(self) -> None:
+        """Plugin without name should NOT satisfy BaseProcessor protocol."""
+
+        class _ProcessorWithoutName:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def process(self, view: memoryview) -> memoryview:
+                return view
+
+            async def process_many(self, views) -> int:
+                return 0
+
+            async def health_check(self) -> bool:
+                return True
+
+        processor = _ProcessorWithoutName()
+        assert not isinstance(processor, BaseProcessor)

--- a/tests/unit/test_story430_validator_checks_name.py
+++ b/tests/unit/test_story430_validator_checks_name.py
@@ -1,0 +1,181 @@
+"""
+Verify validators check for name attribute.
+
+Story 4.30: Plugin API Standardization and Testing Documentation
+"""
+
+from __future__ import annotations
+
+from fapilog.testing import validate_enricher, validate_processor, validate_sink
+
+
+class TestValidateSinkChecksName:
+    """Test that validate_sink() checks for name attribute."""
+
+    def test_validate_sink_rejects_nameless(self) -> None:
+        """Sink without name should fail validation."""
+
+        class _NamelessSink:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+        result = validate_sink(_NamelessSink())
+        assert not result.valid
+        assert any("name" in e.lower() for e in result.errors)
+
+    def test_validate_sink_accepts_named(self) -> None:
+        """Sink with name should pass validation."""
+
+        class _NamedSink:
+            name = "test"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+        result = validate_sink(_NamedSink())
+        assert result.valid
+
+    def test_validate_sink_rejects_non_string_name(self) -> None:
+        """Sink with non-string name should fail validation."""
+
+        class _BadNameSink:
+            name = 123  # Invalid: should be string
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+        result = validate_sink(_BadNameSink())
+        assert not result.valid
+        assert any("name" in e.lower() and "string" in e.lower() for e in result.errors)
+
+
+class TestValidateEnricherChecksName:
+    """Test that validate_enricher() checks for name attribute."""
+
+    def test_validate_enricher_rejects_nameless(self) -> None:
+        """Enricher without name should fail validation."""
+
+        class _NamelessEnricher:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def enrich(self, event: dict) -> dict:
+                return {}
+
+        result = validate_enricher(_NamelessEnricher())
+        assert not result.valid
+        assert any("name" in e.lower() for e in result.errors)
+
+    def test_validate_enricher_accepts_named(self) -> None:
+        """Enricher with name should pass validation."""
+
+        class _NamedEnricher:
+            name = "test"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def enrich(self, event: dict) -> dict:
+                return {}
+
+        result = validate_enricher(_NamedEnricher())
+        assert result.valid
+
+    def test_validate_enricher_rejects_non_string_name(self) -> None:
+        """Enricher with non-string name should fail validation."""
+
+        class _BadNameEnricher:
+            name = None  # Invalid: should be string
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def enrich(self, event: dict) -> dict:
+                return {}
+
+        result = validate_enricher(_BadNameEnricher())
+        assert not result.valid
+
+
+class TestValidateProcessorChecksName:
+    """Test that validate_processor() checks for name attribute."""
+
+    def test_validate_processor_rejects_nameless(self) -> None:
+        """Processor without name should fail validation."""
+
+        class _NamelessProcessor:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def process(self, view: memoryview) -> memoryview:
+                return view
+
+        result = validate_processor(_NamelessProcessor())
+        assert not result.valid
+        assert any("name" in e.lower() for e in result.errors)
+
+    def test_validate_processor_accepts_named(self) -> None:
+        """Processor with name should pass validation."""
+
+        class _NamedProcessor:
+            name = "test"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def process(self, view: memoryview) -> memoryview:
+                return view
+
+        result = validate_processor(_NamedProcessor())
+        assert result.valid
+
+    def test_validate_processor_rejects_non_string_name(self) -> None:
+        """Processor with non-string name should fail validation."""
+
+        class _BadNameProcessor:
+            name = []  # Invalid: should be string
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def process(self, view: memoryview) -> memoryview:
+                return view
+
+        result = validate_processor(_BadNameProcessor())
+        assert not result.valid

--- a/tests/unit/test_testing_validators.py
+++ b/tests/unit/test_testing_validators.py
@@ -86,6 +86,8 @@ class TestValidateEnricher:
         from fapilog.testing import validate_enricher
 
         class ValidEnricher:
+            name = "valid"
+
             async def start(self) -> None:
                 pass
 
@@ -165,6 +167,8 @@ class TestValidateProcessor:
         from fapilog.testing import validate_processor
 
         class ValidProcessor:
+            name = "valid"
+
             async def start(self) -> None:
                 pass
 


### PR DESCRIPTION
## Summary

This PR implements **Story 4.30: Plugin API Standardization and Testing Documentation**.

Adds `name: str` attribute to all plugin protocols for consistency. Updates validators to check for name attribute. Creates comprehensive testing utilities documentation.

## Changes

### Protocol Standardization
All plugin protocols now require a `name` attribute:

| Protocol | Change |
|----------|--------|
| `BaseSink` | Added `name: str` |
| `BaseEnricher` | Added `name: str` |
| `BaseProcessor` | Added `name: str` |
| `BaseRedactor` | Already had `name: str` ✓ |

This ensures consistency across all plugin types and enables:
- Type checker enforcement of `name` attribute
- Simpler `get_plugin_name()` utility
- Consistent testing validators

### Validator Updates
- `validate_sink()` now checks for `name` attribute
- `validate_enricher()` now checks for `name` attribute
- `validate_processor()` now checks for `name` attribute
- All validators verify `name` is a string

### Documentation
Created `docs/user-guide/testing-plugins.md` with:
- Mock plugins (MockSink, MockEnricher, MockRedactor, MockProcessor)
- Protocol validators (validate_sink, validate_enricher, etc.)
- Test data factories (create_log_event, create_batch_events, etc.)
- Testing patterns and best practices
- Migration notes for existing plugins

Updated `docs/user-guide/context-enrichment.md` with:
- Detailed runtime enricher control section
- Common patterns for enable/disable enrichers
- Important notes about the `name` attribute requirement

## Tests Added
| File | Purpose |
|------|---------|
| `tests/unit/test_story430_protocol_name_attribute.py` | Verify protocols have name in annotations |
| `tests/unit/test_story430_validator_checks_name.py` | Verify validators check for name |

## Breaking Changes
Third-party plugins without a `name` attribute will:
- Fail `isinstance(plugin, BaseSink)` checks
- Fail validation with `validate_sink()`

**Migration:** Add `name = "my-plugin"` as a class attribute.

## Results
- ✅ All 1228 tests pass
- ✅ Coverage: 91.0% (above 90% requirement)
- ✅ All pre-commit hooks pass

## Acceptance Criteria (Story 4.30)
- [x] `name: str` attribute added to `BaseSink` protocol
- [x] `name: str` attribute added to `BaseEnricher` protocol
- [x] `name: str` attribute added to `BaseProcessor` protocol
- [x] `validate_sink()` checks for `name` attribute
- [x] `validate_enricher()` checks for `name` attribute
- [x] `validate_processor()` checks for `name` attribute
- [x] New documentation: `docs/user-guide/testing-plugins.md`
- [x] Testing docs added to navigation/index
- [x] All existing tests pass
- [x] 90%+ coverage maintained