### PR TITLE
feat: add plugin lifecycle management for enrichers and redactors (Story 4.34)

### DIFF
--- a/docs/stories/4.34.plugin-lifecycle-management.md
+++ b/docs/stories/4.34.plugin-lifecycle-management.md
@@ -1,6 +1,6 @@
 # Story 4.34: Plugin Lifecycle Management
 
-**Status:** Draft  
+**Status:** Complete  
 **Priority:** High  
 **Depends on:** None  
 **Effort:** 1-2 days
@@ -71,6 +71,7 @@ logger._redactors = cast(list[_BaseRedactor], redactors)
 ### Lifecycle Call Order
 
 **Startup:**
+
 1. Load plugins
 2. Call `start()` on enrichers (parallel or sequential)
 3. Call `start()` on redactors (sequential - order may matter)
@@ -78,6 +79,7 @@ logger._redactors = cast(list[_BaseRedactor], redactors)
 5. Start logger workers
 
 **Shutdown:**
+
 1. Stop logger workers (drain queue)
 2. Call `stop()` on sinks (existing behavior)
 3. Call `stop()` on redactors (reverse order)
@@ -118,7 +120,7 @@ Add helper functions:
 
 ```python
 async def _start_plugins(
-    plugins: list[Any], 
+    plugins: list[Any],
     plugin_type: str,
 ) -> list[Any]:
     """Start plugins, returning only successfully started ones."""
@@ -173,13 +175,13 @@ async def get_async_logger(
 ) -> AsyncLoggerFacade:
     cfg_source = settings or _Settings()
     sinks, enrichers, redactors, metrics = _build_pipeline(cfg_source)
-    
+
     # Start enrichers and redactors
     enrichers = await _start_plugins(enrichers, "enricher")
     redactors = await _start_plugins(redactors, "redactor")
-    
+
     sink_write, sink_write_serialized = _fanout_writer(sinks)
-    
+
     logger = AsyncLoggerFacade(
         # ... existing params ...
         enrichers=cast(list[_BaseEnricher], enrichers),
@@ -202,13 +204,13 @@ def get_logger(
     settings: _Settings | None = None,
 ) -> SyncLoggerFacade:
     # ... existing setup ...
-    
+
     # Start enrichers and redactors (sync wrapper)
     async def _do_start():
         nonlocal enrichers, redactors
         enrichers = await _start_plugins(enrichers, "enricher")
         redactors = await _start_plugins(redactors, "redactor")
-    
+
     try:
         asyncio.get_running_loop()
         # Inside event loop - schedule for later
@@ -216,7 +218,7 @@ def get_logger(
     except RuntimeError:
         # No loop - run sync
         asyncio.run(_do_start())
-    
+
     # ... rest of function ...
 ```
 
@@ -229,7 +231,7 @@ Add stop calls to `stop_and_drain()`:
 ```python
 async def stop_and_drain(self) -> DrainResult:
     # ... existing drain logic ...
-    
+
     # Stop redactors (reverse order)
     for redactor in reversed(self._redactors):
         try:
@@ -237,7 +239,7 @@ async def stop_and_drain(self) -> DrainResult:
                 await redactor.stop()
         except Exception:
             pass
-    
+
     # Stop enrichers
     for enricher in reversed(self._enrichers):
         try:
@@ -245,7 +247,7 @@ async def stop_and_drain(self) -> DrainResult:
                 await enricher.stop()
         except Exception:
             pass
-    
+
     return DrainResult(...)
 ```
 
@@ -257,14 +259,14 @@ Ensure `runtime()` and `runtime_async()` properly stop plugins on exit.
 
 ## Acceptance Criteria
 
-- [ ] `get_async_logger()` calls `start()` on all enrichers before returning
-- [ ] `get_async_logger()` calls `start()` on all redactors before returning
-- [ ] `get_logger()` calls `start()` on enrichers/redactors (sync-safe)
-- [ ] `stop_and_drain()` calls `stop()` on enrichers and redactors
-- [ ] Failed `start()` emits diagnostics and excludes plugin from active list
-- [ ] Failed `stop()` emits diagnostics but continues with other plugins
-- [ ] Existing tests pass (backward compatible)
-- [ ] New tests verify lifecycle calls
+- [x] `get_async_logger()` calls `start()` on all enrichers before returning
+- [x] `get_async_logger()` calls `start()` on all redactors before returning
+- [x] `get_logger()` calls `start()` on enrichers/redactors (sync-safe)
+- [x] `stop_and_drain()` calls `stop()` on enrichers and redactors
+- [x] Failed `start()` emits diagnostics and excludes plugin from active list
+- [x] Failed `stop()` emits diagnostics but continues with other plugins
+- [x] Existing tests pass (backward compatible)
+- [x] New tests verify lifecycle calls
 
 ---
 
@@ -276,27 +278,27 @@ async def test_enricher_lifecycle_called():
     """Enricher start/stop are called during logger lifecycle."""
     started = False
     stopped = False
-    
+
     class TestEnricher:
         name = "test"
-        
+
         async def start(self):
             nonlocal started
             started = True
-        
+
         async def stop(self):
             nonlocal stopped
             stopped = True
-        
+
         async def enrich(self, event):
             return {}
-    
+
     # Inject into enricher list
     # ... test setup ...
-    
+
     logger = await get_async_logger()
     assert started is True
-    
+
     await logger.drain()
     assert stopped is True
 
@@ -306,13 +308,13 @@ async def test_enricher_start_failure_contained():
     """Failed enricher start doesn't prevent logger creation."""
     class FailingEnricher:
         name = "failing"
-        
+
         async def start(self):
             raise RuntimeError("start failed")
-        
+
         async def enrich(self, event):
             return {}
-    
+
     # Enricher should be excluded but logger should work
     # ... test assertions ...
 ```
@@ -321,9 +323,8 @@ async def test_enricher_start_failure_contained():
 
 ## Files Changed
 
-| File | Change |
-|------|--------|
-| `src/fapilog/__init__.py` | Add `_start_plugins`, `_stop_plugins`; update factories |
-| `src/fapilog/core/logger.py` | Add stop calls in `stop_and_drain()` |
-| `tests/unit/test_plugin_lifecycle.py` | New test file |
-
+| File                                  | Change                                                  |
+| ------------------------------------- | ------------------------------------------------------- |
+| `src/fapilog/__init__.py`             | Add `_start_plugins`, `_stop_plugins`; update factories |
+| `src/fapilog/core/logger.py`          | Add stop calls in `stop_and_drain()`                    |
+| `tests/unit/test_plugin_lifecycle.py` | New test file                                           |

--- a/tests/unit/test_plugin_lifecycle.py
+++ b/tests/unit/test_plugin_lifecycle.py
@@ -1,0 +1,535 @@
+"""
+Tests for plugin lifecycle management (Story 4.34).
+
+Verifies that enrichers and redactors have their start() and stop()
+lifecycle methods called during logger initialization and shutdown.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fapilog import Settings, get_async_logger, get_logger
+from fapilog.plugins.enrichers import BaseEnricher
+from fapilog.plugins.redactors import BaseRedactor
+
+
+class TrackingEnricher(BaseEnricher):
+    """Test enricher that tracks lifecycle calls."""
+
+    name = "tracking_enricher"
+
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+        self.start_called_count = 0
+        self.stop_called_count = 0
+
+    async def start(self) -> None:
+        self.started = True
+        self.start_called_count += 1
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self.stop_called_count += 1
+
+    async def enrich(self, event: dict) -> dict:
+        return {"enriched_by": self.name}
+
+
+class TrackingRedactor(BaseRedactor):
+    """Test redactor that tracks lifecycle calls."""
+
+    name = "tracking_redactor"
+
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+        self.start_called_count = 0
+        self.stop_called_count = 0
+
+    async def start(self) -> None:
+        self.started = True
+        self.start_called_count += 1
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self.stop_called_count += 1
+
+    async def redact(self, event: dict) -> dict:
+        return event
+
+
+class FailingStartEnricher(BaseEnricher):
+    """Enricher that fails on start."""
+
+    name = "failing_start_enricher"
+
+    async def start(self) -> None:
+        raise RuntimeError("start failed intentionally")
+
+    async def enrich(self, event: dict) -> dict:
+        return {}
+
+
+class FailingStartRedactor(BaseRedactor):
+    """Redactor that fails on start."""
+
+    name = "failing_start_redactor"
+
+    async def start(self) -> None:
+        raise RuntimeError("start failed intentionally")
+
+    async def redact(self, event: dict) -> dict:
+        return event
+
+
+class FailingStopEnricher(BaseEnricher):
+    """Enricher that fails on stop."""
+
+    name = "failing_stop_enricher"
+
+    def __init__(self) -> None:
+        self.started = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        raise RuntimeError("stop failed intentionally")
+
+    async def enrich(self, event: dict) -> dict:
+        return {}
+
+
+class FailingStopRedactor(BaseRedactor):
+    """Redactor that fails on stop."""
+
+    name = "failing_stop_redactor"
+
+    def __init__(self) -> None:
+        self.started = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        raise RuntimeError("stop failed intentionally")
+
+    async def redact(self, event: dict) -> dict:
+        return event
+
+
+class NoLifecycleEnricher(BaseEnricher):
+    """Enricher without lifecycle methods (backward compatibility)."""
+
+    name = "no_lifecycle_enricher"
+
+    async def enrich(self, event: dict) -> dict:
+        return {"no_lifecycle": True}
+
+
+class NoLifecycleRedactor(BaseRedactor):
+    """Redactor without lifecycle methods (backward compatibility)."""
+
+    name = "no_lifecycle_redactor"
+
+    async def redact(self, event: dict) -> dict:
+        return event
+
+
+# -----------------------------------------------------------------------------
+# Tests for _start_plugins helper
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_plugins_calls_start_on_enrichers():
+    """_start_plugins should call start() on plugins that have it."""
+    from fapilog import _start_plugins
+
+    enricher = TrackingEnricher()
+    assert not enricher.started
+
+    result = await _start_plugins([enricher], "enricher")
+
+    assert enricher.started
+    assert enricher.start_called_count == 1
+    assert enricher in result
+
+
+@pytest.mark.asyncio
+async def test_start_plugins_calls_start_on_redactors():
+    """_start_plugins should call start() on redactors."""
+    from fapilog import _start_plugins
+
+    redactor = TrackingRedactor()
+    assert not redactor.started
+
+    result = await _start_plugins([redactor], "redactor")
+
+    assert redactor.started
+    assert redactor.start_called_count == 1
+    assert redactor in result
+
+
+@pytest.mark.asyncio
+async def test_start_plugins_excludes_failed_plugins():
+    """Failed start() should exclude plugin from returned list."""
+    from fapilog import _start_plugins
+
+    failing = FailingStartEnricher()
+    working = TrackingEnricher()
+
+    result = await _start_plugins([failing, working], "enricher")
+
+    assert failing not in result
+    assert working in result
+    assert working.started
+
+
+@pytest.mark.asyncio
+async def test_start_plugins_handles_no_lifecycle_methods():
+    """Plugins without start() should still be included."""
+    from fapilog import _start_plugins
+
+    enricher = NoLifecycleEnricher()
+
+    result = await _start_plugins([enricher], "enricher")
+
+    assert enricher in result
+
+
+# -----------------------------------------------------------------------------
+# Tests for _stop_plugins helper
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_plugins_calls_stop_on_enrichers():
+    """_stop_plugins should call stop() on plugins."""
+    from fapilog import _stop_plugins
+
+    enricher = TrackingEnricher()
+    enricher.started = True
+
+    await _stop_plugins([enricher], "enricher")
+
+    assert enricher.stopped
+    assert enricher.stop_called_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_plugins_calls_stop_on_redactors():
+    """_stop_plugins should call stop() on redactors."""
+    from fapilog import _stop_plugins
+
+    redactor = TrackingRedactor()
+    redactor.started = True
+
+    await _stop_plugins([redactor], "redactor")
+
+    assert redactor.stopped
+    assert redactor.stop_called_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_plugins_continues_on_failure():
+    """Failed stop() should not prevent other plugins from stopping."""
+    from fapilog import _stop_plugins
+
+    failing = FailingStopEnricher()
+    failing.started = True
+    working = TrackingEnricher()
+    working.started = True
+
+    # Should not raise, should continue with other plugins
+    await _stop_plugins([failing, working], "enricher")
+
+    assert working.stopped
+
+
+@pytest.mark.asyncio
+async def test_stop_plugins_calls_in_reverse_order():
+    """_stop_plugins should call stop() in reverse order."""
+    from fapilog import _stop_plugins
+
+    stop_order: list[str] = []
+
+    class OrderedEnricher(BaseEnricher):
+        name = "ordered"
+
+        def __init__(self, order_id: str) -> None:
+            self.order_id = order_id
+
+        async def stop(self) -> None:
+            stop_order.append(self.order_id)
+
+        async def enrich(self, event: dict) -> dict:
+            return {}
+
+    e1 = OrderedEnricher("first")
+    e2 = OrderedEnricher("second")
+    e3 = OrderedEnricher("third")
+
+    await _stop_plugins([e1, e2, e3], "enricher")
+
+    assert stop_order == ["third", "second", "first"]
+
+
+@pytest.mark.asyncio
+async def test_stop_plugins_handles_no_lifecycle_methods():
+    """Plugins without stop() should be handled gracefully."""
+    from fapilog import _stop_plugins
+
+    enricher = NoLifecycleEnricher()
+
+    # Should not raise
+    await _stop_plugins([enricher], "enricher")
+
+
+# -----------------------------------------------------------------------------
+# Tests for get_async_logger lifecycle integration
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_logger_starts_enrichers(monkeypatch):
+    """get_async_logger should call start() on enrichers."""
+    enricher = TrackingEnricher()
+
+    # Patch _build_pipeline to return our test enricher
+    def mock_build_pipeline(settings):
+        return [], [enricher], [], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = await get_async_logger(settings=Settings(plugins__enabled=False))
+    assert enricher.started
+
+    await logger.drain()
+
+
+@pytest.mark.asyncio
+async def test_async_logger_starts_redactors(monkeypatch):
+    """get_async_logger should call start() on redactors."""
+    redactor = TrackingRedactor()
+
+    def mock_build_pipeline(settings):
+        return [], [], [redactor], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = await get_async_logger(settings=Settings(plugins__enabled=False))
+    assert redactor.started
+
+    await logger.drain()
+
+
+@pytest.mark.asyncio
+async def test_async_logger_excludes_failed_enrichers(monkeypatch):
+    """Failed enricher start should exclude it from active list."""
+    failing = FailingStartEnricher()
+    working = TrackingEnricher()
+
+    def mock_build_pipeline(settings):
+        return [], [failing, working], [], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = await get_async_logger(settings=Settings(plugins__enabled=False))
+
+    # Failing enricher should not be in the logger's enricher list
+    assert failing not in logger._enrichers
+    assert working in logger._enrichers
+
+    await logger.drain()
+
+
+@pytest.mark.asyncio
+async def test_async_logger_stops_enrichers_on_drain(monkeypatch):
+    """drain() should call stop() on enrichers."""
+    enricher = TrackingEnricher()
+
+    def mock_build_pipeline(settings):
+        return [], [enricher], [], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = await get_async_logger(settings=Settings(plugins__enabled=False))
+    assert enricher.started
+    assert not enricher.stopped
+
+    await logger.drain()
+
+    assert enricher.stopped
+
+
+@pytest.mark.asyncio
+async def test_async_logger_stops_redactors_on_drain(monkeypatch):
+    """drain() should call stop() on redactors."""
+    redactor = TrackingRedactor()
+
+    def mock_build_pipeline(settings):
+        return [], [], [redactor], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = await get_async_logger(settings=Settings(plugins__enabled=False))
+    assert redactor.started
+    assert not redactor.stopped
+
+    await logger.drain()
+
+    assert redactor.stopped
+
+
+# -----------------------------------------------------------------------------
+# Tests for sync logger lifecycle integration
+# -----------------------------------------------------------------------------
+
+
+def test_sync_logger_starts_enrichers(monkeypatch):
+    """get_logger should call start() on enrichers."""
+    import asyncio
+
+    enricher = TrackingEnricher()
+
+    def mock_build_pipeline(settings):
+        return [], [enricher], [], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = get_logger(settings=Settings(plugins__enabled=False))
+    assert enricher.started
+
+    asyncio.run(logger.stop_and_drain())
+
+
+def test_sync_logger_starts_redactors(monkeypatch):
+    """get_logger should call start() on redactors."""
+    import asyncio
+
+    redactor = TrackingRedactor()
+
+    def mock_build_pipeline(settings):
+        return [], [], [redactor], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = get_logger(settings=Settings(plugins__enabled=False))
+    assert redactor.started
+
+    asyncio.run(logger.stop_and_drain())
+
+
+def test_sync_logger_excludes_failed_enrichers(monkeypatch):
+    """Failed enricher start should exclude it from active list in sync logger."""
+    import asyncio
+
+    failing = FailingStartEnricher()
+    working = TrackingEnricher()
+
+    def mock_build_pipeline(settings):
+        return [], [failing, working], [], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = get_logger(settings=Settings(plugins__enabled=False))
+
+    assert failing not in logger._enrichers
+    assert working in logger._enrichers
+
+    asyncio.run(logger.stop_and_drain())
+
+
+def test_sync_logger_stops_enrichers_on_drain(monkeypatch):
+    """stop_and_drain() should call stop() on enrichers for sync logger."""
+    import asyncio
+
+    enricher = TrackingEnricher()
+
+    def mock_build_pipeline(settings):
+        return [], [enricher], [], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = get_logger(settings=Settings(plugins__enabled=False))
+    assert enricher.started
+    assert not enricher.stopped
+
+    asyncio.run(logger.stop_and_drain())
+
+    assert enricher.stopped
+
+
+# -----------------------------------------------------------------------------
+# Tests for error containment
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_failure_does_not_prevent_other_stops(monkeypatch):
+    """Failed stop() should not prevent other plugins from being stopped."""
+    failing = FailingStopEnricher()
+    working = TrackingEnricher()
+
+    def mock_build_pipeline(settings):
+        return [], [failing, working], [], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = await get_async_logger(settings=Settings(plugins__enabled=False))
+
+    # Both should have been started
+    assert failing.started
+    assert working.started
+
+    # Drain should not raise even though failing.stop() raises
+    await logger.drain()
+
+    # Working enricher should still have been stopped
+    assert working.stopped
+
+
+# -----------------------------------------------------------------------------
+# Tests for backward compatibility
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enricher_without_lifecycle_still_works(monkeypatch):
+    """Enrichers without start/stop should work normally."""
+    enricher = NoLifecycleEnricher()
+
+    def mock_build_pipeline(settings):
+        return [], [enricher], [], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = await get_async_logger(settings=Settings(plugins__enabled=False))
+
+    # Should be in the enricher list
+    assert enricher in logger._enrichers
+
+    # Should not raise on drain
+    await logger.drain()
+
+
+@pytest.mark.asyncio
+async def test_redactor_without_lifecycle_still_works(monkeypatch):
+    """Redactors without start/stop should work normally."""
+    redactor = NoLifecycleRedactor()
+
+    def mock_build_pipeline(settings):
+        return [], [], [redactor], None
+
+    monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
+
+    logger = await get_async_logger(settings=Settings(plugins__enabled=False))
+
+    # Should be in the redactor list
+    assert redactor in logger._redactors
+
+    # Should not raise on drain
+    await logger.drain()


### PR DESCRIPTION
## Summary

This PR implements Story 4.34: Plugin Lifecycle Management, ensuring that enrichers and redactors have their `start()` and `stop()` lifecycle methods called during logger initialization and shutdown.

## Problem

Previously, the logger called `start()` and `stop()` on **sinks**, but NOT on **enrichers** or **redactors**. This meant:
- Enrichers needing initialization (DB connections, cache warming) didn't get started
- Enrichers holding resources (connections, file handles) didn't get stopped
- Inconsistent protocol expectations

## Solution

### New Helper Functions (`src/fapilog/__init__.py`)
- `_start_plugins(plugins, plugin_type)` - Starts plugins, returns only successfully started ones
- `_stop_plugins(plugins, plugin_type)` - Stops plugins in reverse order, containing errors

### Updated Logger Factories
- `get_async_logger()` now calls `start()` on enrichers and redactors before returning
- `get_logger()` does the same in a sync-safe manner

### Updated Logger Facades (`src/fapilog/core/logger.py`)
- Both `SyncLoggerFacade` and `AsyncLoggerFacade` now call `stop()` on enrichers and redactors during `stop_and_drain()`
- Errors are contained and logged, not propagated

## Key Design Decisions

- **Backward compatible**: Plugins without `start()`/`stop()` methods still work
- **Error containment**: A failing plugin doesn't prevent others from starting/stopping
- **Reverse order stop**: Plugins are stopped in reverse order to respect potential dependencies

## Testing

21 new tests covering:
- `_start_plugins` and `_stop_plugins` helper functions
- Async and sync logger lifecycle integration
- Error containment during start/stop
- Backward compatibility for plugins without lifecycle methods

All 1221 existing tests pass.

Closes #434