### PR TITLE
docs: rewrite processor documentation with use cases (Story 4.40)

### DIFF
--- a/docs/api-reference/plugins/processors.md
+++ b/docs/api-reference/plugins/processors.md
@@ -1,15 +1,53 @@
 # Processors
 
-Plugins that transform or filter log entries before they reach sinks.
+Plugins that transform serialized log data (`memoryview`) after enrichment/redaction and before sinks.
 
 ## Contract
 
-Implement `BaseProcessor.process(entry: dict) -> dict | None` (async). Return a modified entry to continue, or `None` to drop. Errors should be contained.
+- `name: str`
+- `async start(self) -> None` (optional)
+- `async stop(self) -> None` (optional)
+- `async process(self, view: memoryview) -> memoryview` (required)
+- `async process_many(self, views: Iterable[memoryview]) -> int` (optional helper)
+- `async health_check(self) -> bool` (optional)
+
+Errors should be contained by processors; callers isolate failures per processor.
+
+## Usage and order
+
+Processors run after serialization and before sinks. Configure via `core.processors` (e.g., `["gzip", "encrypt"]`). Order is preserved:
+
+```
+Event → Enrichers → Redactors → Serialize → Processor 1 → Processor 2 → Sinks
+```
+
+## When to use processors
+
+- Compression for disk/network
+- Encryption for at-rest/transport protection
+- Format conversion (JSON → MessagePack/BSON)
+- Checksums/MACs for integrity
+- Framing or header injection for streaming protocols
+
+If you need to add or inspect fields, use an enricher instead.
 
 ## Built-in processors
 
-The core pipeline does not ship additional processors by default; processors are reserved for advanced transformations/filters when configured.
+| Processor | Description |
+| --- | --- |
+| `zero_copy` | Pass-through processor (no transformation), useful for benchmarking |
 
-## Usage
+## Example
 
-Processors execute after enrichers/redactors and before queue/sink emission. Ensure they are non-blocking and idempotent.*** End Patch
+```python
+from fapilog.plugins import BaseProcessor
+
+
+class GzipProcessor:
+    name = "gzip"
+
+    async def process(self, view: memoryview) -> memoryview:
+        import gzip
+
+        return memoryview(gzip.compress(bytes(view), compresslevel=6))
+```

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -34,7 +34,7 @@ Output destination management for logs and events.
 
 ### [Processors](processors.md)
 
-Data processing and transformation pipelines.
+Transform serialized log data (compression, encryption, format conversion).
 
 ### [Enrichers](enrichers.md)
 

--- a/docs/plugins/processors.md
+++ b/docs/plugins/processors.md
@@ -1,29 +1,110 @@
 # Processors
 
-Transform or filter log entries between enrichment and queue/sink stages. Implement `BaseProcessor`.
+Processors transform **serialized** log data (memoryview) after enrichment/redaction and before sinks run.
+
+## When to use processors
+
+Use processors when you need to operate on bytes, not event dicts. Examples:
+
+| Use case | Description |
+| --- | --- |
+| Compression | Compress JSON before writing to disk/network |
+| Encryption | Encrypt serialized entries for storage or transport |
+| Format conversion | Convert JSON to MessagePack/BSON/Avro |
+| Checksums | Add integrity MAC/CRC for downstream verification |
+| Framing | Add message boundaries/headers for streaming protocols |
+
+### Processors vs. Enrichers
+
+| Question | Use an enricher | Use a processor |
+| --- | --- | --- |
+| Need to add fields to the event dict? | ✅ | ❌ |
+| Need to transform raw bytes? | ❌ | ✅ |
+| Input type | `dict` | `memoryview` |
+| Called | Before serialization | After serialization |
+
+Rule of thumb: if you must inspect or add fields, use an enricher. If you only need to transform the serialized bytes, use a processor.
 
 ## Implementing a processor
 
 ```python
 from fapilog.plugins import BaseProcessor
 
-class SamplingProcessor(BaseProcessor):
-    name = "sampling-processor"
 
-    async def process(self, entry: dict) -> dict | None:
-        # Return None to drop, or a modified entry to continue
-        return entry
+class GzipProcessor:
+    """Compress serialized entries with gzip."""
+
+    name = "gzip"
+
+    def __init__(self, level: int = 6) -> None:
+        self._level = level
+
+    async def start(self) -> None:
+        pass  # optional
+
+    async def stop(self) -> None:
+        pass  # optional
+
+    async def process(self, view: memoryview) -> memoryview:
+        import gzip
+
+        compressed = gzip.compress(bytes(view), compresslevel=self._level)
+        return memoryview(compressed)
+
+    async def health_check(self) -> bool:
+        return True
 ```
 
-## Registering a processor
+### Example: Encrypt before sinks
 
-- Declare an entry point under `fapilog.processors` in `pyproject.toml`.
-- Provide `PLUGIN_METADATA` with `plugin_type: "processor"` and compatible API version.
+```python
+from cryptography.fernet import Fernet
+
+
+class EncryptProcessor:
+    name = "encrypt"
+
+    def __init__(self, key: bytes) -> None:
+        self._fernet = Fernet(key)
+
+    async def process(self, view: memoryview) -> memoryview:
+        encrypted = self._fernet.encrypt(bytes(view))
+        return memoryview(encrypted)
+```
+
+### Example: Convert JSON to MessagePack
+
+```python
+import json
+import msgpack
+
+
+class MsgPackProcessor:
+    name = "msgpack"
+
+    async def process(self, view: memoryview) -> memoryview:
+        data = json.loads(bytes(view))
+        packed = msgpack.packb(data)
+        return memoryview(packed)
+```
 
 ## Built-in processors
 
-- Core pipeline currently runs without custom processors by default; processors are reserved for advanced transforms/filters.
+| Processor | Description |
+| --- | --- |
+| `zero_copy` | Pass-through processor for benchmarking (no transformation) |
 
-## Usage
+## Registration
 
-Processors execute after enrichers and redactors but before queueing/sink emission when configured. Ensure they are non-blocking and handle errors internally to avoid disrupting the pipeline.
+- Declare an entry point under `fapilog.processors` in `pyproject.toml`.
+- Include `PLUGIN_METADATA` with `plugin_type: "processor"` and compatible API version.
+
+## Configuration and order
+
+Configure processors via settings (`core.processors`) or env (`FAPILOG_CORE__PROCESSORS`). They run in order:
+
+```
+Event → Enrichers → Redactors → Serialize → Processor 1 → Processor 2 → Sinks
+```
+
+Keep processors async, contain errors, and consider CPU/I/O cost since they run on every log write.


### PR DESCRIPTION
## Summary

Complete rewrite of processor documentation to explain **when** and **why** to use processors, not just **how**.

## Key Changes

### docs/plugins/processors.md (complete rewrite)

- **Use case table**: Compression, encryption, format conversion, checksums, framing
- **Processors vs Enrichers comparison**: Clear decision table
- **Practical examples**:
  - `GzipProcessor` - compression
  - `EncryptProcessor` - encryption with Fernet
  - `MsgPackProcessor` - format conversion
- **Pipeline order diagram**: Shows where processors fit
- **Configuration guidance**: Settings and env vars

### docs/api-reference/plugins/processors.md

- Expanded contract documentation
- Added usage and order section
- Included example code

### docs/plugins/index.md

- Updated description: "Transform serialized log data (compression, encryption, format conversion)"

## Before vs After

**Before**: "Data processing and transformation pipelines" (vague)

**After**: Clear use cases, decision guidance, and practical examples