### PR TITLE
docs: document write_serialized protocol extension (Story 4.39)

### DIFF
--- a/docs/api-reference/plugins/sinks.md
+++ b/docs/api-reference/plugins/sinks.md
@@ -10,10 +10,30 @@ Implement `BaseSink` methods:
 
 - `async start(self) -> None`: optional initialization.
 - `async write(self, entry: dict) -> None`: required; receives enriched/redacted envelope.
-- `async write_serialized(self, view) -> None`: optional fast-path when `serialize_in_flush=True`.
 - `async stop(self) -> None`: optional teardown.
 
 Errors should be contained; do not raise into the pipeline.
+
+### Optional methods
+
+#### write_serialized
+
+```python
+async def write_serialized(self, view: SerializedView) -> None
+```
+
+Fast path when `Settings.core.serialize_in_flush=True`. If present, fapilog pre-serializes entries once and calls this method instead of `write()` for sinks that consume bytes. If absent, fapilog automatically falls back to `write()`.
+
+`SerializedView` exposes:
+
+```python
+@dataclass
+class SerializedView:
+    data: memoryview
+
+    def __bytes__(self) -> bytes:
+        return bytes(self.data)
+```
 
 ## Built-in sinks
 

--- a/docs/plugins/sinks.md
+++ b/docs/plugins/sinks.md
@@ -17,10 +17,6 @@ class MySink(BaseSink):
         # entry is a dict log envelope; emit to your target
         ...
 
-    async def write_serialized(self, view) -> None:
-        # Optional fast-path when serialize_in_flush=True
-        ...
-
     async def stop(self) -> None:
         ...
 ```
@@ -40,3 +36,30 @@ class MySink(BaseSink):
 ## Usage
 
 Sinks are discovered via entry points when plugin discovery is enabled. You can also wire custom sinks programmatically by passing them into the container/settings before creating a logger.
+
+## Optional: write_serialized fast path
+
+For sinks that operate on bytes (files, sockets, HTTP), implement `write_serialized()` to accept a pre-serialized payload and avoid redundant JSON encoding when `Settings.core.serialize_in_flush=True`:
+
+```python
+from fapilog.core.serialization import SerializedView
+
+class MyFastSink:
+    name = "my-fast-sink"
+
+    async def write(self, entry: dict) -> None:
+        # Fallback path: serialize yourself
+        data = json.dumps(entry).encode()
+        await self._send(data)
+
+    async def write_serialized(self, view: SerializedView) -> None:
+        # Fast path: fapilog already serialized; avoid extra work
+        await self._send(bytes(view.data))
+```
+
+When to implement:
+- You already need serialized bytes
+- You do not need to inspect/modify the dict entry
+- Performance or allocation reduction is important
+
+If `write_serialized` is absent, fapilog automatically calls `write()` instead. The `SerializedView` wrapper exposes a memoryview via `data` and `__bytes__` for convenience; treat it as read-only.

--- a/src/fapilog/plugins/sinks/__init__.py
+++ b/src/fapilog/plugins/sinks/__init__.py
@@ -21,6 +21,9 @@ class BaseSink(Protocol):
       the core pipeline. If an error occurs, swallow it or emit diagnostics.
     - Deterministic output: each invocation of ``write`` produces one record in
       the configured destination.
+    - Optional fast path: sinks may expose ``write_serialized(view)`` to accept
+      pre-serialized payloads when serialize_in_flush=True; if absent, fapilog
+      automatically calls ``write`` instead.
     - Concurrency: implementations should be safe to call from multiple tasks or
       protect internal state with an ``asyncio.Lock``.
 

--- a/src/fapilog/testing/validators.py
+++ b/src/fapilog/testing/validators.py
@@ -69,6 +69,13 @@ def validate_sink(sink: Any) -> ValidationResult:
         if not asyncio.iscoroutinefunction(sink.health_check):
             warnings.append("health_check should be async")
 
+    # Informational: fast-path support
+    if not hasattr(sink, "write_serialized"):
+        warnings.append(
+            "Sink does not implement write_serialized() fast path; "
+            "consider adding it for serialize_in_flush=True"
+        )
+
     # Check write signature
     if hasattr(sink, "write"):
         sig = inspect.signature(sink.write)

--- a/tests/unit/test_testing_validators.py
+++ b/tests/unit/test_testing_validators.py
@@ -32,6 +32,27 @@ class TestValidateSink:
         assert result.valid
         assert result.plugin_type == "BaseSink"
         assert len(result.errors) == 0
+        assert isinstance(result.warnings, list)
+
+    def test_validate_sink_warns_without_write_serialized(self) -> None:
+        """Sink without write_serialized should emit informational warning."""
+        from fapilog.testing import validate_sink
+
+        class NoFastPath:
+            name = "no-fast-path"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def write(self, entry: dict) -> None:
+                pass
+
+        result = validate_sink(NoFastPath())
+        assert result.valid
+        assert any("write_serialized" in w for w in result.warnings)
 
     def test_validate_sink_missing_method(self) -> None:
         """Sink missing required method should fail."""


### PR DESCRIPTION
## Summary

Documents the optional `write_serialized()` fast path for sinks that accept pre-serialized data.

## Changes

| File | Change |
|------|--------|
| `src/fapilog/plugins/sinks/__init__.py` | Added fast path mention to BaseSink docstring |
| `docs/plugins/sinks.md` | New section with example implementation |
| `docs/api-reference/plugins/sinks.md` | Added method reference with SerializedView structure |
| `src/fapilog/testing/validators.py` | Informational warning for sinks without write_serialized |
| `tests/unit/test_testing_validators.py` | Test for new validator warning |

## When to Implement `write_serialized()`

- Your sink writes bytes (files, network sockets, HTTP)
- Re-serialization would be redundant
- Performance is critical

## How It Works

When `Settings.core.serialize_in_flush=True`:
1. Entry is serialized once before sink calls
2. If `write_serialized()` exists, it's called with `SerializedView`
3. If not, `write()` is called with the original dict

The validator now emits an informational warning (not an error) for sinks that don't implement the fast path.