### PR TITLE
feat: remove unimplemented alerting plugin type (Story 4.32)

### DIFF
--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -19,9 +19,6 @@ Declare entry points in `pyproject.toml` under one of the v3 groups per plugin t
 [project.entry-points."fapilog.redactors"]
 "my-redactor" = "my_package.my_redactor"
 
-[project.entry-points."fapilog.alerting"]
-"my-alert" = "my_package.my_alert"
-
 # Fallback generic group (type derived from PLUGIN_METADATA["plugin_type"]) when needed
 [project.entry-points."fapilog.plugins"]
 "legacy-plugin" = "my_package.legacy"
@@ -35,7 +32,7 @@ Each module must export a `PLUGIN_METADATA` mapping with at least:
 PLUGIN_METADATA = {
   "name": "my-plugin",
   "version": "1.2.3",
-  "plugin_type": "sink",  # sink|processor|enricher|redactor|alerting
+  "plugin_type": "sink",  # sink|processor|enricher|redactor
   "entry_point": "my_package.my_sink:Plugin",
   "description": "...",
   "author": "Your Name",

--- a/docs/stories/4.12.alerting-interface.md
+++ b/docs/stories/4.12.alerting-interface.md
@@ -1,7 +1,14 @@
 # Story 4.12: Alerting Interface (Core No-op + Extras Providers)
 
+> **Status:** Cancelled - Not Implemented
+> 
+> This interface was designed but never implemented. Alerting functionality
+> is available via custom sinks or the built-in compliance alert mechanism
+> in `fapilog.core.audit`. The `"alerting"` plugin type has been removed.
+> See Story 4.32 for details.
+
 ## Status
-Draft
+Cancelled
 
 ## Story
 **As an** SRE/ops engineer,

--- a/docs/stories/4.32.remove-unimplemented-alerting-plugin-type.md
+++ b/docs/stories/4.32.remove-unimplemented-alerting-plugin-type.md
@@ -1,6 +1,6 @@
 # Story 4.32: Remove Unimplemented Alerting Plugin Type
 
-**Status:** Draft  
+**Status:** Complete  
 **Priority:** Critical  
 **Depends on:** None  
 **Effort:** 0.5 days
@@ -58,11 +58,13 @@ These are independent of the plugin system.
 Remove `"alerting"` from valid types and update documentation.
 
 **Pros:**
+
 - Honest about current capabilities
 - Removes dead code/documentation
 - Fast to implement
 
 **Cons:**
+
 - Could be seen as feature removal (but it never worked)
 
 ### Option B: Implement Alerting Plugin Type
@@ -70,10 +72,12 @@ Remove `"alerting"` from valid types and update documentation.
 Add `BaseAlerting` protocol, loader registry, and discovery.
 
 **Pros:**
+
 - Feature completeness
 - Matches original design intent
 
 **Cons:**
+
 - Significant effort
 - Unclear use case vs. custom sinks with alerting logic
 - No user demand demonstrated
@@ -83,10 +87,12 @@ Add `BaseAlerting` protocol, loader registry, and discovery.
 Keep the type but document it as "reserved for future use."
 
 **Pros:**
+
 - Reserves the namespace
 - Transparent about status
 
 **Cons:**
+
 - Still allows invalid plugin metadata
 - Confusing state
 
@@ -120,7 +126,9 @@ Remove the alerting entry point example:
 
 ```markdown
 # DELETE these lines:
+
 # [project.entry-points."fapilog.alerting"]
+
 # "my-alert" = "my_package.my_alert"
 ```
 
@@ -136,7 +144,7 @@ Add a note at the top:
 
 ```markdown
 > **Status:** Cancelled - Not Implemented
-> 
+>
 > This interface was designed but never implemented. Alerting functionality
 > is available via custom sinks or the built-in compliance alert mechanism
 > in `fapilog.core.audit`. The `"alerting"` plugin type has been removed.
@@ -153,7 +161,7 @@ def test_alerting_not_valid_plugin_type():
     """Alerting is not a valid plugin type (was designed but never implemented)."""
     from fapilog.plugins.metadata import PluginMetadata
     import pytest
-    
+
     with pytest.raises(ValueError, match="Invalid plugin type"):
         PluginMetadata(
             name="test",
@@ -170,20 +178,19 @@ def test_alerting_not_valid_plugin_type():
 
 ## Acceptance Criteria
 
-- [ ] `"alerting"` removed from `valid_types` in metadata.py
-- [ ] Alerting entry point example removed from authoring.md
-- [ ] Story 4.12 marked as cancelled with explanation
-- [ ] Test confirms alerting metadata is rejected
-- [ ] No runtime errors from existing code
+- [x] `"alerting"` removed from `valid_types` in metadata.py
+- [x] Alerting entry point example removed from authoring.md
+- [x] Story 4.12 marked as cancelled with explanation
+- [x] Test confirms alerting metadata is rejected
+- [x] No runtime errors from existing code
 
 ---
 
 ## Files Changed
 
-| File | Change |
-|------|--------|
-| `src/fapilog/plugins/metadata.py` | Remove "alerting" from valid_types |
-| `docs/plugins/authoring.md` | Remove alerting entry point example |
-| `docs/stories/4.12.alerting-interface.md` | Mark as cancelled |
-| `tests/unit/test_plugin_metadata.py` | Add rejection test |
-
+| File                                      | Change                              |
+| ----------------------------------------- | ----------------------------------- |
+| `src/fapilog/plugins/metadata.py`         | Remove "alerting" from valid_types  |
+| `docs/plugins/authoring.md`               | Remove alerting entry point example |
+| `docs/stories/4.12.alerting-interface.md` | Mark as cancelled                   |
+| `tests/unit/test_plugin_metadata.py`      | Add rejection test                  |

--- a/src/fapilog/plugins/metadata.py
+++ b/src/fapilog/plugins/metadata.py
@@ -48,7 +48,7 @@ class PluginMetadata(BaseModel):
 
     # Plugin type and interface
     plugin_type: str = Field(
-        description="Plugin type (sink, processor, enricher, redactor, alerting)"
+        description="Plugin type (sink, processor, enricher, redactor)"
     )
     entry_point: str = Field(description="Entry point for plugin loading")
 
@@ -89,7 +89,7 @@ class PluginMetadata(BaseModel):
     @classmethod
     def validate_plugin_type(cls, v: str) -> str:
         """Validate plugin type."""
-        valid_types = {"sink", "processor", "enricher", "redactor", "alerting"}
+        valid_types = {"sink", "processor", "enricher", "redactor"}
         if v not in valid_types:
             raise ValueError(f"Invalid plugin type: {v}. Must be one of: {valid_types}")
         return v

--- a/tests/unit/test_plugin_metadata.py
+++ b/tests/unit/test_plugin_metadata.py
@@ -86,7 +86,7 @@ class TestPluginMetadata:
 
     def test_all_valid_plugin_types(self) -> None:
         """Test all valid plugin types."""
-        for plugin_type in ["sink", "processor", "enricher", "redactor", "alerting"]:
+        for plugin_type in ["sink", "processor", "enricher", "redactor"]:
             metadata = PluginMetadata(
                 name=f"{plugin_type}-plugin",
                 version="1.0.0",
@@ -97,6 +97,19 @@ class TestPluginMetadata:
                 compatibility=PluginCompatibility(min_fapilog_version="3.0.0"),
             )
             assert metadata.plugin_type == plugin_type
+
+    def test_alerting_not_valid_plugin_type(self) -> None:
+        """Alerting is not a valid plugin type (was designed but never implemented)."""
+        with pytest.raises(ValueError, match="Invalid plugin type"):
+            PluginMetadata(
+                name="test",
+                version="1.0.0",
+                plugin_type="alerting",
+                entry_point="test:Test",
+                description="test",
+                author="test",
+                compatibility=PluginCompatibility(min_fapilog_version="0.3.0"),
+            )
 
     def test_invalid_version(self) -> None:
         """Test invalid version raises error."""


### PR DESCRIPTION
## Summary

Remove the unimplemented `alerting` plugin type from the plugin metadata validation and documentation.

## Problem

The plugin metadata validation accepted `"alerting"` as a valid plugin type, but:
- ❌ No `BaseAlerting` protocol exists
- ❌ No `BUILTIN_ALERTING` registry in loader
- ❌ No `fapilog.alerting` entry point group
- ❌ No alerting plugins could be discovered or loaded

This was misleading - users could create plugins with `plugin_type: "alerting"` that passed validation but could never be used.

## Changes

| File | Change |
|------|--------|
| `src/fapilog/plugins/metadata.py` | Remove "alerting" from valid_types |
| `docs/plugins/authoring.md` | Remove alerting entry point example |
| `docs/stories/4.12.alerting-interface.md` | Mark as cancelled |
| `tests/unit/test_plugin_metadata.py` | Add rejection test |
| `docs/stories/4.32.remove-unimplemented-alerting-plugin-type.md` | Mark as complete |

## Testing

- All existing tests pass
- New test `test_alerting_not_valid_plugin_type` confirms rejection
- 233 plugin-related tests pass

## Notes

Alerting functionality is still available via:
- Custom sinks with alerting logic
- Built-in compliance alert mechanism in `fapilog.core.audit`

If there's future demand for a dedicated alerting plugin type, a new story can implement it properly.