### PR TITLE
fix(plugins): Standardize PLUGIN_METADATA names to snake_case (Story 5.1)

### DIFF
--- a/docs/api-reference/plugins/sinks.md
+++ b/docs/api-reference/plugins/sinks.md
@@ -37,9 +37,9 @@ class SerializedView:
 
 ## Built-in sinks
 
-- **stdout-json**: default sink, JSON lines to stdout.
-- **rotating-file**: size/time-based rotation with optional compression.
-- **http_client**: POST log entries to an HTTP endpoint.
+- **stdout_json**: default sink, JSON lines to stdout.
+- **rotating_file**: size/time-based rotation with optional compression.
+- **http**: POST log entries to an HTTP endpoint.
 - **webhook**: POST log entries to a webhook with optional signing.
 
 ## Configuration (env)

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -3,14 +3,14 @@
 
 | Name | Type | Version | API | Author | Description |
 |------|------|---------|-----|--------|-------------|
-| context-vars-enricher | enricher | 1.0.0 | 1.0 | Fapilog Core | Adds context variables like request_id and user_id when available. |
+| context_vars | enricher | 1.0.0 | 1.0 | Fapilog Core | Adds context variables like request_id and user_id when available. |
 | field_mask | redactor | 1.0.0 | 1.0 | Fapilog Core | Masks configured fields in structured events. |
 | http | sink | 1.0.0 | 1.0 | Fapilog Core | Async HTTP sink that POSTs JSON to a configured endpoint. |
-| mmap-persistence | sink | 1.0.0 | 1.0 | Fapilog Core | Memory-mapped file sink for zero-copy friendly persistence. |
+| mmap_persistence | sink | 1.0.0 | 1.0 | Fapilog Core | Memory-mapped file sink for zero-copy friendly persistence. |
 | regex_mask | redactor | 1.0.0 | 1.0 | Fapilog Core | Masks values for fields whose dot-paths match configured regex patterns. |
-| rotating-file | sink | 1.0.0 | 1.0 | Fapilog Core | Async rotating file sink with size/time rotation and retention |
-| runtime-info-enricher | enricher | 1.0.0 | 1.0 | Fapilog Core | Adds runtime/system information such as host, pid, and python version. |
-| stdout-json | sink | 1.0.0 | 1.0 | Fapilog Core | Async stdout JSONL sink |
+| rotating_file | sink | 1.0.0 | 1.0 | Fapilog Core | Async rotating file sink with size/time rotation and retention |
+| runtime_info | enricher | 1.0.0 | 1.0 | Fapilog Core | Adds runtime/system information such as host, pid, and python version. |
+| stdout_json | sink | 1.0.0 | 1.0 | Fapilog Core | Async stdout JSONL sink |
 | url_credentials | redactor | 1.0.0 | 1.0 | Fapilog Core | Strips user:pass@ credentials from URL-like strings. |
 | webhook | sink | 1.0.0 | 1.0 | Fapilog Core | Webhook sink that POSTs JSON with optional signing. |
-| zero-copy | processor | 1.0.0 | 1.0 | Fapilog Core | Zero-copy pass-through processor for performance benchmarking. |
+| zero_copy | processor | 1.0.0 | 1.0 | Fapilog Core | Zero-copy pass-through processor for performance benchmarking. |

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -8,21 +8,28 @@ Declare entry points in `pyproject.toml` under one of the v3 groups per plugin t
 
 ```
 [project.entry-points."fapilog.sinks"]
-"my-sink" = "my_package.my_sink"
+"my_sink" = "my_package.my_sink"
 
 [project.entry-points."fapilog.processors"]
-"my-processor" = "my_package.my_processor"
+"my_processor" = "my_package.my_processor"
 
 [project.entry-points."fapilog.enrichers"]
-"my-enricher" = "my_package.my_enricher"
+"my_enricher" = "my_package.my_enricher"
 
 [project.entry-points."fapilog.redactors"]
-"my-redactor" = "my_package.my_redactor"
+"my_redactor" = "my_package.my_redactor"
 
 # Fallback generic group (type derived from PLUGIN_METADATA["plugin_type"]) when needed
 [project.entry-points."fapilog.plugins"]
 "legacy-plugin" = "my_package.legacy"
 ```
+
+## Naming Convention
+
+- Use lowercase with underscores (snake_case): `field_mask`, `rotating_file`, `runtime_info`.
+- Avoid type suffixes in names (`-sink`, `-processor`, etc.); the `plugin_type` field already captures that.
+- The class `name` attribute and `PLUGIN_METADATA["name"]` must match.
+- Hyphen variants are normalized automatically for compatibility, but prefer snake_case in docs/config.
 
 ## PLUGIN_METADATA
 
@@ -30,7 +37,7 @@ Each module must export a `PLUGIN_METADATA` mapping with at least:
 
 ```
 PLUGIN_METADATA = {
-  "name": "my-plugin",
+  "name": "my_plugin",
   "version": "1.2.3",
   "plugin_type": "sink",  # sink|processor|enricher|redactor
   "entry_point": "my_package.my_sink:Plugin",

--- a/docs/plugins/contracts-and-versioning.md
+++ b/docs/plugins/contracts-and-versioning.md
@@ -36,7 +36,7 @@ Minimal `PLUGIN_METADATA` example for a sink:
 
 ```python
 PLUGIN_METADATA = {
-    "name": "stdout-json-sink",
+    "name": "stdout_json",
     "version": "0.1.0",
     "plugin_type": "sink",
     "entry_point": "your_module:YourPluginClassOrModule",

--- a/docs/plugins/sinks.md
+++ b/docs/plugins/sinks.md
@@ -8,7 +8,7 @@ Output destinations for serialized log entries. Implement `BaseSink`.
 from fapilog.plugins import BaseSink
 
 class MySink(BaseSink):
-    name = "my-sink"
+    name = "my_sink"
 
     async def start(self) -> None:
         ...
@@ -28,9 +28,9 @@ class MySink(BaseSink):
 
 ## Built-in sinks (code-supported)
 
-- `stdout-json` (default)
-- `rotating-file` (size/time rotation)
-- `http_client` (HTTP POST)
+- `stdout_json` (default)
+- `rotating_file` (size/time rotation)
+- `http` (HTTP POST)
 - `mmap_persistence` (experimental; local persistence)
 
 ## Usage
@@ -45,7 +45,7 @@ For sinks that operate on bytes (files, sockets, HTTP), implement `write_seriali
 from fapilog.core.serialization import SerializedView
 
 class MyFastSink:
-    name = "my-fast-sink"
+    name = "my_fast_sink"
 
     async def write(self, entry: dict) -> None:
         # Fallback path: serialize yourself

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,7 +3,7 @@
 This page lists planned features that are **not implemented yet**. Today, fapilog ships:
 
 - Async/sync factories and runtime contexts (awaitable async factory)
-- Redactors/enrichers, stdout and rotating-file sinks, HTTP client sink
+- Redactors/enrichers, stdout_json and rotating_file sinks, HTTP client sink
 - Metrics hooks and basic CLI commands (`version/settings/emit/flush/drain`)
 
 ## Pipeline & Sinks (planned)

--- a/src/fapilog/plugins/enrichers/__init__.py
+++ b/src/fapilog/plugins/enrichers/__init__.py
@@ -99,13 +99,13 @@ register_builtin(
     "fapilog.enrichers",
     "runtime_info",
     RuntimeInfoEnricher,
-    aliases=["runtime-info"],
+    aliases=["runtime-info", "runtime-info-enricher"],
 )
 register_builtin(
     "fapilog.enrichers",
     "context_vars",
     ContextVarsEnricher,
-    aliases=["context-vars"],
+    aliases=["context-vars", "context-vars-enricher"],
 )
 
 __all__ = [

--- a/src/fapilog/plugins/enrichers/context_vars.py
+++ b/src/fapilog/plugins/enrichers/context_vars.py
@@ -74,7 +74,7 @@ __all__ = ["ContextVarsEnricher"]
 
 # Minimal PLUGIN_METADATA for discovery
 PLUGIN_METADATA = {
-    "name": "context-vars-enricher",
+    "name": "context_vars",
     "version": "1.0.0",
     "plugin_type": "enricher",
     "entry_point": "fapilog.plugins.enrichers.context_vars:ContextVarsEnricher",

--- a/src/fapilog/plugins/enrichers/runtime_info.py
+++ b/src/fapilog/plugins/enrichers/runtime_info.py
@@ -45,7 +45,7 @@ __all__ = ["RuntimeInfoEnricher"]
 
 # Minimal PLUGIN_METADATA for discovery
 PLUGIN_METADATA = {
-    "name": "runtime-info-enricher",
+    "name": "runtime_info",
     "version": "1.0.0",
     "plugin_type": "enricher",
     "entry_point": "fapilog.plugins.enrichers.runtime_info:RuntimeInfoEnricher",

--- a/src/fapilog/plugins/processors/zero_copy.py
+++ b/src/fapilog/plugins/processors/zero_copy.py
@@ -77,7 +77,7 @@ class ZeroCopyProcessor:
 
 # Plugin metadata for discovery
 PLUGIN_METADATA = {
-    "name": "zero-copy",
+    "name": "zero_copy",
     "version": "1.0.0",
     "plugin_type": "processor",
     "entry_point": "fapilog.plugins.processors.zero_copy:ZeroCopyProcessor",

--- a/src/fapilog/plugins/sinks/mmap_persistence.py
+++ b/src/fapilog/plugins/sinks/mmap_persistence.py
@@ -278,7 +278,7 @@ class MemoryMappedPersistence:
 
 # Plugin metadata for discovery
 PLUGIN_METADATA = {
-    "name": "mmap-persistence",
+    "name": "mmap_persistence",
     "version": "1.0.0",
     "plugin_type": "sink",
     "entry_point": "fapilog.plugins.sinks.mmap_persistence:MemoryMappedPersistence",

--- a/src/fapilog/plugins/sinks/rotating_file.py
+++ b/src/fapilog/plugins/sinks/rotating_file.py
@@ -461,7 +461,7 @@ class RotatingFileSink:
 
 # Minimal plugin metadata for discovery compatibility (local/entry-point)
 PLUGIN_METADATA = {
-    "name": "rotating-file",
+    "name": "rotating_file",
     "version": "1.0.0",
     "plugin_type": "sink",
     "entry_point": "fapilog.plugins.sinks.rotating_file:RotatingFileSink",

--- a/src/fapilog/plugins/sinks/stdout_json.py
+++ b/src/fapilog/plugins/sinks/stdout_json.py
@@ -139,7 +139,7 @@ _VULTURE_USED: tuple[object, ...] = (
 
 # Minimal plugin metadata for discovery compatibility
 PLUGIN_METADATA = {
-    "name": "stdout-json",
+    "name": "stdout_json",
     "version": "1.0.0",
     "plugin_type": "sink",
     "entry_point": "fapilog.plugins.sinks.stdout_json:StdoutJsonSink",

--- a/tests/unit/test_plugin_metadata_consistency.py
+++ b/tests/unit/test_plugin_metadata_consistency.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from fapilog.plugins import loader
+from fapilog.plugins.enrichers.context_vars import (
+    PLUGIN_METADATA as CONTEXT_META,
+)
+from fapilog.plugins.enrichers.context_vars import (
+    ContextVarsEnricher,
+)
+from fapilog.plugins.enrichers.runtime_info import (
+    PLUGIN_METADATA as RUNTIME_META,
+)
+from fapilog.plugins.enrichers.runtime_info import (
+    RuntimeInfoEnricher,
+)
+from fapilog.plugins.processors.zero_copy import (
+    PLUGIN_METADATA as ZERO_COPY_META,
+)
+from fapilog.plugins.processors.zero_copy import (
+    ZeroCopyProcessor,
+)
+from fapilog.plugins.sinks.rotating_file import (
+    PLUGIN_METADATA as ROTATING_FILE_META,
+)
+from fapilog.plugins.sinks.rotating_file import (
+    RotatingFileSink,
+)
+from fapilog.plugins.sinks.stdout_json import (
+    PLUGIN_METADATA as STDOUT_META,
+)
+from fapilog.plugins.sinks.stdout_json import (
+    StdoutJsonSink,
+)
+from fapilog.plugins.utils import normalize_plugin_name
+
+
+def test_builtin_metadata_matches_class_names() -> None:
+    cases = [
+        (ContextVarsEnricher, CONTEXT_META),
+        (RuntimeInfoEnricher, RUNTIME_META),
+        (ZeroCopyProcessor, ZERO_COPY_META),
+        (StdoutJsonSink, STDOUT_META),
+        (RotatingFileSink, ROTATING_FILE_META),
+    ]
+
+    for cls, meta in cases:
+        assert normalize_plugin_name(cls.name) == normalize_plugin_name(meta["name"])
+
+
+def test_warn_on_name_mismatch(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_warn(category, message, **attrs):  # noqa: D401
+        calls.append({"category": category, "message": message, "attrs": attrs})
+
+    monkeypatch.setattr(loader, "diagnostics", types.SimpleNamespace(warn=fake_warn))
+
+    mod = types.ModuleType("fake_plugin_mod")
+    mod.PLUGIN_METADATA = {"name": "meta-name"}
+    monkeypatch.setitem(sys.modules, "fake_plugin_mod", mod)
+
+    class Dummy:
+        __module__ = "fake_plugin_mod"
+        name = "class_name"
+
+    loader._warn_on_name_mismatch(Dummy)
+
+    assert calls
+    call = calls[0]
+    assert call["category"] == "plugins"
+    assert call["attrs"]["class_name"] == "class_name"
+    assert call["attrs"]["metadata_name"] == "meta-name"
+    assert call["attrs"]["plugin"] == "Dummy"
+
+
+def test_warn_on_name_mismatch_skips_normalized_equivalents(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_warn(*_args, **_kwargs):
+        calls.append({})
+
+    monkeypatch.setattr(loader, "diagnostics", types.SimpleNamespace(warn=fake_warn))
+
+    mod = types.ModuleType("fake_plugin_mod2")
+    mod.PLUGIN_METADATA = {"name": "my-plugin"}
+    monkeypatch.setitem(sys.modules, "fake_plugin_mod2", mod)
+
+    class Dummy2:
+        __module__ = "fake_plugin_mod2"
+        name = "my_plugin"
+
+    loader._warn_on_name_mismatch(Dummy2)
+
+    assert calls == []
+
+
+def test_loader_supports_legacy_enricher_aliases() -> None:
+    plugin = loader.load_plugin("fapilog.enrichers", "context-vars-enricher", {})
+    assert isinstance(plugin, ContextVarsEnricher)


### PR DESCRIPTION
## Summary

Fixes inconsistencies between plugin class `name` attributes and `PLUGIN_METADATA["name"]` values across all built-in plugins.

## Problem

The plugin audit revealed naming mismatches that could confuse users:

| Plugin | Class `name` | Old PLUGIN_METADATA | New PLUGIN_METADATA |
|--------|---------------|---------------------|---------------------|
| ContextVarsEnricher | `context_vars` | `context-vars-enricher` | `context_vars` |
| RuntimeInfoEnricher | `runtime_info` | `runtime-info-enricher` | `runtime_info` |
| ZeroCopyProcessor | `zero_copy` | `zero-copy` | `zero_copy` |
| StdoutJsonSink | `stdout_json` | `stdout-json` | `stdout_json` |
| RotatingFileSink | `rotating_file` | `rotating-file` | `rotating_file` |
| MemoryMappedPersistence | `mmap_persistence` | `mmap-persistence` | `mmap_persistence` |

## Changes

### Code
- **PLUGIN_METADATA updates**: All names now use snake_case, matching class attributes
- **Removed type suffixes**: No more `-enricher`, `-sink` suffixes (redundant with `plugin_type`)
- **Added validation**: `_warn_on_name_mismatch()` in loader emits diagnostic on inconsistencies
- **Legacy aliases**: Old names still work for backward compatibility

### Documentation
- Updated `docs/plugins/authoring.md` with naming convention
- Updated examples across plugin docs to use snake_case

## Backward Compatibility

✅ **Fully backward compatible** - legacy names work via aliases:

```python
# Both work:
load_plugin("fapilog.enrichers", "context_vars", {})      # New
load_plugin("fapilog.enrichers", "context-vars-enricher", {})  # Legacy
```

## Test Coverage

- `test_builtin_metadata_matches_class_names` - validates all built-ins
- `test_warn_on_name_mismatch` - validates warning emission
- `test_loader_supports_legacy_enricher_aliases` - backward compatibility

Closes #51