### PR TITLE
feat(plugins): Wire processors into logging pipeline (Story 5.0)

### DIFF
--- a/docs/api-reference/plugins/processors.md
+++ b/docs/api-reference/plugins/processors.md
@@ -8,7 +8,7 @@ Plugins that transform serialized log data (`memoryview`) after enrichment/redac
 - `async start(self) -> None` (optional)
 - `async stop(self) -> None` (optional)
 - `async process(self, view: memoryview) -> memoryview` (required)
-- `async process_many(self, views: Iterable[memoryview]) -> int` (optional helper)
+- `async process_many(self, views: Iterable[memoryview]) -> list[memoryview]` (optional helper; default delegates to `process`)
 - `async health_check(self) -> bool` (optional)
 
 Errors should be contained by processors; callers isolate failures per processor.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -71,6 +71,8 @@
 | `FAPILOG__PLUGINS__DENYLIST` | list | PydanticUndefined | Plugin names to block from loading |
 | `FAPILOG__PLUGINS__ENABLED` | bool | True | Enable plugin loading |
 | `FAPILOG__PLUGINS__VALIDATION_MODE` | str | disabled | Plugin validation mode: disabled, warn, or strict |
+| `FAPILOG__PROCESSOR_CONFIG__EXTRA` | dict | PydanticUndefined | Configuration for third-party processors by name |
+| `FAPILOG__PROCESSOR_CONFIG__ZERO_COPY` | dict | PydanticUndefined | Configuration for zero_copy processor (reserved for future options) |
 | `FAPILOG__REDACTOR_CONFIG__EXTRA` | dict | PydanticUndefined | Configuration for third-party redactors by name |
 | `FAPILOG__REDACTOR_CONFIG__FIELD_MASK__BLOCK_ON_UNREDACTABLE` | bool | False | Block log entry if redaction fails |
 | `FAPILOG__REDACTOR_CONFIG__FIELD_MASK__FIELDS_TO_MASK` | list | PydanticUndefined | Field names to mask (case-insensitive) |

--- a/docs/plugins/configuration.md
+++ b/docs/plugins/configuration.md
@@ -20,7 +20,8 @@ This guide explains the new configuration-driven plugin wiring introduced in Sto
   - `redactor_config.field_mask`: fields, mask string, guardrails
   - `redactor_config.regex_mask`: patterns, mask string, guardrails
   - `redactor_config.url_credentials`: max string length
-- Third-party plugins use `extra` maps (`sink_config.extra`, `enricher_config.extra`, `redactor_config.extra`) with arbitrary keys.
+  - `processor_config.zero_copy`: reserved for zero_copy options; third-party configs via `processor_config.extra`
+  - Third-party plugins use `extra` maps (`sink_config.extra`, `enricher_config.extra`, `redactor_config.extra`, `processor_config.extra`) with arbitrary keys.
 
 ### Environment Examples
 
@@ -31,6 +32,10 @@ FAPILOG_SINK_CONFIG__ROTATING_FILE__DIRECTORY="/var/log/app"
 
 # Disable enrichers
 FAPILOG_CORE__ENRICHERS='[]'
+
+# Processors with config
+FAPILOG_CORE__PROCESSORS='["gzip"]'
+FAPILOG_PROCESSOR_CONFIG__EXTRA__GZIP='{\"level\":4}'
 
 # Redactors via legacy order (still supported)
 FAPILOG_CORE__ENABLE_REDACTORS=true

--- a/docs/plugins/processors.md
+++ b/docs/plugins/processors.md
@@ -86,6 +86,14 @@ class MsgPackProcessor:
         data = json.loads(bytes(view))
         packed = msgpack.packb(data)
         return memoryview(packed)
+
+
+### Batch processing
+
+Implement `process_many(self, views: Iterable[memoryview]) -> list[memoryview]`
+when batching improves performance (shared compression dictionary, reused crypto
+context, etc.). The default implementation simply calls `process()` for each
+view and returns the processed results in order.
 ```
 
 ## Built-in processors
@@ -101,7 +109,7 @@ class MsgPackProcessor:
 
 ## Configuration and order
 
-Configure processors via settings (`core.processors`) or env (`FAPILOG_CORE__PROCESSORS`). They run in order:
+Configure processors via settings (`core.processors`) or env (`FAPILOG_CORE__PROCESSORS`). Per-processor kwargs live under `processor_config` (e.g., `processor_config.extra.gzip = {"level": 5}`). They run in order:
 
 ```
 Event → Enrichers → Redactors → Serialize → Processor 1 → Processor 2 → Sinks

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -174,6 +174,19 @@ class RedactorUrlCredentialsSettings(BaseModel):
     )
 
 
+class ProcessorConfigSettings(BaseModel):
+    """Per-processor configuration for built-in and third-party processors."""
+
+    zero_copy: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Configuration for zero_copy processor (reserved for future options)",
+    )
+    extra: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Configuration for third-party processors by name",
+    )
+
+
 # Keep explicit version to allow schema gating and forward migrations later
 LATEST_CONFIG_SCHEMA_VERSION = "1.0"
 
@@ -579,6 +592,10 @@ class Settings(BaseSettings):
     )
     redactor_config: RedactorConfig = Field(
         default_factory=RedactorConfig, description="Per-redactor plugin configuration"
+    )
+    processor_config: ProcessorConfigSettings = Field(
+        default_factory=ProcessorConfigSettings,
+        description="Per-processor plugin configuration",
     )
 
     # Settings behavior

--- a/src/fapilog/plugins/health.py
+++ b/src/fapilog/plugins/health.py
@@ -85,6 +85,7 @@ async def aggregate_plugin_health(
     enrichers: list[Any],
     redactors: list[Any],
     sinks: list[Any],
+    processors: list[Any] | None = None,
     *,
     timeout_seconds: float = 5.0,
 ) -> AggregatedHealth:
@@ -101,6 +102,10 @@ async def aggregate_plugin_health(
     """
     plugin_healths: list[PluginHealth] = []
 
+    for p in processors or []:
+        plugin_healths.append(
+            await check_plugin_health(p, "processor", timeout_seconds)
+        )
     for e in enrichers:
         plugin_healths.append(await check_plugin_health(e, "enricher", timeout_seconds))
     for r in redactors:

--- a/src/fapilog/plugins/processors/__init__.py
+++ b/src/fapilog/plugins/processors/__init__.py
@@ -31,12 +31,9 @@ class BaseProcessor(Protocol):
     async def process(self, view: memoryview) -> memoryview:
         """Transform a single view and return the processed view."""
 
-    async def process_many(self, views: Iterable[memoryview]) -> int:
-        count = 0
-        for v in views:
-            _ = await self.process(v)
-            count += 1
-        return count
+    async def process_many(self, views: Iterable[memoryview]) -> list[memoryview]:
+        """Process multiple views, returning processed views in order."""
+        return [await self.process(v) for v in views]
 
     async def health_check(self) -> bool:  # pragma: no cover - optional
         """Return True if the processor is healthy. Default: assume healthy."""

--- a/src/fapilog/plugins/processors/zero_copy.py
+++ b/src/fapilog/plugins/processors/zero_copy.py
@@ -51,17 +51,13 @@ class ZeroCopyProcessor:
                 cause=e,
             ) from e
 
-    async def process_many(self, views: Iterable[memoryview]) -> int:
-        """Process many payloads; returns the number processed.
-
-        Uses a lock to model shared state protection if extended.
-        """
-        count = 0
+    async def process_many(self, views: Iterable[memoryview]) -> list[memoryview]:
+        """Process many payloads; returns processed views."""
+        out: list[memoryview] = []
         async with self._lock:
             for v in views:
-                _ = await self.process(v)
-                count += 1
-        return count
+                out.append(await self.process(v))
+        return out
 
     async def health_check(self) -> bool:
         """Verify processor is ready to accept views.

--- a/tests/unit/test_pipeline_processors.py
+++ b/tests/unit/test_pipeline_processors.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog import Settings, _build_pipeline
+from fapilog.plugins.processors import BaseProcessor
+
+
+class _DelegatingProcessor(BaseProcessor):
+    name = "delegating"
+
+    def __init__(self) -> None:
+        self.seen: list[memoryview] = []
+
+    async def process(self, view: memoryview) -> memoryview:  # noqa: D401
+        self.seen.append(view)
+        return memoryview(view.tobytes() + b"!")
+
+
+def test_build_pipeline_loads_processors_with_configs(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_load_plugins(group, names, settings, cfgs):
+        captured["group"] = group
+        captured["names"] = list(names)
+        captured["cfgs"] = cfgs
+        return ["proc-instance"]
+
+    monkeypatch.setattr("fapilog._load_plugins", fake_load_plugins)
+
+    settings = Settings(
+        core={"processors": ["zero-copy"]},
+        plugins={"enabled": True},
+    )
+
+    sinks, enrichers, redactors, processors, metrics = _build_pipeline(settings)
+
+    assert processors == ["proc-instance"]
+    assert captured["group"] == "fapilog.processors"
+    assert captured["names"] == ["zero-copy"]
+    assert "zero_copy" in captured["cfgs"]
+
+
+@pytest.mark.asyncio
+async def test_base_processor_process_many_returns_processed_views() -> None:
+    proc = _DelegatingProcessor()
+    views = [memoryview(b"a"), memoryview(b"b")]
+
+    out = await proc.process_many(views)
+
+    assert [bytes(v) for v in out] == [b"a!", b"b!"]
+    # process_many should delegate to process for each view
+    assert proc.seen and len(proc.seen) == 2

--- a/tests/unit/test_plugin_health.py
+++ b/tests/unit/test_plugin_health.py
@@ -153,9 +153,20 @@ class _DummyHealthSink:
         return True
 
 
+class _DummyHealthProcessor:
+    name = "proc"
+
+    async def process(self, view: memoryview) -> memoryview:
+        return view
+
+    async def health_check(self) -> bool:
+        return True
+
+
 @pytest.mark.asyncio
 async def test_logger_check_health_aggregates() -> None:
     sink = _DummyHealthSink()
+    processor = _DummyHealthProcessor()
     logger = SyncLoggerFacade(
         name="h",
         queue_capacity=4,
@@ -168,6 +179,7 @@ async def test_logger_check_health_aggregates() -> None:
     )
     logger._sinks = [sink]  # noqa: SLF001
     logger._redactors = [_DummyHealthRedactor()]  # noqa: SLF001
+    logger._processors = [processor]  # noqa: SLF001
     health = await logger.check_health()
     assert health.all_healthy is True
 

--- a/tests/unit/test_processors_pipeline.py
+++ b/tests/unit/test_processors_pipeline.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog.core.concurrency import NonBlockingRingQueue
+from fapilog.core.events import LogEvent
+from fapilog.core.worker import LoggerWorker, strict_envelope_mode_enabled
+from fapilog.metrics.metrics import MetricsCollector
+from fapilog.plugins.processors import BaseProcessor
+
+
+class _AppendProcessor(BaseProcessor):
+    """Test processor that appends a marker for order assertions."""
+
+    def __init__(self, marker: bytes) -> None:
+        self.marker = marker
+        self.name = f"append-{marker.decode()}"
+
+    async def process(self, view: memoryview) -> memoryview:
+        return memoryview(view.tobytes() + self.marker)
+
+
+class _FailingProcessor(BaseProcessor):
+    name = "failing"
+
+    async def process(self, view: memoryview) -> memoryview:  # noqa: D401
+        raise RuntimeError("boom")
+
+
+class _PassthroughProcessor(BaseProcessor):
+    name = "passthrough"
+
+    async def process(self, view: memoryview) -> memoryview:  # noqa: D401
+        return view
+
+
+def _make_worker(
+    *,
+    sink_write_serialized,
+    sink_write,
+    processors_getter,
+    metrics=None,
+    emit_processor_diagnostics: bool = True,
+):
+    return LoggerWorker(
+        queue=NonBlockingRingQueue(capacity=4),
+        batch_max_size=4,
+        batch_timeout_seconds=0.01,
+        sink_write=sink_write,
+        sink_write_serialized=sink_write_serialized,
+        enrichers_getter=lambda: [],
+        redactors_getter=lambda: [],
+        metrics=metrics,
+        serialize_in_flush=True,
+        strict_envelope_mode_provider=strict_envelope_mode_enabled,
+        stop_flag=lambda: False,
+        drained_event=None,
+        flush_event=None,
+        flush_done_event=None,
+        emit_enricher_diagnostics=True,
+        emit_redactor_diagnostics=True,
+        counters={"processed": 0, "dropped": 0},
+        processors_getter=processors_getter,
+        emit_processor_diagnostics=emit_processor_diagnostics,
+    )
+
+
+def _log_batch() -> list[dict]:
+    return [LogEvent(level="INFO", message="hello").to_mapping()]
+
+
+@pytest.mark.asyncio
+async def test_worker_applies_processors_in_order() -> None:
+    serialized: list[bytes] = []
+
+    async def sink_write_serialized(view):
+        serialized.append(bytes(view))
+
+    fallback: list[dict] = []
+
+    async def sink_write(entry):
+        fallback.append(entry)
+
+    worker = _make_worker(
+        sink_write_serialized=sink_write_serialized,
+        sink_write=sink_write,
+        processors_getter=lambda: [
+            _AppendProcessor(b"1"),
+            _AppendProcessor(b"2"),
+        ],
+    )
+
+    batch = _log_batch()
+    await worker.flush_batch(batch)
+
+    assert fallback == []  # fast-path used
+    assert serialized  # sink_write_serialized was called
+    # Order preserved: markers appended sequentially
+    assert serialized[0].endswith(b"12")
+
+
+@pytest.mark.asyncio
+async def test_worker_contains_processor_errors_and_records_metrics(
+    monkeypatch,
+) -> None:
+    serialized: list[bytes] = []
+    diagnostics: list[dict] = []
+
+    async def sink_write_serialized(view):
+        serialized.append(bytes(view))
+
+    async def sink_write(entry):
+        serialized.append(str(entry).encode())
+
+    metrics = MetricsCollector(enabled=True)
+
+    def fake_warn(_category, _message, **attrs):
+        diagnostics.append(attrs)
+
+    monkeypatch.setattr("fapilog.core.worker.warn", fake_warn)
+
+    worker = _make_worker(
+        sink_write_serialized=sink_write_serialized,
+        sink_write=sink_write,
+        processors_getter=lambda: [
+            _FailingProcessor(),
+            _AppendProcessor(b"x"),
+        ],
+        metrics=metrics,
+    )
+
+    batch = _log_batch()
+    await worker.flush_batch(batch)
+
+    # Error should not block subsequent processors or sinks
+    assert serialized
+    assert serialized[0].endswith(b"x")
+    # Diagnostics emitted for failing processor
+    assert diagnostics
+    assert diagnostics[-1].get("processor") == "failing"
+    # Metrics recorded plugin error
+    snap = await metrics.snapshot()
+    assert snap.plugin_errors == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_preserves_original_view_on_failure(monkeypatch) -> None:
+    serialized: list[bytes] = []
+
+    async def sink_write_serialized(view):
+        serialized.append(bytes(view))
+
+    async def sink_write(entry):
+        serialized.append(str(entry).encode())
+
+    # Capture the bytes produced before processor mutation
+    original_bytes: list[bytes] = []
+
+    class CaptureProcessor(BaseProcessor):
+        name = "capture"
+
+        async def process(self, view: memoryview) -> memoryview:
+            original_bytes.append(view.tobytes())
+            raise RuntimeError("stop here")
+
+    worker = _make_worker(
+        sink_write_serialized=sink_write_serialized,
+        sink_write=sink_write,
+        processors_getter=lambda: [CaptureProcessor()],
+        emit_processor_diagnostics=False,
+    )
+
+    batch = _log_batch()
+    await worker.flush_batch(batch)
+
+    assert serialized  # fallback to original view written
+    assert original_bytes
+    assert serialized[0] == original_bytes[0]

--- a/tests/unit/test_story430_protocol_name_attribute.py
+++ b/tests/unit/test_story430_protocol_name_attribute.py
@@ -127,8 +127,8 @@ class TestIsinstanceChecksWithName:
             async def process(self, view: memoryview) -> memoryview:
                 return view
 
-            async def process_many(self, views) -> int:
-                return 0
+            async def process_many(self, views):
+                return []
 
             async def health_check(self) -> bool:
                 return True
@@ -149,8 +149,8 @@ class TestIsinstanceChecksWithName:
             async def process(self, view: memoryview) -> memoryview:
                 return view
 
-            async def process_many(self, views) -> int:
-                return 0
+            async def process_many(self, views):
+                return []
 
             async def health_check(self) -> bool:
                 return True


### PR DESCRIPTION
## Summary

Wires the **Processor** plugin type into the core logging pipeline, completing the plugin system.

## Changes

### Core Pipeline Integration
- **`_apply_processors()`** added to `LoggerWorker` - runs processors sequentially after serialization
- **`_build_pipeline()`** updated to load and return processors alongside sinks/enrichers/redactors
- Both `SyncLoggerFacade` and `AsyncLoggerFacade` now manage processor lifecycle

### API Fixes
- **`BaseProcessor.process_many()`** now returns `list[memoryview]` instead of `int`
- `ZeroCopyProcessor` updated to new signature

### Configuration
- Added `ProcessorConfigSettings` with `zero_copy` and `extra` blocks
- Processors configured via `core.processors` list or `FAPILOG_CORE__PROCESSORS` env var

### Health & Observability
- Processors included in `aggregate_plugin_health()`
- Processor timing recorded via `plugin_timer` metrics

### Error Containment
- Processor failures fall back to original view and continue chain
- Diagnostics emitted for failures (rate-limited)

## Pipeline Flow

```
Event → Enrichers → Redactors → Serialize → Processor 1 → Processor 2 → Sinks
```

## Test Coverage
- `test_processors_pipeline.py` - order, error containment, fallback
- `test_pipeline_processors.py` - config loading, `process_many()` signature
- Updated `test_zero_copy_processor.py` for new return type

## Documentation
- Updated `docs/plugins/processors.md` with batch processing section
- Updated `docs/plugins/configuration.md` with processor config examples
- Updated `docs/api-reference/plugins/processors.md` signature

Closes #50