### PR TITLE
feat(plugins): add Filter plugin type (Story 5.2)

### DIFF
--- a/docs/core-concepts/pipeline-architecture.md
+++ b/docs/core-concepts/pipeline-architecture.md
@@ -8,11 +8,11 @@ fapilog uses a pipeline architecture that processes log messages through several
 
 ```
 ┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
-│ Application │───▶│   Context   │───▶│ Enrichers   │───▶│ Redactors   │
+│ Application │───▶│   Context   │───▶│   Filters   │───▶│ Enrichers   │
 └─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘
-                                                              │
-┌─────────────┐    ┌─────────────┐    ┌─────────────┐        │
-│    Sinks    │◀───│    Queue    │◀───│ Processors  │◀───────┘
+                                                                  │
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐            │
+│    Sinks    │◀───│    Queue    │◀───│ Processors  │◀──────────┘
 └─────────────┘    └─────────────┘    └─────────────┘
 ```
 
@@ -53,7 +53,17 @@ logger.info("Request processed", status_code=200)
 - Service name
 - Environment
 
-### 3. Enrichers
+### 3. Filters
+
+Filters run first and can drop or tweak events before any enrichment or redaction. Returning `None` drops the event; returning a dict continues processing.
+
+**Built-in filters:**
+
+- **Level** - Drop events below a configured level (wired from `core.log_level`).
+- **Sampling** - Keep a percentage of events.
+- **Rate Limit** - Token bucket limiter (optionally per key).
+
+### 4. Enrichers
 
 Enrichers add additional metadata to messages:
 
@@ -80,7 +90,7 @@ Enrichers add additional metadata to messages:
 }
 ```
 
-### 4. Redactors
+### 5. Redactors
 
 Redactors remove or mask sensitive information:
 
@@ -110,7 +120,7 @@ Redactors remove or mask sensitive information:
 }
 ```
 
-### 5. Processors
+### 6. Processors
 
 Processors transform and optimize messages:
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -19,6 +19,7 @@
 | `FAPILOG__CORE__EXCEPTIONS_ENABLED` | bool | True | Enable structured exception serialization for log calls |
 | `FAPILOG__CORE__EXCEPTIONS_MAX_FRAMES` | int | 50 | Maximum number of stack frames to capture for exceptions |
 | `FAPILOG__CORE__EXCEPTIONS_MAX_STACK_CHARS` | int | 20000 | Maximum total characters for serialized stack string |
+| `FAPILOG__CORE__FILTERS` | list | PydanticUndefined | Filter plugins to apply before enrichment (by name) |
 | `FAPILOG__CORE__INTERNAL_LOGGING_ENABLED` | bool | False | Emit DEBUG/WARN diagnostics for internal errors |
 | `FAPILOG__CORE__LOG_LEVEL` | Literal | INFO | Default log level |
 | `FAPILOG__CORE__MAX_QUEUE_SIZE` | int | 10000 | Maximum in-memory queue size for async processing |
@@ -48,6 +49,10 @@
 | `FAPILOG__ENRICHER_CONFIG__INTEGRITY__ROTATE_CHAIN` | bool | False | Reset chain after rotation |
 | `FAPILOG__ENRICHER_CONFIG__INTEGRITY__USE_KMS_SIGNING` | bool | False | Sign integrity hashes via KMS provider |
 | `FAPILOG__ENRICHER_CONFIG__RUNTIME_INFO` | dict | PydanticUndefined | Configuration for runtime_info enricher |
+| `FAPILOG__FILTER_CONFIG__EXTRA` | dict | PydanticUndefined | Configuration for third-party filters by name |
+| `FAPILOG__FILTER_CONFIG__LEVEL` | dict | PydanticUndefined | Configuration for level filter |
+| `FAPILOG__FILTER_CONFIG__RATE_LIMIT` | dict | PydanticUndefined | Configuration for rate_limit filter |
+| `FAPILOG__FILTER_CONFIG__SAMPLING` | dict | PydanticUndefined | Configuration for sampling filter |
 | `FAPILOG__HTTP__ENDPOINT` | str | None | — | HTTP endpoint to POST log events to |
 | `FAPILOG__HTTP__HEADERS` | dict | PydanticUndefined | Default headers to send with each request |
 | `FAPILOG__HTTP__HEADERS_JSON` | str | None | — | JSON-encoded headers map (e.g. '{"Authorization": "Bearer x"}') |

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -19,6 +19,9 @@ Declare entry points in `pyproject.toml` under one of the v3 groups per plugin t
 [project.entry-points."fapilog.redactors"]
 "my_redactor" = "my_package.my_redactor"
 
+[project.entry-points."fapilog.filters"]
+"my_filter" = "my_package.my_filter"
+
 # Fallback generic group (type derived from PLUGIN_METADATA["plugin_type"]) when needed
 [project.entry-points."fapilog.plugins"]
 "legacy-plugin" = "my_package.legacy"

--- a/docs/plugins/configuration.md
+++ b/docs/plugins/configuration.md
@@ -9,6 +9,7 @@ This guide explains the new configuration-driven plugin wiring introduced in Sto
   - `core.enrichers`: default `runtime_info`, `context_vars`
   - `core.redactors`: empty disables; legacy `redactors_order` honored when empty and redactors enabled
   - `core.processors`: optional processors
+  - `core.filters`: optional filters that run before enrichers
 - Names accept hyphens or underscores; they are normalized internally (`field-mask` == `field_mask`). Built-ins register both forms.
 
 ## Per-Plugin Configuration
@@ -21,6 +22,7 @@ This guide explains the new configuration-driven plugin wiring introduced in Sto
   - `redactor_config.regex_mask`: patterns, mask string, guardrails
   - `redactor_config.url_credentials`: max string length
   - `processor_config.zero_copy`: reserved for zero_copy options; third-party configs via `processor_config.extra`
+  - `filter_config.level/sampling/rate_limit`: built-in filters; third-party configs via `filter_config.extra`
   - Third-party plugins use `extra` maps (`sink_config.extra`, `enricher_config.extra`, `redactor_config.extra`, `processor_config.extra`) with arbitrary keys.
 
 ### Environment Examples
@@ -45,6 +47,7 @@ FAPILOG_CORE__REDACTORS_ORDER='["field-mask","regex-mask"]'
 ## Loader Behavior
 
 - Built-ins register in the loader registry with aliases; third-party plugins discovered via entry points (`fapilog.sinks`, `fapilog.enrichers`, `fapilog.redactors`, `fapilog.processors`).
+- `core.log_level` now gates events via an implicit `level` filter when no explicit `core.filters` are configured (set to `DEBUG` to allow everything).
 - Allow/deny lists live under `Settings.plugins` and are respected for every plugin load.
 - Missing or failing plugins emit diagnostics and are skipped; logging continues with remaining plugins.
 

--- a/docs/plugins/contracts-and-versioning.md
+++ b/docs/plugins/contracts-and-versioning.md
@@ -10,6 +10,7 @@ Fapilog exposes runtime-checkable Protocols for all plugin types. Implementation
 - Enrichers: `fapilog.plugins.enrichers.BaseEnricher`
 - Processors: `fapilog.plugins.processors.BaseProcessor`
 - Redactors: `fapilog.plugins.redactors.BaseRedactor`
+- Filters: `fapilog.plugins.filters.BaseFilter`
 
 These are re-exported in `fapilog.plugins` for convenient import:
 

--- a/docs/plugins/filters.md
+++ b/docs/plugins/filters.md
@@ -1,0 +1,22 @@
+# Filters
+
+Filters run first in the pipeline. They can drop an event (return `None`) or mutate it before enrichers run.
+
+## Contract
+
+- `name: str`
+- `async start()/stop()` optional lifecycle hooks
+- `async filter(event: dict) -> dict | None` (return `None` to drop)
+- `async health_check() -> bool` (optional)
+
+## Built-in filters
+
+- `level`: drop events below a minimum level.
+- `sampling`: probabilistic sampling with optional seed.
+- `rate_limit`: token-bucket rate limiting with optional key partitioning.
+
+## Configuration
+
+Configure filters via `core.filters` and `filter_config.*`. When `core.log_level` is set (and no explicit `core.filters` are provided), fapilog automatically prepends a `level` filter using that threshold.
+
+Execution order is the list order: filters run before enrichers, redactors, processors, and sinks.

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -120,6 +120,14 @@
       "title": "Exceptions Max Stack Chars",
       "type": "integer"
     },
+    "filters": {
+      "description": "Filter plugins to apply before enrichment (by name)",
+      "items": {
+        "type": "string"
+      },
+      "title": "Filters",
+      "type": "array"
+    },
     "internal_logging_enabled": {
       "default": false,
       "description": "Emit DEBUG/WARN diagnostics for internal errors",

--- a/docs/settings-guide.md
+++ b/docs/settings-guide.md
@@ -28,6 +28,7 @@ This guide documents Settings groups and fields.
 | `core.enrichers` | list | PydanticUndefined | Enricher plugins to use (by name) |
 | `core.redactors` | list | PydanticUndefined | Redactor plugins to use (by name); empty to disable |
 | `core.processors` | list | PydanticUndefined | Processor plugins to use (by name) |
+| `core.filters` | list | PydanticUndefined | Filter plugins to apply before enrichment (by name) |
 | `core.redaction_max_depth` | int | None | 6 | Optional max depth guardrail for nested redaction |
 | `core.redaction_max_keys_scanned` | int | None | 5000 | Optional max keys scanned guardrail for redaction |
 | `core.exceptions_enabled` | bool | True | Enable structured exception serialization for log calls |

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -314,6 +314,10 @@ class CoreSettings(BaseModel):
         default_factory=list,
         description=("Processor plugins to use (by name)"),
     )
+    filters: list[str] = Field(
+        default_factory=list,
+        description=("Filter plugins to apply before enrichment (by name)"),
+    )
     redaction_max_depth: int | None = Field(
         default=6,
         ge=1,
@@ -561,6 +565,23 @@ class Settings(BaseSettings):
             description="Configuration for third-party redactors by name",
         )
 
+    class FilterConfig(BaseModel):
+        """Per-filter configuration for built-in filters."""
+
+        level: dict[str, Any] = Field(
+            default_factory=dict, description="Configuration for level filter"
+        )
+        sampling: dict[str, Any] = Field(
+            default_factory=dict, description="Configuration for sampling filter"
+        )
+        rate_limit: dict[str, Any] = Field(
+            default_factory=dict, description="Configuration for rate_limit filter"
+        )
+        extra: dict[str, dict[str, Any]] = Field(
+            default_factory=dict,
+            description="Configuration for third-party filters by name",
+        )
+
     # Plugin configuration (simplified - discovery/registry removed)
     class PluginsSettings(BaseModel):
         """Settings controlling plugin behavior."""
@@ -592,6 +613,9 @@ class Settings(BaseSettings):
     )
     redactor_config: RedactorConfig = Field(
         default_factory=RedactorConfig, description="Per-redactor plugin configuration"
+    )
+    filter_config: FilterConfig = Field(
+        default_factory=FilterConfig, description="Per-filter plugin configuration"
     )
     processor_config: ProcessorConfigSettings = Field(
         default_factory=ProcessorConfigSettings,

--- a/src/fapilog/plugins/__init__.py
+++ b/src/fapilog/plugins/__init__.py
@@ -6,6 +6,7 @@ Provides base protocols for plugin authors.
 
 # Public protocols for plugin authors
 from .enrichers import BaseEnricher
+from .filters import BaseFilter
 from .loader import (
     PluginLoadError,
     PluginNotFoundError,
@@ -31,6 +32,7 @@ __all__ = [
     "BaseProcessor",
     "BaseSink",
     "BaseRedactor",
+    "BaseFilter",
     # Loader helpers
     "load_plugin",
     "list_available_plugins",

--- a/src/fapilog/plugins/filters/__init__.py
+++ b/src/fapilog/plugins/filters/__init__.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import random
+from typing import Iterable, Protocol, runtime_checkable
+
+from ...core import diagnostics
+from ...metrics.metrics import MetricsCollector, plugin_timer
+from ..loader import register_builtin
+from .level import LevelFilter
+from .rate_limit import RateLimitFilter
+from .sampling import SamplingFilter
+
+
+@runtime_checkable
+class BaseFilter(Protocol):
+    """Contract for filters that can drop or transform events before enrichment."""
+
+    name: str
+
+    async def start(self) -> None:
+        """Initialize filter resources (optional)."""
+
+    async def stop(self) -> None:
+        """Release filter resources (optional)."""
+
+    async def filter(self, event: dict) -> dict | None:
+        """Return event to continue or None to drop."""
+
+    async def health_check(self) -> bool:
+        """Return True if healthy."""
+        return True
+
+
+async def filter_in_order(
+    event: dict,
+    filters: Iterable[BaseFilter],
+    *,
+    metrics: MetricsCollector | None = None,
+) -> dict | None:
+    """Apply filters sequentially; return None when any drops the event."""
+    current = dict(event)
+    for f in filters:
+        name = getattr(f, "name", type(f).__name__)
+        try:
+            async with plugin_timer(metrics, name):
+                result = await f.filter(dict(current))
+        except Exception as exc:
+            try:
+                diagnostics.warn(
+                    "filter",
+                    "filter exception",
+                    filter=name,
+                    reason=str(exc),
+                )
+            except Exception:
+                pass
+            continue
+
+        if result is None:
+            if metrics is not None:
+                await metrics.record_events_filtered(1)
+            return None
+        current = result
+    return current
+
+
+# Register built-ins with legacy aliases
+register_builtin("fapilog.filters", "level", LevelFilter)
+register_builtin("fapilog.filters", "sampling", SamplingFilter)
+register_builtin(
+    "fapilog.filters",
+    "rate_limit",
+    RateLimitFilter,
+    aliases=["rate-limit"],
+)
+
+# Touch random to quiet linters about unused imports (used in sampling filter)
+_ = random.random
+
+__all__ = [
+    "BaseFilter",
+    "filter_in_order",
+    "LevelFilter",
+    "SamplingFilter",
+    "RateLimitFilter",
+]

--- a/src/fapilog/plugins/filters/level.py
+++ b/src/fapilog/plugins/filters/level.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+LEVEL_PRIORITY = {
+    "DEBUG": 10,
+    "INFO": 20,
+    "WARNING": 30,
+    "WARN": 30,
+    "ERROR": 40,
+    "CRITICAL": 50,
+    "FATAL": 50,
+}
+
+
+@dataclass
+class LevelFilterConfig:
+    min_level: str = "INFO"
+    drop_below: bool = True
+
+
+class LevelFilter:
+    """Filter events by log level threshold."""
+
+    name = "level"
+
+    def __init__(
+        self, *, config: LevelFilterConfig | dict | None = None, **kwargs: Any
+    ) -> None:
+        if isinstance(config, dict):
+            raw = config.get("config", config)
+            cfg = LevelFilterConfig(**raw)
+        elif config is None:
+            raw_kwargs = kwargs.get("config", kwargs)
+            cfg = LevelFilterConfig(**raw_kwargs) if raw_kwargs else LevelFilterConfig()
+        else:
+            cfg = config
+        self._min_priority = LEVEL_PRIORITY.get(cfg.min_level.upper(), 20)
+        self._drop_below = bool(cfg.drop_below)
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def filter(self, event: dict) -> dict | None:
+        level = str(event.get("level", "INFO")).upper()
+        priority = LEVEL_PRIORITY.get(level, 20)
+        if self._drop_below and priority < self._min_priority:
+            return None
+        return event
+
+    async def health_check(self) -> bool:
+        return True
+
+
+PLUGIN_METADATA = {
+    "name": "level",
+    "version": "1.0.0",
+    "plugin_type": "filter",
+    "entry_point": "fapilog.plugins.filters.level:LevelFilter",
+    "description": "Filter events by minimum level threshold.",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.4.0"},
+    "api_version": "1.0",
+}

--- a/src/fapilog/plugins/filters/rate_limit.py
+++ b/src/fapilog/plugins/filters/rate_limit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class RateLimitFilterConfig:
+    capacity: int = 10  # tokens
+    refill_rate_per_sec: float = 5.0  # tokens per second
+    key_field: str | None = None  # event key used to partition buckets
+
+
+class RateLimitFilter:
+    """Token-bucket rate limiter."""
+
+    name = "rate_limit"
+
+    def __init__(
+        self, *, config: RateLimitFilterConfig | dict | None = None, **kwargs: Any
+    ) -> None:
+        if isinstance(config, dict):
+            raw = config.get("config", config)
+            cfg = RateLimitFilterConfig(**raw)
+        elif config is None:
+            raw_kwargs = kwargs.get("config", kwargs)
+            cfg = (
+                RateLimitFilterConfig(**raw_kwargs)
+                if raw_kwargs
+                else RateLimitFilterConfig()
+            )
+        else:
+            cfg = config
+        self._capacity = max(1, int(cfg.capacity))
+        self._refill_rate = max(0.0, float(cfg.refill_rate_per_sec))
+        self._key_field = cfg.key_field
+        self._buckets: dict[str, tuple[float, float]] = {}  # key -> (tokens, ts)
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def filter(self, event: dict) -> dict | None:
+        key = self._resolve_key(event)
+        now = time.monotonic()
+        tokens, last = self._buckets.get(key, (self._capacity, now))
+        # Refill
+        elapsed = max(0.0, now - last)
+        tokens = min(self._capacity, tokens + elapsed * self._refill_rate)
+        if tokens < 1.0:
+            self._buckets[key] = (tokens, now)
+            return None
+        tokens -= 1.0
+        self._buckets[key] = (tokens, now)
+        return event
+
+    def _resolve_key(self, event: dict) -> str:
+        if not self._key_field:
+            return "global"
+        return str(event.get(self._key_field, "global"))
+
+    async def health_check(self) -> bool:
+        return True
+
+
+PLUGIN_METADATA = {
+    "name": "rate_limit",
+    "version": "1.0.0",
+    "plugin_type": "filter",
+    "entry_point": "fapilog.plugins.filters.rate_limit:RateLimitFilter",
+    "description": "Token bucket rate limiter filter.",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.4.0"},
+    "api_version": "1.0",
+}

--- a/src/fapilog/plugins/filters/sampling.py
+++ b/src/fapilog/plugins/filters/sampling.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class SamplingFilterConfig:
+    sample_rate: float = 1.0
+    seed: int | None = None
+
+
+class SamplingFilter:
+    """Probabilistic sampling filter."""
+
+    name = "sampling"
+
+    def __init__(
+        self, *, config: SamplingFilterConfig | dict | None = None, **kwargs: Any
+    ) -> None:
+        if isinstance(config, dict):
+            raw = config.get("config", config)
+            cfg = SamplingFilterConfig(**raw)
+        elif config is None:
+            raw_kwargs = kwargs.get("config", kwargs)
+            cfg = (
+                SamplingFilterConfig(**raw_kwargs)
+                if raw_kwargs
+                else SamplingFilterConfig()
+            )
+        else:
+            cfg = config
+        self._rate = max(0.0, min(1.0, float(cfg.sample_rate)))
+        if cfg.seed is not None:
+            random.seed(cfg.seed)
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def filter(self, event: dict) -> dict | None:
+        if self._rate >= 1.0:
+            return event
+        if self._rate <= 0.0:
+            return None
+        return event if random.random() < self._rate else None
+
+    async def health_check(self) -> bool:
+        return True
+
+
+PLUGIN_METADATA = {
+    "name": "sampling",
+    "version": "1.0.0",
+    "plugin_type": "filter",
+    "entry_point": "fapilog.plugins.filters.sampling:SamplingFilter",
+    "description": "Probabilistic sampling filter.",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.4.0"},
+    "api_version": "1.0",
+}

--- a/src/fapilog/plugins/health.py
+++ b/src/fapilog/plugins/health.py
@@ -86,6 +86,7 @@ async def aggregate_plugin_health(
     redactors: list[Any],
     sinks: list[Any],
     processors: list[Any] | None = None,
+    filters: list[Any] | None = None,
     *,
     timeout_seconds: float = 5.0,
 ) -> AggregatedHealth:
@@ -102,6 +103,8 @@ async def aggregate_plugin_health(
     """
     plugin_healths: list[PluginHealth] = []
 
+    for f in filters or []:
+        plugin_healths.append(await check_plugin_health(f, "filter", timeout_seconds))
     for p in processors or []:
         plugin_healths.append(
             await check_plugin_health(p, "processor", timeout_seconds)

--- a/src/fapilog/plugins/loader.py
+++ b/src/fapilog/plugins/loader.py
@@ -64,6 +64,7 @@ BUILTIN_SINKS: dict[str, type] = {}
 BUILTIN_ENRICHERS: dict[str, type] = {}
 BUILTIN_REDACTORS: dict[str, type] = {}
 BUILTIN_PROCESSORS: dict[str, type] = {}
+BUILTIN_FILTERS: dict[str, type] = {}
 
 # Optional alias mapping per group (alias -> canonical name)
 BUILTIN_ALIASES: dict[str, dict[str, str]] = {
@@ -71,6 +72,7 @@ BUILTIN_ALIASES: dict[str, dict[str, str]] = {
     "fapilog.enrichers": {},
     "fapilog.redactors": {},
     "fapilog.processors": {},
+    "fapilog.filters": {},
 }
 
 
@@ -119,6 +121,7 @@ def _validate_plugin(instance: Any, group: str, mode: ValidationMode) -> bool:
     """Validate a plugin against its protocol."""
     from ..testing.validators import (
         validate_enricher,
+        validate_filter,
         validate_processor,
         validate_redactor,
         validate_sink,
@@ -129,6 +132,7 @@ def _validate_plugin(instance: Any, group: str, mode: ValidationMode) -> bool:
         "fapilog.enrichers": validate_enricher,
         "fapilog.redactors": validate_redactor,
         "fapilog.processors": validate_processor,
+        "fapilog.filters": validate_filter,
     }
     validator = validator_map.get(group)
     if validator is None:
@@ -245,6 +249,7 @@ def _registry_for_group(group: str) -> dict[str, type] | None:
         "fapilog.enrichers": BUILTIN_ENRICHERS,
         "fapilog.redactors": BUILTIN_REDACTORS,
         "fapilog.processors": BUILTIN_PROCESSORS,
+        "fapilog.filters": BUILTIN_FILTERS,
     }.get(group)
 
 

--- a/src/fapilog/plugins/utils.py
+++ b/src/fapilog/plugins/utils.py
@@ -81,6 +81,8 @@ def get_plugin_type(plugin: Any) -> str:
         return "enricher"
     elif hasattr(plugin, "redact"):
         return "redactor"
+    elif hasattr(plugin, "filter"):
+        return "filter"
     elif hasattr(plugin, "process"):
         return "processor"
     return "unknown"

--- a/tests/unit/test_core_log_level_wiring.py
+++ b/tests/unit/test_core_log_level_wiring.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog import Settings, _build_pipeline
+from fapilog.core.worker import LoggerWorker, strict_envelope_mode_enabled
+from fapilog.metrics.metrics import MetricsCollector
+from fapilog.plugins.filters import BaseFilter
+
+
+class CaptureFilter(BaseFilter):
+    name = "capture"
+
+    def __init__(self) -> None:
+        self.seen = []
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def filter(self, event: dict) -> dict | None:
+        self.seen.append(event)
+        return event
+
+
+@pytest.mark.asyncio
+async def test_core_log_level_auto_injects_level_filter() -> None:
+    settings = Settings(core={"log_level": "INFO", "enable_metrics": True})
+    sinks, enrichers, redactors, processors, filters, metrics = _build_pipeline(
+        settings
+    )
+    names = [getattr(f, "name", "") for f in filters]
+    assert "level" in names
+
+
+@pytest.mark.asyncio
+async def test_level_filter_drops_debug_before_enrichers(monkeypatch) -> None:
+    metrics = MetricsCollector(enabled=True)
+    captured = []
+
+    class DummySink:
+        async def write(self, entry: dict) -> None:
+            captured.append(entry)
+
+    settings = Settings(core={"log_level": "INFO", "enable_metrics": True})
+    sinks, enrichers, redactors, processors, filters, metrics = _build_pipeline(
+        settings
+    )
+
+    worker = LoggerWorker(
+        queue=None,  # type: ignore[arg-type]
+        batch_max_size=1,
+        batch_timeout_seconds=0.01,
+        sink_write=DummySink().write,
+        sink_write_serialized=None,
+        filters_getter=lambda: filters,
+        enrichers_getter=lambda: enrichers,
+        redactors_getter=lambda: redactors,
+        processors_getter=lambda: processors,
+        metrics=metrics,
+        serialize_in_flush=False,
+        strict_envelope_mode_provider=strict_envelope_mode_enabled,
+        stop_flag=lambda: False,
+        drained_event=None,
+        flush_event=None,
+        flush_done_event=None,
+        emit_filter_diagnostics=True,
+        emit_enricher_diagnostics=True,
+        emit_redactor_diagnostics=True,
+        emit_processor_diagnostics=True,
+        counters={"processed": 0, "dropped": 0},
+    )
+
+    debug_evt = {
+        "level": "DEBUG",
+        "message": "drop me",
+        "context": {},
+        "diagnostics": {},
+    }
+    info_evt = {"level": "INFO", "message": "keep me", "context": {}, "diagnostics": {}}
+    await worker.flush_batch([debug_evt, info_evt])
+
+    snap = await metrics.snapshot()
+    assert snap.events_filtered == 1
+    assert len(captured) == 1
+    assert captured[0]["message"] == "keep me"

--- a/tests/unit/test_filters_level.py
+++ b/tests/unit/test_filters_level.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog.plugins.filters.level import LevelFilter, LevelFilterConfig
+
+
+@pytest.mark.asyncio
+async def test_level_filter_drops_below_threshold() -> None:
+    filt = LevelFilter(config=LevelFilterConfig(min_level="INFO"))
+    assert await filt.filter({"level": "DEBUG"}) is None
+    assert await filt.filter({"level": "info"}) == {"level": "info"}
+    assert await filt.filter({"level": "WARNING"}) == {"level": "WARNING"}
+
+
+@pytest.mark.asyncio
+async def test_level_filter_drop_below_false_keeps_all() -> None:
+    filt = LevelFilter(config=LevelFilterConfig(min_level="ERROR", drop_below=False))
+    evt = {"level": "DEBUG", "msg": "keep"}
+    assert await filt.filter(evt) == evt

--- a/tests/unit/test_filters_pipeline.py
+++ b/tests/unit/test_filters_pipeline.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog.core.concurrency import NonBlockingRingQueue
+from fapilog.core.events import LogEvent
+from fapilog.core.worker import LoggerWorker, strict_envelope_mode_enabled
+from fapilog.metrics.metrics import MetricsCollector
+from fapilog.plugins.filters import BaseFilter, filter_in_order
+
+
+class DropAllFilter(BaseFilter):
+    name = "drop_all"
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def filter(self, event: dict) -> dict | None:  # noqa: D401
+        return None
+
+
+class AppendFieldFilter(BaseFilter):
+    name = "append_field"
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def filter(self, event: dict) -> dict | None:  # noqa: D401
+        new = dict(event)
+        new["filtered"] = True
+        return new
+
+
+class ErrorFilter(BaseFilter):
+    name = "error"
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def filter(self, event: dict) -> dict | None:  # noqa: D401
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_filter_in_order_drops_and_short_circuits() -> None:
+    metrics = MetricsCollector(enabled=True)
+    event = {"level": "INFO"}
+    result = await filter_in_order(
+        event,
+        [AppendFieldFilter(), DropAllFilter(), AppendFieldFilter()],
+        metrics=metrics,
+    )
+    assert result is None
+    snap = await metrics.snapshot()
+    assert snap.events_filtered == 1
+
+
+@pytest.mark.asyncio
+async def test_filter_in_order_contains_errors_and_continues(monkeypatch) -> None:
+    warned: list[dict] = []
+
+    def fake_warn(_c, _m, **attrs):
+        warned.append(attrs)
+
+    monkeypatch.setattr("fapilog.plugins.filters.diagnostics.warn", fake_warn)
+
+    event = {"level": "INFO"}
+    out = await filter_in_order(
+        event,
+        [ErrorFilter(), AppendFieldFilter()],
+        metrics=None,
+    )
+    assert out is not None and out.get("filtered") is True
+    assert warned and warned[-1]["filter"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_worker_applies_filters_before_enrichers(monkeypatch) -> None:
+    queue: NonBlockingRingQueue[dict[str, object]] = NonBlockingRingQueue(capacity=2)
+    counters = {"processed": 0, "dropped": 0}
+    metrics = MetricsCollector(enabled=True)
+    events: list[dict] = []
+
+    async def sink_write(entry: dict[str, object]) -> None:
+        events.append(entry)
+
+    # Ensure enrichers not called if filter drops
+    class EnricherCalled(Exception):
+        pass
+
+    async def enricher(event: dict) -> dict:
+        raise EnricherCalled
+
+    worker = LoggerWorker(
+        queue=queue,
+        batch_max_size=2,
+        batch_timeout_seconds=0.01,
+        sink_write=sink_write,
+        sink_write_serialized=None,
+        filters_getter=lambda: [DropAllFilter()],
+        enrichers_getter=lambda: [enricher],  # type: ignore[list-item]
+        redactors_getter=lambda: [],
+        processors_getter=lambda: [],
+        metrics=metrics,
+        serialize_in_flush=False,
+        strict_envelope_mode_provider=strict_envelope_mode_enabled,
+        stop_flag=lambda: False,
+        drained_event=None,
+        flush_event=None,
+        flush_done_event=None,
+        emit_filter_diagnostics=True,
+        emit_enricher_diagnostics=True,
+        emit_redactor_diagnostics=True,
+        emit_processor_diagnostics=True,
+        counters=counters,
+    )
+
+    evt = LogEvent(level="DEBUG", message="msg").to_mapping()
+    await worker.flush_batch([evt])
+
+    assert events == []  # dropped
+    snap = await metrics.snapshot()
+    assert snap.events_filtered == 1

--- a/tests/unit/test_filters_sampling.py
+++ b/tests/unit/test_filters_sampling.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog.plugins.filters.sampling import SamplingFilter, SamplingFilterConfig
+
+
+@pytest.mark.asyncio
+async def test_sampling_filter_all_or_none() -> None:
+    keep_all = SamplingFilter(config=SamplingFilterConfig(sample_rate=1.0, seed=42))
+    drop_all = SamplingFilter(config=SamplingFilterConfig(sample_rate=0.0, seed=42))
+
+    evt = {"level": "INFO"}
+    assert await keep_all.filter(evt) == evt
+    assert await drop_all.filter(evt) is None
+
+
+@pytest.mark.asyncio
+async def test_sampling_filter_probabilistic_with_seed() -> None:
+    filt = SamplingFilter(config=SamplingFilterConfig(sample_rate=0.5, seed=1234))
+    kept = 0
+    total = 200
+    for _ in range(total):
+        if await filt.filter({"level": "INFO"}):
+            kept += 1
+    assert 60 < kept < 140

--- a/tests/unit/test_plugin_lifecycle.py
+++ b/tests/unit/test_plugin_lifecycle.py
@@ -324,7 +324,7 @@ async def test_async_logger_starts_enrichers(monkeypatch):
 
     # Patch _build_pipeline to return our test enricher
     def mock_build_pipeline(settings):
-        return [], [enricher], [], [], None
+        return [], [enricher], [], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -340,7 +340,7 @@ async def test_async_logger_starts_redactors(monkeypatch):
     redactor = TrackingRedactor()
 
     def mock_build_pipeline(settings):
-        return [], [], [redactor], [], None
+        return [], [], [redactor], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -356,7 +356,7 @@ async def test_async_logger_starts_processors(monkeypatch):
     processor = TrackingProcessor()
 
     def mock_build_pipeline(settings):
-        return [], [], [], [processor], None
+        return [], [], [], [processor], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -373,7 +373,7 @@ async def test_async_logger_excludes_failed_enrichers(monkeypatch):
     working = TrackingEnricher()
 
     def mock_build_pipeline(settings):
-        return [], [failing, working], [], [], None
+        return [], [failing, working], [], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -392,7 +392,7 @@ async def test_async_logger_stops_enrichers_on_drain(monkeypatch):
     enricher = TrackingEnricher()
 
     def mock_build_pipeline(settings):
-        return [], [enricher], [], [], None
+        return [], [enricher], [], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -411,7 +411,7 @@ async def test_async_logger_stops_redactors_on_drain(monkeypatch):
     redactor = TrackingRedactor()
 
     def mock_build_pipeline(settings):
-        return [], [], [redactor], [], None
+        return [], [], [redactor], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -430,7 +430,7 @@ async def test_async_logger_stops_processors_on_drain(monkeypatch):
     processor = TrackingProcessor()
 
     def mock_build_pipeline(settings):
-        return [], [], [], [processor], None
+        return [], [], [], [processor], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -455,7 +455,7 @@ def test_sync_logger_starts_enrichers(monkeypatch):
     enricher = TrackingEnricher()
 
     def mock_build_pipeline(settings):
-        return [], [enricher], [], [], None
+        return [], [enricher], [], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -472,7 +472,7 @@ def test_sync_logger_starts_redactors(monkeypatch):
     redactor = TrackingRedactor()
 
     def mock_build_pipeline(settings):
-        return [], [], [redactor], [], None
+        return [], [], [redactor], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -489,7 +489,7 @@ def test_sync_logger_starts_processors(monkeypatch):
     processor = TrackingProcessor()
 
     def mock_build_pipeline(settings):
-        return [], [], [], [processor], None
+        return [], [], [], [processor], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -507,7 +507,7 @@ def test_sync_logger_excludes_failed_enrichers(monkeypatch):
     working = TrackingEnricher()
 
     def mock_build_pipeline(settings):
-        return [], [failing, working], [], [], None
+        return [], [failing, working], [], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -526,7 +526,7 @@ def test_sync_logger_stops_enrichers_on_drain(monkeypatch):
     enricher = TrackingEnricher()
 
     def mock_build_pipeline(settings):
-        return [], [enricher], [], [], None
+        return [], [enricher], [], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -546,7 +546,7 @@ def test_sync_logger_stops_processors_on_drain(monkeypatch):
     processor = TrackingProcessor()
 
     def mock_build_pipeline(settings):
-        return [], [], [], [processor], None
+        return [], [], [], [processor], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -571,7 +571,7 @@ async def test_stop_failure_does_not_prevent_other_stops(monkeypatch):
     working = TrackingEnricher()
 
     def mock_build_pipeline(settings):
-        return [], [failing, working], [], [], None
+        return [], [failing, working], [], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -599,7 +599,7 @@ async def test_enricher_without_lifecycle_still_works(monkeypatch):
     enricher = NoLifecycleEnricher()
 
     def mock_build_pipeline(settings):
-        return [], [enricher], [], [], None
+        return [], [enricher], [], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 
@@ -618,7 +618,7 @@ async def test_redactor_without_lifecycle_still_works(monkeypatch):
     redactor = NoLifecycleRedactor()
 
     def mock_build_pipeline(settings):
-        return [], [], [redactor], [], None
+        return [], [], [redactor], [], [], None
 
     monkeypatch.setattr("fapilog._build_pipeline", mock_build_pipeline)
 

--- a/tests/unit/test_story430_protocol_name_attribute.py
+++ b/tests/unit/test_story430_protocol_name_attribute.py
@@ -6,7 +6,13 @@ Story 4.30: Plugin API Standardization and Testing Documentation
 
 from __future__ import annotations
 
-from fapilog.plugins import BaseEnricher, BaseProcessor, BaseRedactor, BaseSink
+from fapilog.plugins import (
+    BaseEnricher,
+    BaseFilter,
+    BaseProcessor,
+    BaseRedactor,
+    BaseSink,
+)
 
 
 class TestProtocolsHaveNameAttribute:
@@ -157,3 +163,43 @@ class TestIsinstanceChecksWithName:
 
         processor = _ProcessorWithoutName()
         assert not isinstance(processor, BaseProcessor)
+
+    def test_filter_with_name_satisfies_protocol(self) -> None:
+        """Filter with name should satisfy BaseFilter protocol."""
+
+        class _FilterWithName:
+            name = "filter"
+
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def filter(self, event: dict) -> dict | None:
+                return event
+
+            async def health_check(self) -> bool:
+                return True
+
+        f = _FilterWithName()
+        assert isinstance(f, BaseFilter)
+
+    def test_filter_without_name_fails_protocol(self) -> None:
+        """Filter without name should NOT satisfy BaseFilter protocol."""
+
+        class _FilterWithoutName:
+            async def start(self) -> None:
+                pass
+
+            async def stop(self) -> None:
+                pass
+
+            async def filter(self, event: dict) -> dict | None:
+                return event
+
+            async def health_check(self) -> bool:
+                return True
+
+        f = _FilterWithoutName()
+        assert not isinstance(f, BaseFilter)

--- a/tests/unit/test_tamper_plugin_standard.py
+++ b/tests/unit/test_tamper_plugin_standard.py
@@ -139,6 +139,9 @@ async def test_standard_tamper_configs_flow_into_pipeline(
             return _DummySink(**(config or {}))
         if group == "fapilog.enrichers":
             return _DummyEnricher(**(config or {}))
+        if group in ("fapilog.redactors", "fapilog.processors", "fapilog.filters"):
+            # Return a minimal mock for these groups
+            return None
         raise AssertionError(f"unexpected group {group}")
 
     monkeypatch.setattr("fapilog.plugins.loader.load_plugin", _fake_load)


### PR DESCRIPTION
## Summary

Introduces a new **Filter** plugin type for filtering log events before enrichment, implementing Story 5.2.

## New Plugin Type: Filter

- `BaseFilter` protocol with `filter(event) -> dict | None`
- Filters run **BEFORE** enrichers in the pipeline
- Filter returning `None` drops the event
- Error containment: filter errors don't crash the pipeline

## Built-in Filters

| Filter | Description |
|--------|-------------|
| `LevelFilter` | Drop events below configured level threshold |
| `SamplingFilter` | Random probability sampling |
| `RateLimitFilter` | Token bucket rate limiting with per-key support |

## core.log_level Wiring

- Auto-injects `LevelFilter` when `core.log_level` is set
- Fast-path level gate in `_enqueue()` for efficiency
- DEBUG logs dropped before queue when `log_level=INFO+`

## Metrics

- Added `events_filtered` counter to MetricsCollector
- Added `fapilog_events_filtered_total` Prometheus metric

## Configuration

```yaml
core:
  filters: ["level", "sampling"]

filter_config:
  level:
    min_level: INFO
  sampling:
    sample_rate: 0.5
```

## Pipeline Order

```
Queue → Filters → Enrichers → Redactors → Serialize → Processors → Sinks
```

## Files Changed

- 30 files changed
- 952 insertions, 40 deletions
- New filter plugin module with 3 built-in filters
- Comprehensive unit tests

## Related

- Story 5.2: Add Filter Plugin Type
- Closes #52