### PR TITLE
feat: add plugin validation at load time (Story 4.36)

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -70,6 +70,7 @@
 | `FAPILOG__PLUGINS__ALLOWLIST` | list | PydanticUndefined | If non-empty, only these plugin names are allowed |
 | `FAPILOG__PLUGINS__DENYLIST` | list | PydanticUndefined | Plugin names to block from loading |
 | `FAPILOG__PLUGINS__ENABLED` | bool | True | Enable plugin loading |
+| `FAPILOG__PLUGINS__VALIDATION_MODE` | str | disabled | Plugin validation mode: disabled, warn, or strict |
 | `FAPILOG__REDACTOR_CONFIG__EXTRA` | dict | PydanticUndefined | Configuration for third-party redactors by name |
 | `FAPILOG__REDACTOR_CONFIG__FIELD_MASK__BLOCK_ON_UNREDACTABLE` | bool | False | Block log entry if redaction fails |
 | `FAPILOG__REDACTOR_CONFIG__FIELD_MASK__FIELDS_TO_MASK` | list | PydanticUndefined | Field names to mask (case-insensitive) |

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -656,6 +656,12 @@
       "description": "Enable plugin loading",
       "title": "Enabled",
       "type": "boolean"
+    },
+    "validation_mode": {
+      "default": "disabled",
+      "description": "Plugin validation mode: disabled, warn, or strict",
+      "title": "Validation Mode",
+      "type": "string"
     }
   },
   "title": "PluginsSettings",

--- a/docs/settings-guide.md
+++ b/docs/settings-guide.md
@@ -123,3 +123,4 @@ This guide documents Settings groups and fields.
 | `plugins.enabled` | bool | True | Enable plugin loading |
 | `plugins.allowlist` | list | PydanticUndefined | If non-empty, only these plugin names are allowed |
 | `plugins.denylist` | list | PydanticUndefined | Plugin names to block from loading |
+| `plugins.validation_mode` | str | disabled | Plugin validation mode: disabled, warn, or strict |

--- a/docs/stories/4.36.plugin-validation-at-load-time.md
+++ b/docs/stories/4.36.plugin-validation-at-load-time.md
@@ -1,6 +1,6 @@
 # Story 4.36: Plugin Validation at Load Time
 
-**Status:** Draft  
+**Status:** Complete  
 **Priority:** High  
 **Depends on:** 4.27 (Plugin Testing Utilities)  
 **Effort:** 1 day
@@ -224,14 +224,14 @@ def get_logger(...):
 
 ## Acceptance Criteria
 
-- [ ] `ValidationMode` enum with DISABLED, WARN, STRICT
-- [ ] `load_plugin()` validates when mode is not DISABLED
-- [ ] WARN mode logs errors but loads plugin anyway
-- [ ] STRICT mode raises `PluginLoadError` on invalid plugin
-- [ ] Settings control validation mode via `FAPILOG_PLUGINS__VALIDATION_MODE`
-- [ ] Validation uses existing `fapilog.testing` validators
-- [ ] Unknown plugin groups skip validation gracefully
-- [ ] Backward compatible: disabled by default
+- [x] `ValidationMode` enum with DISABLED, WARN, STRICT
+- [x] `load_plugin()` validates when mode is not DISABLED
+- [x] WARN mode logs errors but loads plugin anyway
+- [x] STRICT mode raises `PluginLoadError` on invalid plugin
+- [x] Settings control validation mode via `FAPILOG_PLUGINS__VALIDATION_MODE`
+- [x] Validation uses existing `fapilog.testing` validators
+- [x] Unknown plugin groups skip validation gracefully
+- [x] Backward compatible: disabled by default
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -443,6 +443,8 @@ ignore_names = [
     "should_allow",
     "record_success",
     "record_failure",
+    # ValidationMode enum values
+    "WARN",
     
     # Context management API
     "error_chain_var",

--- a/src/fapilog/__init__.py
+++ b/src/fapilog/__init__.py
@@ -63,6 +63,21 @@ def _plugin_allowed(name: str, settings: _Settings) -> bool:
     return True
 
 
+def _apply_plugin_settings(settings: _Settings) -> None:
+    """Apply plugin validation mode and related settings to the loader."""
+
+    mode_map = {
+        "disabled": _loader.ValidationMode.DISABLED,
+        "warn": _loader.ValidationMode.WARN,
+        "strict": _loader.ValidationMode.STRICT,
+    }
+    mode = mode_map.get(
+        (settings.plugins.validation_mode or "disabled").lower(),
+        _loader.ValidationMode.DISABLED,
+    )
+    _loader.set_validation_mode(mode)
+
+
 def _sink_configs(settings: _Settings) -> dict[str, dict[str, Any]]:
     scfg = settings.sink_config
     configs: dict[str, dict[str, Any]] = {
@@ -405,6 +420,7 @@ def get_logger(
     settings: _Settings | None = None,
 ) -> SyncLoggerFacade:
     cfg_source = settings or _Settings()
+    _apply_plugin_settings(cfg_source)
     sinks, enrichers, redactors, metrics = _build_pipeline(cfg_source)
 
     # Start enrichers and redactors (sync-safe)
@@ -515,6 +531,7 @@ async def get_async_logger(
     settings: _Settings | None = None,
 ) -> AsyncLoggerFacade:
     cfg_source = settings or _Settings()
+    _apply_plugin_settings(cfg_source)
     sinks, enrichers, redactors, metrics = _build_pipeline(cfg_source)
 
     # Start enrichers and redactors (plugins that fail are excluded)

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -561,6 +561,10 @@ class Settings(BaseSettings):
             default_factory=list,
             description="Plugin names to block from loading",
         )
+        validation_mode: str = Field(
+            default="disabled",
+            description="Plugin validation mode: disabled, warn, or strict",
+        )
 
     plugins: PluginsSettings = Field(
         default_factory=PluginsSettings,

--- a/tests/unit/test_plugin_validation_at_load.py
+++ b/tests/unit/test_plugin_validation_at_load.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog import _apply_plugin_settings
+from fapilog.core.settings import Settings
+from fapilog.plugins import loader
+from fapilog.testing import validators
+
+
+@pytest.fixture
+def clean_registries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate plugin registries and validation mode per test."""
+    monkeypatch.setattr(loader, "BUILTIN_SINKS", {}, raising=False)
+    monkeypatch.setattr(loader, "BUILTIN_ALIASES", {"fapilog.sinks": {}}, raising=False)
+    monkeypatch.setattr(
+        loader, "_validation_mode", loader.ValidationMode.DISABLED, raising=False
+    )
+
+
+def _register_invalid_sink() -> type:
+    class InvalidSink:
+        name = "invalid"
+
+        async def start(self) -> None:  # pragma: no cover - used via loader
+            return None
+
+        async def stop(self) -> None:  # pragma: no cover - used via loader
+            return None
+
+    loader.register_builtin("fapilog.sinks", "invalid", InvalidSink)
+    return InvalidSink
+
+
+def test_validation_strict_rejects_invalid(clean_registries: None) -> None:
+    _register_invalid_sink()
+
+    with pytest.raises(loader.PluginLoadError, match="failed validation"):
+        loader.load_plugin(
+            "fapilog.sinks",
+            "invalid",
+            validation_mode=loader.ValidationMode.STRICT,
+        )
+
+
+def test_validation_warn_logs_but_loads(
+    clean_registries: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[tuple[str, str, dict[str, object]]] = []
+
+    def _capture_warn(component: str, message: str, **fields: object) -> None:
+        captured.append((component, message, fields))
+
+    monkeypatch.setattr(loader.diagnostics, "warn", _capture_warn)
+    InvalidSink = _register_invalid_sink()
+
+    plugin = loader.load_plugin(
+        "fapilog.sinks",
+        "invalid",
+        validation_mode=loader.ValidationMode.WARN,
+    )
+
+    assert isinstance(plugin, InvalidSink)
+    assert captured, "expected diagnostics warning in WARN mode"
+    component, message, fields = captured[0]
+    assert component == "plugins"
+    assert "validation failed" in message
+    assert fields.get("plugin") == "invalid"
+
+
+def test_validation_disabled_skips_checks(
+    clean_registries: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _failing_validator(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("validation should be skipped")
+
+    monkeypatch.setattr(validators, "validate_sink", _failing_validator)
+    InvalidSink = _register_invalid_sink()
+
+    plugin = loader.load_plugin(
+        "fapilog.sinks",
+        "invalid",
+        validation_mode=loader.ValidationMode.DISABLED,
+    )
+
+    assert isinstance(plugin, InvalidSink)
+
+
+def test_settings_apply_validation_mode_default(
+    clean_registries: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FAPILOG_PLUGINS__VALIDATION_MODE", "strict")
+    settings = Settings()
+    _apply_plugin_settings(settings)
+    _register_invalid_sink()
+
+    with pytest.raises(loader.PluginLoadError):
+        loader.load_plugin("fapilog.sinks", "invalid")


### PR DESCRIPTION
## Summary

Adds optional validation of plugins at load time using the existing `fapilog.testing` validators.

## Changes

- **`src/fapilog/plugins/loader.py`**: Added `ValidationMode` enum and `_validate_plugin()` function, integrated validation into `load_plugin()`
- **`src/fapilog/core/settings.py`**: Added `validation_mode` field to `PluginsSettings`
- **`src/fapilog/__init__.py`**: Added `_apply_plugin_settings()` called from both `get_logger()` and `get_async_logger()`
- **`tests/unit/test_plugin_validation_at_load.py`**: New test file with 4 tests

## Validation Modes

| Mode | Behavior |
|------|----------|
| `disabled` (default) | No validation, current behavior |
| `warn` | Validate and log diagnostics, but load anyway |
| `strict` | Validate and reject invalid plugins with `PluginLoadError` |

## Configuration

```bash
export FAPILOG_PLUGINS__VALIDATION_MODE=strict  # or warn, disabled
```

## Backward Compatibility

- Validation is **disabled by default**
- Existing code continues to work unchanged
- Uses existing validators from `fapilog.testing`