### PR TITLE
refactor: extract LoggerWorker to reduce duplication (Story 4.38)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,6 +445,11 @@ ignore_names = [
     "record_failure",
     # ValidationMode enum values
     "WARN",
+    # LoggerWorker public API
+    "LoggerWorker",
+    "flush_batch",
+    "strict_envelope_mode_enabled",
+    "enqueue_with_backpressure",
     
     # Context management API
     "error_chain_var",

--- a/src/fapilog/core/worker.py
+++ b/src/fapilog/core/worker.py
@@ -1,0 +1,332 @@
+"""
+Shared logger worker logic for SyncLoggerFacade and AsyncLoggerFacade.
+
+Extracted to reduce duplication of batch flushing and worker loops.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Awaitable, Callable
+
+from ..metrics.metrics import MetricsCollector
+from ..plugins.enrichers import BaseEnricher, enrich_parallel
+from ..plugins.redactors import BaseRedactor, redact_in_order
+from .concurrency import NonBlockingRingQueue
+from .diagnostics import warn
+from .serialization import (
+    SerializedView,
+    serialize_envelope,
+    serialize_mapping_to_json_bytes,
+)
+
+
+def strict_envelope_mode_enabled() -> bool:
+    """Best-effort lookup for strict envelope mode."""
+    try:
+        from . import settings as _settings
+
+        return bool(_settings.Settings().core.strict_envelope_mode)
+    except Exception:
+        return False
+
+
+async def enqueue_with_backpressure(
+    queue: NonBlockingRingQueue[dict[str, Any]],
+    payload: dict[str, Any],
+    *,
+    timeout: float,
+    drop_on_full: bool,
+    metrics: MetricsCollector | None,
+    current_high_watermark: int,
+) -> tuple[bool, int]:
+    """Shared enqueue logic with optional backpressure and metrics."""
+
+    effective_timeout: float | None = timeout if drop_on_full else None
+    high_watermark = current_high_watermark
+
+    if queue.try_enqueue(payload):
+        qsize = queue.qsize()
+        if qsize > high_watermark:
+            high_watermark = qsize
+            if metrics is not None:
+                await metrics.set_queue_high_watermark(qsize)
+        return True, high_watermark
+
+    if effective_timeout is not None and effective_timeout > 0:
+        if metrics is not None:
+            await metrics.record_backpressure_wait(1)
+        try:
+            await queue.await_enqueue(payload, timeout=effective_timeout)
+            qsize = queue.qsize()
+            if qsize > high_watermark:
+                high_watermark = qsize
+                if metrics is not None:
+                    await metrics.set_queue_high_watermark(qsize)
+            return True, high_watermark
+        except Exception:
+            if metrics is not None:
+                await metrics.record_events_dropped(1)
+            return False, high_watermark
+
+    if not drop_on_full:
+        if metrics is not None:
+            await metrics.record_backpressure_wait(1)
+        try:
+            await queue.await_enqueue(payload, timeout=None)
+            qsize = queue.qsize()
+            if qsize > high_watermark:
+                high_watermark = qsize
+                if metrics is not None:
+                    await metrics.set_queue_high_watermark(qsize)
+            return True, high_watermark
+        except Exception:
+            if metrics is not None:
+                await metrics.record_events_dropped(1)
+            return False, high_watermark
+
+    if metrics is not None:
+        await metrics.record_events_dropped(1)
+    return False, high_watermark
+
+
+class LoggerWorker:
+    """Background worker that processes log batches."""
+
+    def __init__(
+        self,
+        *,
+        queue: NonBlockingRingQueue[dict[str, Any]],
+        batch_max_size: int,
+        batch_timeout_seconds: float,
+        sink_write: Callable[[dict[str, Any]], Awaitable[None]],
+        sink_write_serialized: Callable[[SerializedView], Awaitable[None]] | None,
+        enrichers_getter: Callable[[], list[BaseEnricher]],
+        redactors_getter: Callable[[], list[BaseRedactor]],
+        metrics: MetricsCollector | None,
+        serialize_in_flush: bool,
+        strict_envelope_mode_provider: Callable[[], bool],
+        stop_flag: Callable[[], bool],
+        drained_event: asyncio.Event | None,
+        flush_event: asyncio.Event | None,
+        flush_done_event: asyncio.Event | None,
+        emit_enricher_diagnostics: bool,
+        emit_redactor_diagnostics: bool,
+        counters: dict[str, int],
+    ) -> None:
+        self._queue = queue
+        self._batch_max_size = batch_max_size
+        self._batch_timeout_seconds = batch_timeout_seconds
+        self._sink_write = sink_write
+        self._sink_write_serialized = sink_write_serialized
+        self._enrichers_getter = enrichers_getter
+        self._redactors_getter = redactors_getter
+        self._metrics = metrics
+        self._serialize_in_flush = serialize_in_flush
+        self._strict_envelope_mode_provider = strict_envelope_mode_provider
+        self._stop_flag = stop_flag
+        self._drained_event = drained_event
+        self._flush_event = flush_event
+        self._flush_done_event = flush_done_event
+        self._emit_enricher_diagnostics = emit_enricher_diagnostics
+        self._emit_redactor_diagnostics = emit_redactor_diagnostics
+        self._counters = counters
+
+    async def run(self, *, in_thread_mode: bool = False) -> None:
+        batch: list[dict[str, Any]] = []
+        next_flush_deadline: float | None = None
+        try:
+            while True:
+                if self._stop_flag():
+                    self._drain_queue(batch)
+                    await self._flush_batch(batch)
+                    if in_thread_mode:
+                        loop = asyncio.get_running_loop()
+                        loop.stop()
+                    if self._drained_event is not None:
+                        self._drained_event.set()
+                    return
+
+                if self._flush_event is not None and self._flush_event.is_set():
+                    self._drain_queue(batch)
+                    if batch:
+                        await self._flush_batch(batch)
+                        next_flush_deadline = None
+                    self._flush_event.clear()
+                    if self._flush_done_event is not None:
+                        self._flush_done_event.set()
+                    continue
+
+                ok, item = self._queue.try_dequeue()
+                if ok and item is not None:
+                    batch.append(item)
+                    if len(batch) >= self._batch_max_size:
+                        await self._flush_batch(batch)
+                        next_flush_deadline = None
+                        continue
+                    if next_flush_deadline is None:
+                        next_flush_deadline = (
+                            time.perf_counter() + self._batch_timeout_seconds
+                        )
+                    continue
+
+                now = time.perf_counter()
+                if next_flush_deadline is not None and now >= next_flush_deadline:
+                    await self._flush_batch(batch)
+                    next_flush_deadline = None
+                    continue
+
+                await asyncio.sleep(0.001)
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:  # pragma: no cover - defensive catch
+            self._emit_worker_error(exc)
+            return
+
+    async def flush_batch(self, batch: list[dict[str, Any]]) -> None:
+        await self._flush_batch(batch)
+
+    async def _flush_batch(self, batch: list[dict[str, Any]]) -> None:
+        if not batch:
+            return
+        start = time.perf_counter()
+        try:
+            for entry in batch:
+                entry = await self._apply_enrichers(entry)
+                entry = await self._apply_redactors(entry)
+                if self._serialize_in_flush and self._sink_write_serialized is not None:
+                    view, drop_entry = await self._try_serialize(entry)
+                    if drop_entry:
+                        continue
+                    if view is not None:
+                        try:
+                            await self._sink_write_serialized(view)
+                            self._counters["processed"] += 1
+                            continue
+                        except Exception:
+                            # Fall back to default path on serialized sink errors
+                            pass
+                await self._sink_write(entry)
+                self._counters["processed"] += 1
+        except Exception as exc:
+            self._counters["dropped"] += len(batch)
+            if self._metrics is not None:
+                await self._record_sink_error()
+            self._emit_sink_flush_error(exc)
+        finally:
+            await self._record_flush_metrics(len(batch), time.perf_counter() - start)
+            batch.clear()
+
+    def _drain_queue(self, batch: list[dict[str, Any]]) -> None:
+        while True:
+            ok, item = self._queue.try_dequeue()
+            if not ok or item is None:
+                break
+            batch.append(item)
+
+    async def _apply_enrichers(self, entry: dict[str, Any]) -> dict[str, Any]:
+        enrichers = self._enrichers_getter()
+        if not enrichers:
+            return entry
+        try:
+            return await enrich_parallel(entry, enrichers, metrics=self._metrics)
+        except Exception:
+            if self._emit_enricher_diagnostics:
+                try:
+                    warn("enricher", "enrichment error", _rate_limit_key="enrich")
+                except Exception:
+                    pass
+            return entry
+
+    async def _apply_redactors(self, entry: dict[str, Any]) -> dict[str, Any]:
+        redactors = self._redactors_getter()
+        if not redactors:
+            return entry
+        try:
+            return await redact_in_order(entry, redactors, metrics=self._metrics)
+        except Exception:
+            if self._emit_redactor_diagnostics:
+                try:
+                    warn("redactor", "redaction error", _rate_limit_key="redact")
+                except Exception:
+                    pass
+            return entry
+
+    async def _try_serialize(
+        self, entry: dict[str, Any]
+    ) -> tuple[SerializedView | None, bool]:
+        try:
+            return serialize_envelope(entry), False
+        except Exception as exc:
+            strict_mode = False
+            try:
+                strict_mode = bool(self._strict_envelope_mode_provider())
+            except Exception:
+                strict_mode = False
+            try:
+                warn(
+                    "sink",
+                    "envelope serialization error",
+                    mode="strict" if strict_mode else "best-effort",
+                    reason=type(exc).__name__,
+                    detail=str(exc),
+                )
+            except Exception:
+                pass
+            if strict_mode:
+                return None, True
+            try:
+                return serialize_mapping_to_json_bytes(entry), False
+            except Exception:
+                return None, False
+
+    async def _record_sink_error(self) -> None:
+        if self._metrics is None:
+            return
+        sink_name = None
+        try:
+            target = getattr(self._sink_write, "__self__", None)
+            if target is not None:
+                sink_name = type(target).__name__
+        except Exception:
+            sink_name = None
+        try:
+            await self._metrics.record_sink_error(sink=sink_name)
+        except Exception:
+            pass
+
+    def _emit_sink_flush_error(self, exc: Exception) -> None:
+        try:
+            warn(
+                "sink",
+                "flush error",
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+        except Exception:
+            pass
+
+    async def _record_flush_metrics(
+        self, batch_size: int, latency_seconds: float
+    ) -> None:
+        if self._metrics is None:
+            return
+        try:
+            await self._metrics.record_flush(
+                batch_size=batch_size,
+                latency_seconds=latency_seconds,
+            )
+        except Exception:
+            pass
+
+    def _emit_worker_error(self, exc: Exception) -> None:
+        try:
+            warn(
+                "worker",
+                "worker_main error",
+                error_type=type(exc).__name__,
+                error=str(exc),
+            )
+        except Exception:
+            pass

--- a/tests/unit/test_core_logger_exceptional_coverage.py
+++ b/tests/unit/test_core_logger_exceptional_coverage.py
@@ -638,7 +638,7 @@ class TestSerializationFallbackPaths:
 
         # Mock serialize_envelope to raise an exception
         with patch(
-            "fapilog.core.logger.serialize_envelope",
+            "fapilog.core.worker.serialize_envelope",
             side_effect=RuntimeError("Serialization error"),
         ):
             # Should fall back to regular sink path
@@ -682,7 +682,7 @@ class TestSerializationFallbackPaths:
             mock_settings.return_value = settings_instance
 
             with patch(
-                "fapilog.core.logger.serialize_envelope",
+                "fapilog.core.worker.serialize_envelope",
                 side_effect=ValueError("Strict serialization error"),
             ):
                 # In strict mode, should drop the entry (line 654: continue)

--- a/tests/unit/test_logger_flush_paths.py
+++ b/tests/unit/test_logger_flush_paths.py
@@ -1,6 +1,6 @@
 import pytest
 
-import fapilog.core.logger as logger_mod
+import fapilog.core.worker as worker_mod
 from fapilog.core.logger import AsyncLoggerFacade
 
 
@@ -15,7 +15,7 @@ async def test_flush_serialization_strict_drops(monkeypatch):
         raise AssertionError("should not be called in strict drop path")
 
     monkeypatch.setattr(
-        logger_mod,
+        worker_mod,
         "serialize_envelope",
         lambda entry: (_ for _ in ()).throw(ValueError("boom")),
     )
@@ -53,7 +53,7 @@ async def test_flush_serialization_best_effort_uses_fallback(monkeypatch):
         serialized_calls.append(view)
 
     monkeypatch.setattr(
-        logger_mod,
+        worker_mod,
         "serialize_envelope",
         lambda entry: (_ for _ in ()).throw(ValueError("boom")),
     )

--- a/tests/unit/test_logger_worker.py
+++ b/tests/unit/test_logger_worker.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from fapilog.core.concurrency import NonBlockingRingQueue
+from fapilog.core.worker import LoggerWorker, strict_envelope_mode_enabled
+
+
+@pytest.mark.asyncio
+async def test_worker_run_flushes_and_signals_drained() -> None:
+    queue: NonBlockingRingQueue[dict[str, object]] = NonBlockingRingQueue(capacity=4)
+    assert queue.try_enqueue({"id": 1})
+
+    drained = asyncio.Event()
+    counters = {"processed": 0, "dropped": 0}
+    stop_flag = False
+    sink_calls: list[dict[str, object]] = []
+
+    async def sink_write(entry: dict[str, object]) -> None:
+        sink_calls.append(entry)
+
+    worker = LoggerWorker(
+        queue=queue,
+        batch_max_size=2,
+        batch_timeout_seconds=0.01,
+        sink_write=sink_write,
+        sink_write_serialized=None,
+        enrichers_getter=lambda: [],
+        redactors_getter=lambda: [],
+        metrics=None,
+        serialize_in_flush=False,
+        strict_envelope_mode_provider=strict_envelope_mode_enabled,
+        stop_flag=lambda: stop_flag,
+        drained_event=drained,
+        flush_event=None,
+        flush_done_event=None,
+        emit_enricher_diagnostics=True,
+        emit_redactor_diagnostics=True,
+        counters=counters,
+    )
+
+    task = asyncio.create_task(worker.run())
+    await asyncio.sleep(0.01)
+    stop_flag = True
+
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert drained.is_set()
+    assert counters["processed"] == 1
+    assert counters["dropped"] == 0
+    assert sink_calls == [{"id": 1}]
+
+
+@pytest.mark.asyncio
+async def test_worker_flush_event_triggers_immediate_flush() -> None:
+    queue: NonBlockingRingQueue[dict[str, object]] = NonBlockingRingQueue(capacity=4)
+    assert queue.try_enqueue({"id": 99})
+
+    flush_event = asyncio.Event()
+    flush_done = asyncio.Event()
+    drained = asyncio.Event()
+    counters = {"processed": 0, "dropped": 0}
+    stop_flag = False
+    sink_calls: list[dict[str, object]] = []
+
+    async def sink_write(entry: dict[str, object]) -> None:
+        sink_calls.append(entry)
+
+    worker = LoggerWorker(
+        queue=queue,
+        batch_max_size=1,
+        batch_timeout_seconds=0.5,
+        sink_write=sink_write,
+        sink_write_serialized=None,
+        enrichers_getter=lambda: [],
+        redactors_getter=lambda: [],
+        metrics=None,
+        serialize_in_flush=False,
+        strict_envelope_mode_provider=strict_envelope_mode_enabled,
+        stop_flag=lambda: stop_flag,
+        drained_event=drained,
+        flush_event=flush_event,
+        flush_done_event=flush_done,
+        emit_enricher_diagnostics=True,
+        emit_redactor_diagnostics=True,
+        counters=counters,
+    )
+
+    task = asyncio.create_task(worker.run())
+
+    flush_event.set()
+    await asyncio.wait_for(flush_done.wait(), timeout=1.0)
+    stop_flag = True
+
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert sink_calls == [{"id": 99}]
+    assert counters["processed"] == 1
+    assert drained.is_set()


### PR DESCRIPTION
## Summary

Extracts shared worker and flush logic from `SyncLoggerFacade` and `AsyncLoggerFacade` into a new `LoggerWorker` class, reducing code duplication.

## Changes

| File | Change |
|------|--------|
| `src/fapilog/core/worker.py` | **New** - 330 lines with `LoggerWorker` class |
| `src/fapilog/core/logger.py` | Reduced from 1770 to 1376 lines (-394 lines) |
| `tests/unit/test_logger_worker.py` | **New** - 2 tests for worker isolation |
| `tests/unit/test_*.py` | Updated patch targets for moved functions |

## Key Improvements

- **`LoggerWorker` class**: Handles batch flushing, enrichment, redaction, serialization, and sink writes
- **`enqueue_with_backpressure`**: Shared helper for queue operations with metrics
- **`_WorkerCountersMixin`**: Shared counter properties for facades
- **Coverage increased**: 90% → 91%

## No Functional Changes

All 1252 existing unit tests pass. The refactoring maintains identical behavior.