### PR TITLE
docs: update integrity plugin documentation

### DIFF
--- a/docs/api-reference/plugins/index.md
+++ b/docs/api-reference/plugins/index.md
@@ -168,36 +168,16 @@ class BasePlugin:
 
 ## Enterprise Plugins
 
-For enterprise features like tamper-evident logging, use the `fapilog-tamper` add-on package which provides standard plugins:
+For enterprise features like tamper-evident logging, fapilog provides an integrity plugin hook:
 
 ```python
-# Via Settings (recommended)
-from fapilog import get_logger, Settings
+from fapilog.plugins import IntegrityPlugin, load_integrity_plugin
 
-settings = Settings(
-    core__enrichers=["integrity"],  # IntegrityEnricher from fapilog-tamper
-    core__sinks=["sealed"],         # SealedSink from fapilog-tamper
-)
-
-logger = get_logger(settings=settings)
+# Load an integrity plugin by entry point name
+plugin = load_integrity_plugin("fapilog-tamper")
 ```
 
-```python
-# Via direct plugin loading
-from fapilog.plugins import load_plugin
-
-enricher = load_plugin("fapilog.enrichers", "integrity", {
-    "algorithm": "HMAC-SHA256",
-    "key_id": "audit-key-2025",
-})
-
-sink = load_plugin("fapilog.sinks", "sealed", {
-    "inner_sink": "rotating_file",
-    "sign_manifests": True,
-})
-```
-
-The `fapilog-tamper` package registers plugins via standard entry point groups (`fapilog.enrichers`, `fapilog.sinks`). See [Enterprise Features](../enterprise.md) for more details.
+The integrity plugin system uses the `fapilog.integrity` entry point group for automatic discovery.
 
 ## Best Practices
 

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -62,32 +62,3 @@ from fapilog.plugins import BaseSink, BaseProcessor, BaseEnricher, BaseRedactor
 ```
 
 All interfaces are async-first and must contain errors rather than raising into the core pipeline.
-
-## Testing Your Plugin
-
-fapilog provides comprehensive testing utilities in the `fapilog.testing` module. See the [Testing Plugins Guide](../user-guide/testing-plugins.md) for complete documentation.
-
-Quick example:
-
-```python
-import pytest
-from fapilog.testing import validate_sink, validate_plugin_lifecycle
-
-def test_my_sink_protocol():
-    sink = MySink()
-    result = validate_sink(sink)
-    assert result.valid, f"Protocol errors: {result.errors}"
-
-@pytest.mark.asyncio
-async def test_my_sink_lifecycle():
-    sink = MySink()
-    result = await validate_plugin_lifecycle(sink)
-    assert result.valid
-```
-
-### Available Utilities
-
-- **Mock plugins**: `MockSink`, `MockEnricher`, `MockRedactor`, `MockProcessor`
-- **Validators**: `validate_sink()`, `validate_enricher()`, `validate_redactor()`, `validate_processor()`
-- **Lifecycle testing**: `validate_plugin_lifecycle()`
-- **Event factories**: `create_log_event()`, `create_batch_events()`, `create_sensitive_event()`

--- a/packages/fapilog-tamper/README.md
+++ b/packages/fapilog-tamper/README.md
@@ -1,10 +1,8 @@
 # fapilog-tamper
 
-Tamper-evident logging add-on for fapilog. This package provides:
-
-- **IntegrityEnricher** - Adds per-record MAC/signatures and hash chains
-- **SealedSink** - Generates signed manifests on file rotation
-- **Verification tools** - CLI and API for chain verification
+Tamper-evident logging add-on for fapilog. This package registers the
+`tamper-sealed` integrity plugin and ships the core types and helpers used by
+subsequent stories (enricher, sealed sink, verification).
 
 ## Installation
 
@@ -26,48 +24,15 @@ pip install './packages/fapilog-tamper[all-kms]'
 
 ## Usage
 
-### Via Settings (Recommended)
-
 ```python
-import fapilog
-from fapilog import Settings
+from fapilog.plugins.integrity import load_integrity_plugin
 
-settings = Settings(
-    core__enrichers=["integrity"],
-    core__sinks=["sealed"],
-    enricher_config__integrity__algorithm="HMAC-SHA256",
-    enricher_config__integrity__key_id="audit-key-2025",
-)
-
-with fapilog.runtime(settings=settings) as logger:
-    logger.info("Tamper-evident log entry")
+plugin = load_integrity_plugin("tamper-sealed")
+enricher = plugin.get_enricher()
 ```
 
-### Via Direct Plugin Loading
-
-```python
-from fapilog.plugins import load_plugin
-
-# Load the integrity enricher
-enricher = load_plugin("fapilog.enrichers", "integrity", {
-    "algorithm": "HMAC-SHA256",
-    "key_id": "audit-key-2025",
-    "key_source": "env",
-})
-
-# Load the sealed sink
-sink = load_plugin("fapilog.sinks", "sealed", {
-    "inner_sink": "rotating_file",
-    "sign_manifests": True,
-})
-```
-
-### Environment Variables
-
-```bash
-export FAPILOG_TAMPER_KEY="<base64url-encoded-32-byte-key>"
-export FAPILOG_TAMPER_KEY_ID="audit-key-2025"
-```
+The initial release provides placeholder components; subsequent stories layer on
+full tamper-evident enrichment, sealed sinks, manifests, and verification.
 
 ## Enterprise key management
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -588,6 +588,10 @@ ignore_names = [
   # Stdlib bridge API used externally in examples/tests
   "enable_stdlib_bridge",
   "shutdown",
+  # Integrity plugin API - used via conditional imports in __init__.py
+  "load_integrity_plugin",
+  "get_enricher",
+  "wrap_sink",
   # Audit compliance API - public helper function
   "emit_compliance_alert",
 ]


### PR DESCRIPTION
## Summary

Documentation cleanup related to the integrity plugin API migration.

### Changes

- **`docs/api-reference/plugins/index.md`**: Update Enterprise Plugins section to use new `load_integrity_plugin` API instead of the deprecated `load_plugin` approach with `fapilog.enrichers`/`fapilog.sinks` groups

- **`docs/plugins/authoring.md`**: Remove Testing Your Plugin section (content moved to dedicated testing guide at `docs/user-guide/testing-plugins.md`)

- **`packages/fapilog-tamper/README.md`**: Simplify to reflect current implementation status - placeholder components with full features coming in subsequent stories

- **`pyproject.toml`**: Add integrity plugin API names (`load_integrity_plugin`, `get_enricher`, `wrap_sink`) to vulture ignore list since they're used via conditional imports