### PR TITLE
feat(plugins): add enhanced sampling and rate limiting filters (Story 5.3)

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -49,10 +49,13 @@
 | `FAPILOG__ENRICHER_CONFIG__INTEGRITY__ROTATE_CHAIN` | bool | False | Reset chain after rotation |
 | `FAPILOG__ENRICHER_CONFIG__INTEGRITY__USE_KMS_SIGNING` | bool | False | Sign integrity hashes via KMS provider |
 | `FAPILOG__ENRICHER_CONFIG__RUNTIME_INFO` | dict | PydanticUndefined | Configuration for runtime_info enricher |
+| `FAPILOG__FILTER_CONFIG__ADAPTIVE_SAMPLING` | dict | PydanticUndefined | Configuration for adaptive_sampling filter |
 | `FAPILOG__FILTER_CONFIG__EXTRA` | dict | PydanticUndefined | Configuration for third-party filters by name |
+| `FAPILOG__FILTER_CONFIG__FIRST_OCCURRENCE` | dict | PydanticUndefined | Configuration for first_occurrence filter |
 | `FAPILOG__FILTER_CONFIG__LEVEL` | dict | PydanticUndefined | Configuration for level filter |
 | `FAPILOG__FILTER_CONFIG__RATE_LIMIT` | dict | PydanticUndefined | Configuration for rate_limit filter |
 | `FAPILOG__FILTER_CONFIG__SAMPLING` | dict | PydanticUndefined | Configuration for sampling filter |
+| `FAPILOG__FILTER_CONFIG__TRACE_SAMPLING` | dict | PydanticUndefined | Configuration for trace_sampling filter |
 | `FAPILOG__HTTP__ENDPOINT` | str | None | — | HTTP endpoint to POST log events to |
 | `FAPILOG__HTTP__HEADERS` | dict | PydanticUndefined | Default headers to send with each request |
 | `FAPILOG__HTTP__HEADERS_JSON` | str | None | — | JSON-encoded headers map (e.g. '{"Authorization": "Bearer x"}') |

--- a/docs/examples/sampling-debug-logs.md
+++ b/docs/examples/sampling-debug-logs.md
@@ -1,10 +1,12 @@
 # Sampling Debug Logs
 
-Reduce debug/info volume with sampling.
+Use filter-based sampling to trim DEBUG/INFO noise while keeping critical signals intact.
+
+## Probabilistic sampling (20%)
 
 ```bash
-# Keep 20% of DEBUG/INFO logs; WARN/ERROR unaffected
-export FAPILOG_OBSERVABILITY__LOGGING__SAMPLING_RATE=0.2
+export FAPILOG_CORE__FILTERS='["sampling"]'
+export FAPILOG_FILTER_CONFIG__SAMPLING__CONFIG__SAMPLE_RATE=0.2
 ```
 
 ```python
@@ -13,5 +15,30 @@ from fapilog import get_async_logger
 logger = await get_async_logger()
 await logger.debug("expensive debug payload", detail="...")
 await logger.info("high-volume event")
-# Sampling applies only to DEBUG/INFO
+# Sampling applies only to DEBUG/INFO; WARN/ERROR always pass.
 ```
+
+## Adaptive sampling (target EPS)
+
+Keep a representative sample at high volume, ramp up sampling during quiet periods.
+
+```bash
+export FAPILOG_CORE__FILTERS='["adaptive_sampling"]'
+export FAPILOG_FILTER_CONFIG__ADAPTIVE_SAMPLING__CONFIG__TARGET_EPS=150
+export FAPILOG_FILTER_CONFIG__ADAPTIVE_SAMPLING__CONFIG__MIN_SAMPLE_RATE=0.01
+export FAPILOG_FILTER_CONFIG__ADAPTIVE_SAMPLING__CONFIG__MAX_SAMPLE_RATE=1.0
+```
+
+## Trace-aware sampling
+
+Ensure whole traces stay together:
+
+```bash
+export FAPILOG_CORE__FILTERS='["trace_sampling"]'
+export FAPILOG_FILTER_CONFIG__TRACE_SAMPLING__CONFIG__SAMPLE_RATE=0.15
+export FAPILOG_FILTER_CONFIG__TRACE_SAMPLING__CONFIG__TRACE_ID_FIELD=trace_id
+```
+
+## Migration note
+
+The legacy `observability.logging.sampling_rate` setting now emits a `DeprecationWarning`. Switch to `core.filters=["sampling"]` (or `adaptive_sampling` / `trace_sampling`) with the corresponding `filter_config.*` block to avoid double-sampling and to expose sampling metrics.

--- a/docs/plugins/configuration.md
+++ b/docs/plugins/configuration.md
@@ -22,7 +22,7 @@ This guide explains the new configuration-driven plugin wiring introduced in Sto
   - `redactor_config.regex_mask`: patterns, mask string, guardrails
   - `redactor_config.url_credentials`: max string length
   - `processor_config.zero_copy`: reserved for zero_copy options; third-party configs via `processor_config.extra`
-  - `filter_config.level/sampling/rate_limit`: built-in filters; third-party configs via `filter_config.extra`
+  - `filter_config.level/sampling/adaptive_sampling/trace_sampling/first_occurrence/rate_limit`: built-in filters; third-party configs via `filter_config.extra`
   - Third-party plugins use `extra` maps (`sink_config.extra`, `enricher_config.extra`, `redactor_config.extra`, `processor_config.extra`) with arbitrary keys.
 
 ### Environment Examples

--- a/docs/plugins/filters.md
+++ b/docs/plugins/filters.md
@@ -2,6 +2,14 @@
 
 Filters run first in the pipeline. They can drop an event (return `None`) or mutate it before enrichers run.
 
+```{toctree}
+:maxdepth: 1
+:caption: Filter Guides
+
+filters/sampling
+filters/rate-limiting
+```
+
 ## Contract
 
 - `name: str`
@@ -13,7 +21,10 @@ Filters run first in the pipeline. They can drop an event (return `None`) or mut
 
 - `level`: drop events below a minimum level.
 - `sampling`: probabilistic sampling with optional seed.
-- `rate_limit`: token-bucket rate limiting with optional key partitioning.
+- `adaptive_sampling`: adjust sampling to hit a target events-per-second window.
+- `trace_sampling`: deterministic sampling keyed by `trace_id`.
+- `first_occurrence`: always pass the first occurrence of a unique key, then sample duplicates.
+- `rate_limit`: token-bucket rate limiting with optional key partitioning and max bucket guardrails.
 
 ## Configuration
 

--- a/docs/plugins/filters/rate-limiting.md
+++ b/docs/plugins/filters/rate-limiting.md
@@ -1,0 +1,29 @@
+# Rate Limiting Filter
+
+The `rate_limit` filter applies a token-bucket limit before enrichment. It now supports bounded bucket counts, configurable overflow handling, and diagnostics when nearing capacity.
+
+## Configuration
+
+```yaml
+core:
+  filters: ["rate_limit"]
+filter_config:
+  rate_limit:
+    config:
+      capacity: 10            # tokens per bucket
+      refill_rate_per_sec: 5  # tokens/second
+      key_field: user_id      # optional per-key isolation
+      max_keys: 10000         # bounded bucket count (LRU eviction)
+      overflow_action: drop   # drop | mark
+```
+
+- **capacity / refill_rate_per_sec**: classic token-bucket controls.
+- **key_field**: partitions buckets (e.g., per user, tenant, API key). Omit for a global bucket.
+- **max_keys**: bounds memory; oldest buckets evict when the limit is reached.
+- **overflow_action**: set to `mark` to keep the event but annotate it with `rate_limited=True` instead of dropping.
+
+## Health & diagnostics
+
+- `health_check()` returns `False` when tracked keys exceed 90% of `max_keys` and emits a diagnostic warning.
+- Gauge `fapilog_rate_limit_keys_tracked` reports current bucket count when metrics are enabled.
+- Drops still increment `fapilog_events_filtered_total`.

--- a/docs/plugins/filters/sampling.md
+++ b/docs/plugins/filters/sampling.md
@@ -1,0 +1,106 @@
+# Sampling Filters
+
+Plugin-based sampling replaces the legacy `observability.logging.sampling_rate` knob with explicit, composable filters. Sampling now plugs into the filter stage, so you can combine probabilistic, adaptive, and trace-aware strategies without touching core logger code.
+
+## Quick start
+
+```python
+from fapilog import Settings, get_logger
+
+settings = Settings()
+settings.core.filters = ["sampling"]
+settings.filter_config.sampling = {"config": {"sample_rate": 0.2}}
+
+logger = get_logger(settings=settings)
+logger.debug("kept with 20% probability")
+```
+
+### Adaptive sampling (`adaptive_sampling`)
+
+Target a steady events-per-second rate and let the filter adjust up or down inside configured bounds.
+
+```yaml
+core:
+  filters: ["adaptive_sampling"]
+filter_config:
+  adaptive_sampling:
+    config:
+      target_eps: 100        # desired events/sec
+      min_sample_rate: 0.01  # never drop more than 99%
+      max_sample_rate: 1.0   # never oversample
+      window_seconds: 10
+      smoothing_factor: 0.3  # how quickly to react
+      always_pass_levels: ["ERROR", "CRITICAL"]
+```
+
+### Trace-aware sampling (`trace_sampling`)
+
+Deterministically include or drop entire traces based on `trace_id`, with a random fallback when no trace context is present.
+
+```yaml
+core:
+  filters: ["trace_sampling"]
+filter_config:
+  trace_sampling:
+    config:
+      sample_rate: 0.15
+      trace_id_field: trace_id
+      always_pass_levels: ["ERROR", "CRITICAL"]
+```
+
+### First-occurrence sampling (`first_occurrence`)
+
+Ensure the first occurrence of a message (or custom key) always lands, then sample subsequent duplicates.
+
+```yaml
+core:
+  filters: ["first_occurrence"]
+filter_config:
+  first_occurrence:
+    config:
+      key_fields: ["message"]    # fields that define uniqueness
+      window_seconds: 60         # eviction window
+      max_keys: 10000            # bounded memory (LRU)
+      subsequent_sample_rate: 0  # drop later duplicates; >0 to sample
+```
+
+## Metrics
+
+- `fapilog_filter_sample_rate` (gauge, labeled by `filter`) tracks the current sampling rate reported by sampling filters.
+- Sampling filters run before enrichers and redactors; drops increment `fapilog_events_filtered_total`.
+
+## Migration from legacy sampling
+
+The legacy `observability.logging.sampling_rate` setting is deprecated and now emits a `DeprecationWarning` when used. Move to filter-based sampling to avoid double-sampling and gain observability.
+
+**Before (deprecated):**
+
+```yaml
+observability:
+  logging:
+    sampling_rate: 0.25
+```
+
+**After (recommended):**
+
+```yaml
+core:
+  filters: ["sampling"]
+filter_config:
+  sampling:
+    config:
+      sample_rate: 0.25
+```
+
+If you need adaptive behavior, swap the filter name and config:
+
+```yaml
+core:
+  filters: ["adaptive_sampling"]
+filter_config:
+  adaptive_sampling:
+    config:
+      target_eps: 100
+      min_sample_rate: 0.01
+      max_sample_rate: 1.0
+```

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -11,6 +11,7 @@ contracts-and-versioning
 redactors
 sinks
 enrichers
+filters
 processors
 configuration
 health-checks

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -40,6 +40,19 @@ logger.info("configured", queue=settings.core.max_queue_size)
 - **HTTP sink**: set `FAPILOG_HTTP__ENDPOINT` and optional timeout/retry envs.
 - **Metrics**: set `FAPILOG_CORE__ENABLE_METRICS=true` to record internal metrics.
 
+## Deprecated setting: legacy sampling
+
+`observability.logging.sampling_rate` is deprecated and now raises a `DeprecationWarning`. Move to filter-based sampling to avoid double-sampling and to unlock sampling metrics:
+
+```yaml
+core:
+  filters: ["sampling"]
+filter_config:
+  sampling:
+    config:
+      sample_rate: 0.25
+```
+
 ## Full reference
 
 See `docs/env-vars.md` for the auto-generated environment variable matrix.

--- a/src/fapilog/__init__.py
+++ b/src/fapilog/__init__.py
@@ -161,6 +161,9 @@ def _filter_configs(settings: _Settings) -> dict[str, dict[str, Any]]:
         "level": fcfg.level,
         "sampling": fcfg.sampling,
         "rate_limit": fcfg.rate_limit,
+        "adaptive_sampling": fcfg.adaptive_sampling,
+        "trace_sampling": fcfg.trace_sampling,
+        "first_occurrence": fcfg.first_occurrence,
     }
     cfg.update(fcfg.extra)
     return cfg

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -577,6 +577,18 @@ class Settings(BaseSettings):
         rate_limit: dict[str, Any] = Field(
             default_factory=dict, description="Configuration for rate_limit filter"
         )
+        adaptive_sampling: dict[str, Any] = Field(
+            default_factory=dict,
+            description="Configuration for adaptive_sampling filter",
+        )
+        trace_sampling: dict[str, Any] = Field(
+            default_factory=dict,
+            description="Configuration for trace_sampling filter",
+        )
+        first_occurrence: dict[str, Any] = Field(
+            default_factory=dict,
+            description="Configuration for first_occurrence filter",
+        )
         extra: dict[str, dict[str, Any]] = Field(
             default_factory=dict,
             description="Configuration for third-party filters by name",

--- a/src/fapilog/plugins/filters/adaptive_sampling.py
+++ b/src/fapilog/plugins/filters/adaptive_sampling.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import random
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class AdaptiveSamplingConfig:
+    """Configuration for adaptive sampling."""
+
+    target_eps: float = 100.0
+    min_sample_rate: float = 0.01
+    max_sample_rate: float = 1.0
+    window_seconds: float = 10.0
+    always_pass_levels: list[str] = field(
+        default_factory=lambda: ["ERROR", "CRITICAL", "FATAL"]
+    )
+    smoothing_factor: float = 0.3
+
+
+class AdaptiveSamplingFilter:
+    """Dynamically adjusts sampling based on recent throughput."""
+
+    name = "adaptive_sampling"
+
+    def __init__(
+        self, *, config: AdaptiveSamplingConfig | dict | None = None, **kwargs: Any
+    ) -> None:
+        cfg = self._parse_config(config, kwargs)
+        self._target_eps = max(0.0, float(cfg.target_eps))
+        self._min_rate = max(0.0, min(1.0, float(cfg.min_sample_rate)))
+        self._max_rate = max(self._min_rate, min(1.0, float(cfg.max_sample_rate)))
+        self._window = max(0.001, float(cfg.window_seconds))
+        self._always_pass = {level.upper() for level in cfg.always_pass_levels}
+        self._smoothing = max(0.0, min(1.0, float(cfg.smoothing_factor)))
+
+        self._current_rate = 1.0
+        self._timestamps: deque[float] = deque()
+        self._last_adjustment = time.monotonic()
+
+    @staticmethod
+    def _parse_config(
+        config: AdaptiveSamplingConfig | dict | None, kwargs: dict[str, Any]
+    ) -> AdaptiveSamplingConfig:
+        if isinstance(config, dict):
+            raw = config.get("config", config)
+            return AdaptiveSamplingConfig(**raw)
+        if config is None:
+            raw_kwargs = kwargs.get("config", kwargs)
+            return (
+                AdaptiveSamplingConfig(**raw_kwargs)
+                if raw_kwargs
+                else AdaptiveSamplingConfig()
+            )
+        return config
+
+    async def start(self) -> None:
+        self._timestamps.clear()
+        self._current_rate = 1.0
+        self._last_adjustment = time.monotonic()
+
+    async def stop(self) -> None:
+        return None
+
+    async def filter(self, event: dict) -> dict | None:
+        level = str(event.get("level", "INFO")).upper()
+
+        if level in self._always_pass:
+            self._record_event()
+            return event
+
+        if random.random() > self._current_rate:
+            return None
+
+        self._record_event()
+        self._maybe_adjust_rate()
+        return event
+
+    def _record_event(self) -> None:
+        now = time.monotonic()
+        self._timestamps.append(now)
+        cutoff = now - self._window
+        while self._timestamps and self._timestamps[0] < cutoff:
+            self._timestamps.popleft()
+
+    def _maybe_adjust_rate(self) -> None:
+        now = time.monotonic()
+        if now - self._last_adjustment < 1.0:
+            return
+
+        self._last_adjustment = now
+
+        if not self._timestamps:
+            current_eps = 0.0
+        else:
+            elapsed = max(now - self._timestamps[0], 0.001)
+            current_eps = len(self._timestamps) / elapsed
+
+        if current_eps <= 0:
+            ideal_rate = self._max_rate
+        else:
+            ideal_rate = self._target_eps / current_eps
+
+        ideal_rate = max(self._min_rate, min(self._max_rate, ideal_rate))
+        self._current_rate = (
+            self._smoothing * ideal_rate + (1.0 - self._smoothing) * self._current_rate
+        )
+
+    @property
+    def current_sample_rate(self) -> float:
+        return self._current_rate
+
+    async def health_check(self) -> bool:
+        return True
+
+
+PLUGIN_METADATA = {
+    "name": "adaptive_sampling",
+    "version": "1.0.0",
+    "plugin_type": "filter",
+    "entry_point": "fapilog.plugins.filters.adaptive_sampling:AdaptiveSamplingFilter",
+    "description": "Dynamically adjusts sample rate based on throughput.",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.4.0"},
+    "api_version": "1.0",
+}

--- a/src/fapilog/plugins/filters/first_occurrence.py
+++ b/src/fapilog/plugins/filters/first_occurrence.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import random
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class FirstOccurrenceConfig:
+    """Configuration for first-occurrence filter."""
+
+    key_fields: list[str] | None = None
+    window_seconds: float = 60.0
+    max_keys: int = 10000
+    subsequent_sample_rate: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.key_fields is None:
+            self.key_fields = ["message"]
+
+
+class FirstOccurrenceFilter:
+    """First occurrence of a unique key always passes."""
+
+    name = "first_occurrence"
+
+    def __init__(
+        self, *, config: FirstOccurrenceConfig | dict | None = None, **kwargs: Any
+    ) -> None:
+        cfg = self._parse_config(config, kwargs)
+        self._key_fields = cfg.key_fields
+        self._window = max(0.0, float(cfg.window_seconds))
+        self._max_keys = max(1, int(cfg.max_keys))
+        self._subsequent_rate = max(0.0, min(1.0, float(cfg.subsequent_sample_rate)))
+        self._seen: OrderedDict[str, float] = OrderedDict()
+
+    @staticmethod
+    def _parse_config(
+        config: FirstOccurrenceConfig | dict | None, kwargs: dict[str, Any]
+    ) -> FirstOccurrenceConfig:
+        if isinstance(config, dict):
+            raw = config.get("config", config)
+            return FirstOccurrenceConfig(**raw)
+        if config is None:
+            raw_kwargs = kwargs.get("config", kwargs)
+            return (
+                FirstOccurrenceConfig(**raw_kwargs)
+                if raw_kwargs
+                else FirstOccurrenceConfig()
+            )
+        return config
+
+    async def start(self) -> None:
+        self._seen.clear()
+
+    async def stop(self) -> None:
+        return None
+
+    async def filter(self, event: dict) -> dict | None:
+        key = self._make_key(event)
+        now = time.monotonic()
+        self._prune_expired(now)
+
+        if key not in self._seen:
+            self._seen[key] = now
+            self._seen.move_to_end(key)
+            while len(self._seen) > self._max_keys:
+                self._seen.popitem(last=False)
+            return event
+
+        if self._subsequent_rate <= 0.0:
+            return None
+
+        if random.random() < self._subsequent_rate:
+            return event
+        return None
+
+    def _make_key(self, event: dict) -> str:
+        parts = [str(event.get(field, "")) for field in (self._key_fields or [])]
+        return "|".join(parts)
+
+    def _prune_expired(self, now: float) -> None:
+        cutoff = now - self._window
+        while self._seen:
+            _, oldest_time = next(iter(self._seen.items()))
+            if oldest_time < cutoff:
+                self._seen.popitem(last=False)
+            else:
+                break
+
+    async def health_check(self) -> bool:
+        return True
+
+
+PLUGIN_METADATA = {
+    "name": "first_occurrence",
+    "version": "1.0.0",
+    "plugin_type": "filter",
+    "entry_point": "fapilog.plugins.filters.first_occurrence:FirstOccurrenceFilter",
+    "description": "Pass first occurrences of unique messages with optional sampling.",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.4.0"},
+    "api_version": "1.0",
+}

--- a/src/fapilog/plugins/filters/rate_limit.py
+++ b/src/fapilog/plugins/filters/rate_limit.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import time
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
+
+from ...core import diagnostics
 
 
 @dataclass
@@ -10,6 +13,8 @@ class RateLimitFilterConfig:
     capacity: int = 10  # tokens
     refill_rate_per_sec: float = 5.0  # tokens per second
     key_field: str | None = None  # event key used to partition buckets
+    max_keys: int = 10000  # Max buckets to track
+    overflow_action: str = "drop"  # "drop" or "mark"
 
 
 class RateLimitFilter:
@@ -35,7 +40,11 @@ class RateLimitFilter:
         self._capacity = max(1, int(cfg.capacity))
         self._refill_rate = max(0.0, float(cfg.refill_rate_per_sec))
         self._key_field = cfg.key_field
-        self._buckets: dict[str, tuple[float, float]] = {}  # key -> (tokens, ts)
+        self._max_keys = max(1, int(cfg.max_keys))
+        action = str(cfg.overflow_action).lower()
+        self._overflow_action = action if action in {"drop", "mark"} else "drop"
+        self._buckets: OrderedDict[str, tuple[float, float]] = OrderedDict()
+        self._warned_capacity = False
 
     async def start(self) -> None:
         return None
@@ -46,15 +55,24 @@ class RateLimitFilter:
     async def filter(self, event: dict) -> dict | None:
         key = self._resolve_key(event)
         now = time.monotonic()
+        if key not in self._buckets and len(self._buckets) >= self._max_keys:
+            self._evict_oldest()
         tokens, last = self._buckets.get(key, (self._capacity, now))
         # Refill
         elapsed = max(0.0, now - last)
         tokens = min(self._capacity, tokens + elapsed * self._refill_rate)
-        if tokens < 1.0:
-            self._buckets[key] = (tokens, now)
-            return None
-        tokens -= 1.0
+        allowed = tokens >= 1.0
+        if allowed:
+            tokens -= 1.0
         self._buckets[key] = (tokens, now)
+        self._buckets.move_to_end(key)
+        self._check_capacity_warn()
+        if not allowed:
+            if self._overflow_action == "mark":
+                cloned = dict(event)
+                cloned["rate_limited"] = True
+                return cloned
+            return None
         return event
 
     def _resolve_key(self, event: dict) -> str:
@@ -62,7 +80,39 @@ class RateLimitFilter:
             return "global"
         return str(event.get(self._key_field, "global"))
 
+    def _evict_oldest(self) -> None:
+        try:
+            self._buckets.popitem(last=False)
+        except Exception:
+            return
+
+    def _check_capacity_warn(self) -> None:
+        size = len(self._buckets)
+        threshold = int(self._max_keys * 0.9)
+        if size >= threshold:
+            if not self._warned_capacity:
+                try:
+                    diagnostics.warn(
+                        "filter",
+                        "rate_limit approaching max_keys",
+                        filter="rate_limit",
+                        max_keys=self._max_keys,
+                        keys_tracked=size,
+                    )
+                except Exception:
+                    pass
+            self._warned_capacity = True
+        elif size < max(1, int(self._max_keys * 0.8)):
+            self._warned_capacity = False
+
+    @property
+    def tracked_key_count(self) -> int:
+        return len(self._buckets)
+
     async def health_check(self) -> bool:
+        if len(self._buckets) > self._max_keys * 0.9:
+            self._check_capacity_warn()
+            return False
         return True
 
 

--- a/src/fapilog/plugins/filters/sampling.py
+++ b/src/fapilog/plugins/filters/sampling.py
@@ -48,6 +48,10 @@ class SamplingFilter:
             return None
         return event if random.random() < self._rate else None
 
+    @property
+    def current_sample_rate(self) -> float:
+        return self._rate
+
     async def health_check(self) -> bool:
         return True
 

--- a/src/fapilog/plugins/filters/trace_sampling.py
+++ b/src/fapilog/plugins/filters/trace_sampling.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class TraceSamplingConfig:
+    """Configuration for trace-aware sampling."""
+
+    sample_rate: float = 0.1
+    trace_id_field: str = "trace_id"
+    always_pass_levels: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.always_pass_levels is None:
+            self.always_pass_levels = ["ERROR", "CRITICAL"]
+
+
+class TraceSamplingFilter:
+    """Sample consistently by trace ID."""
+
+    name = "trace_sampling"
+
+    def __init__(
+        self, *, config: TraceSamplingConfig | dict | None = None, **kwargs: Any
+    ) -> None:
+        cfg = self._parse_config(config, kwargs)
+        self._rate = max(0.0, min(1.0, float(cfg.sample_rate)))
+        self._trace_field = str(cfg.trace_id_field)
+        self._always_pass = {level.upper() for level in (cfg.always_pass_levels or [])}
+
+    @staticmethod
+    def _parse_config(
+        config: TraceSamplingConfig | dict | None, kwargs: dict[str, Any]
+    ) -> TraceSamplingConfig:
+        if isinstance(config, dict):
+            raw = config.get("config", config)
+            return TraceSamplingConfig(**raw)
+        if config is None:
+            raw_kwargs = kwargs.get("config", kwargs)
+            return (
+                TraceSamplingConfig(**raw_kwargs)
+                if raw_kwargs
+                else TraceSamplingConfig()
+            )
+        return config
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def filter(self, event: dict) -> dict | None:
+        level = str(event.get("level", "INFO")).upper()
+        if level in self._always_pass:
+            return event
+
+        trace_id = event.get(self._trace_field)
+        if trace_id is None:
+            if random.random() > self._rate:
+                return None
+            return event
+
+        hash_value = int(hashlib.md5(str(trace_id).encode()).hexdigest(), 16)
+        threshold = int(self._rate * (2**128))
+        if hash_value < threshold:
+            return event
+        return None
+
+    @property
+    def current_sample_rate(self) -> float:
+        return self._rate
+
+    async def health_check(self) -> bool:
+        return True
+
+
+PLUGIN_METADATA = {
+    "name": "trace_sampling",
+    "version": "1.0.0",
+    "plugin_type": "filter",
+    "entry_point": "fapilog.plugins.filters.trace_sampling:TraceSamplingFilter",
+    "description": "Deterministic sampling keyed by trace_id.",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.4.0"},
+    "api_version": "1.0",
+}

--- a/tests/unit/test_filters_adaptive_sampling.py
+++ b/tests/unit/test_filters_adaptive_sampling.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog.plugins.filters.adaptive_sampling import (
+    AdaptiveSamplingConfig,
+    AdaptiveSamplingFilter,
+)
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, delta: float) -> None:
+        self.now += delta
+
+
+@pytest.mark.asyncio
+async def test_adaptive_sampling_adjusts_rates(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fapilog.plugins.filters import adaptive_sampling as module
+
+    clock = _FakeClock()
+    monkeypatch.setattr(module, "time", clock)
+
+    filt = AdaptiveSamplingFilter(
+        config=AdaptiveSamplingConfig(
+            target_eps=2.0,
+            window_seconds=10.0,
+            min_sample_rate=0.05,
+            max_sample_rate=1.0,
+            smoothing_factor=1.0,
+        )
+    )
+
+    # High throughput should drive the rate down but stay above the minimum
+    clock.now = 5.0
+    filt._timestamps.extend([4.5, 4.55, 4.6, 4.65, 4.7])
+    filt._last_adjustment = 3.0
+    filt._current_rate = 1.0
+    filt._maybe_adjust_rate()
+    rate_after_high = filt.current_sample_rate
+    assert rate_after_high < 1.0
+    assert rate_after_high >= 0.05
+
+    # Low throughput should allow the rate to move back up toward max
+    filt._timestamps.clear()
+    filt._timestamps.extend([19.0])
+    clock.now = 20.0
+    filt._last_adjustment = 18.0
+    filt._current_rate = 0.1
+    filt._maybe_adjust_rate()
+    rate_after_low = filt.current_sample_rate
+    assert rate_after_low > 0.1
+    assert rate_after_low <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_adaptive_sampling_prunes_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fapilog.plugins.filters import adaptive_sampling as module
+
+    clock = _FakeClock()
+    monkeypatch.setattr(module, "time", clock)
+    monkeypatch.setattr(module.random, "random", lambda: 0.0)
+
+    filt = AdaptiveSamplingFilter(
+        config=AdaptiveSamplingConfig(window_seconds=5.0, smoothing_factor=1.0)
+    )
+    await filt.start()
+
+    clock.now = 0.0
+    await filt.filter({"level": "INFO"})
+
+    clock.advance(10.0)
+    await filt.filter({"level": "INFO"})
+
+    assert len(filt._timestamps) == 1
+    assert filt._timestamps[0] >= clock.now - filt._window
+
+
+@pytest.mark.asyncio
+async def test_adaptive_sampling_priority_levels_always_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fapilog.plugins.filters import adaptive_sampling as module
+
+    clock = _FakeClock()
+    monkeypatch.setattr(module, "time", clock)
+    monkeypatch.setattr(module.random, "random", lambda: 1.0)
+
+    filt = AdaptiveSamplingFilter(
+        config=AdaptiveSamplingConfig(min_sample_rate=0.0, max_sample_rate=0.2)
+    )
+
+    event = {"level": "error", "message": "fail"}
+    assert await filt.filter(event) == event

--- a/tests/unit/test_filters_first_occurrence.py
+++ b/tests/unit/test_filters_first_occurrence.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog.plugins.filters.first_occurrence import (
+    FirstOccurrenceConfig,
+    FirstOccurrenceFilter,
+)
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, delta: float) -> None:
+        self.now += delta
+
+
+@pytest.mark.asyncio
+async def test_first_occurrence_passes_then_drops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fapilog.plugins.filters import first_occurrence as module
+
+    clock = _FakeClock()
+    monkeypatch.setattr(module, "time", clock)
+    monkeypatch.setattr(module.random, "random", lambda: 0.99)
+
+    filt = FirstOccurrenceFilter(
+        config=FirstOccurrenceConfig(subsequent_sample_rate=0.0)
+    )
+    await filt.start()
+
+    evt = {"message": "hello"}
+    assert await filt.filter(evt) == evt
+    assert await filt.filter(evt) is None
+
+
+@pytest.mark.asyncio
+async def test_first_occurrence_window_expiration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fapilog.plugins.filters import first_occurrence as module
+
+    clock = _FakeClock()
+    monkeypatch.setattr(module, "time", clock)
+    monkeypatch.setattr(module.random, "random", lambda: 0.0)
+
+    filt = FirstOccurrenceFilter(
+        config=FirstOccurrenceConfig(window_seconds=2.0, subsequent_sample_rate=0.0)
+    )
+    await filt.start()
+
+    evt = {"message": "event"}
+    assert await filt.filter(evt) == evt
+
+    clock.advance(3.0)
+    assert await filt.filter(evt) == evt
+
+
+@pytest.mark.asyncio
+async def test_first_occurrence_lru_eviction(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fapilog.plugins.filters import first_occurrence as module
+
+    clock = _FakeClock()
+    monkeypatch.setattr(module, "time", clock)
+    monkeypatch.setattr(module.random, "random", lambda: 0.0)
+
+    filt = FirstOccurrenceFilter(
+        config=FirstOccurrenceConfig(max_keys=2, subsequent_sample_rate=0.0)
+    )
+    await filt.start()
+
+    await filt.filter({"message": "a"})
+    await filt.filter({"message": "b"})
+    await filt.filter({"message": "c"})
+
+    assert set(filt._seen.keys()) == {"b", "c"}

--- a/tests/unit/test_filters_rate_limit_enhanced.py
+++ b/tests/unit/test_filters_rate_limit_enhanced.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from fapilog.plugins.filters.rate_limit import RateLimitFilter, RateLimitFilterConfig
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_lru_eviction_and_isolation() -> None:
+    filt = RateLimitFilter(
+        config=RateLimitFilterConfig(
+            capacity=5,
+            refill_rate_per_sec=1.0,
+            key_field="user",
+            max_keys=2,
+        )
+    )
+
+    await filt.start()
+    await filt.filter({"user": "a"})
+    await filt.filter({"user": "b"})
+    assert set(filt._buckets.keys()) == {"a", "b"}
+
+    await filt.filter({"user": "c"})
+    assert set(filt._buckets.keys()) == {"b", "c"}
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_overflow_action_mark_instead_of_drop() -> None:
+    filt = RateLimitFilter(
+        config=RateLimitFilterConfig(
+            capacity=1,
+            refill_rate_per_sec=0.0,
+            key_field="account",
+            overflow_action="mark",
+        )
+    )
+
+    await filt.start()
+    first = await filt.filter({"account": "x"})
+    assert first == {"account": "x"}
+
+    second = await filt.filter({"account": "x"})
+    assert second is not None
+    assert second.get("rate_limited") is True
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_health_check_warns_near_capacity() -> None:
+    filt = RateLimitFilter(
+        config=RateLimitFilterConfig(
+            capacity=1,
+            refill_rate_per_sec=0.0,
+            key_field="user",
+            max_keys=10,
+        )
+    )
+
+    await filt.start()
+    for i in range(10):
+        await filt.filter({"user": f"u{i}"})
+
+    assert await filt.health_check() is False

--- a/tests/unit/test_filters_trace_sampling.py
+++ b/tests/unit/test_filters_trace_sampling.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from fapilog.plugins.filters.trace_sampling import (
+    TraceSamplingConfig,
+    TraceSamplingFilter,
+)
+
+
+def _should_sample(trace_id: str, rate: float) -> bool:
+    hash_value = int(hashlib.md5(str(trace_id).encode()).hexdigest(), 16)
+    threshold = int(rate * (2**128))
+    return hash_value < threshold
+
+
+@pytest.mark.asyncio
+async def test_trace_sampling_is_deterministic() -> None:
+    cfg = TraceSamplingConfig(sample_rate=0.5)
+    filt = TraceSamplingFilter(config=cfg)
+
+    evt = {"trace_id": "abc123", "level": "INFO"}
+    first = await filt.filter(evt)
+    second = await filt.filter(evt)
+
+    expected = _should_sample("abc123", cfg.sample_rate)
+    assert bool(first) == expected
+    assert bool(second) == expected
+
+
+@pytest.mark.asyncio
+async def test_trace_sampling_respects_field_name() -> None:
+    cfg = TraceSamplingConfig(sample_rate=0.8, trace_id_field="tid")
+    filt = TraceSamplingFilter(config=cfg)
+
+    evt = {"tid": "custom-trace", "level": "INFO"}
+    result = await filt.filter(evt)
+    expected = _should_sample("custom-trace", cfg.sample_rate)
+    assert bool(result) == expected
+
+
+@pytest.mark.asyncio
+async def test_trace_sampling_falls_back_to_random(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    filt = TraceSamplingFilter(config=TraceSamplingConfig(sample_rate=0.2))
+
+    monkeypatch.setattr(
+        "fapilog.plugins.filters.trace_sampling.random.random", lambda: 0.99
+    )
+    assert await filt.filter({"level": "INFO"}) is None
+
+    monkeypatch.setattr(
+        "fapilog.plugins.filters.trace_sampling.random.random", lambda: 0.0
+    )
+    assert await filt.filter({"level": "INFO"}) == {"level": "INFO"}
+
+
+@pytest.mark.asyncio
+async def test_trace_sampling_priority_levels_pass() -> None:
+    filt = TraceSamplingFilter(
+        config=TraceSamplingConfig(sample_rate=0.0, always_pass_levels=["error"])
+    )
+
+    evt = {"level": "ERROR", "trace_id": "ignored"}
+    assert await filt.filter(evt) == evt

--- a/tests/unit/test_legacy_sampling_deprecation.py
+++ b/tests/unit/test_legacy_sampling_deprecation.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import warnings
+from types import SimpleNamespace
+
+import pytest
+
+from fapilog.core.logger import SyncLoggerFacade
+
+
+def _make_settings(rate: float, filters: list[str] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        observability=SimpleNamespace(
+            logging=SimpleNamespace(sampling_rate=rate),
+        ),
+        core=SimpleNamespace(
+            error_dedupe_window_seconds=0.0,
+            filters=filters or [],
+        ),
+    )
+
+
+def _make_logger(
+    monkeypatch: pytest.MonkeyPatch,
+    rate: float,
+    *,
+    random_value: float,
+    filters: list[str] | None = None,
+) -> SyncLoggerFacade:
+    async def _sink_write(entry: dict) -> None:  # pragma: no cover - placeholder
+        _ = entry
+
+    settings = _make_settings(rate, filters=filters)
+    monkeypatch.setattr("fapilog.core.logger.Settings", lambda: settings, raising=False)
+    monkeypatch.setattr(
+        "fapilog.core.settings.Settings", lambda: settings, raising=False
+    )
+    monkeypatch.setattr("random.random", lambda: random_value)
+
+    logger = SyncLoggerFacade(
+        name="legacy",
+        queue_capacity=4,
+        batch_max_size=1,
+        batch_timeout_seconds=0.01,
+        backpressure_wait_ms=1,
+        drop_on_full=False,
+        sink_write=_sink_write,
+        sink_write_serialized=None,
+        enrichers=[],
+        processors=[],
+        filters=[],
+        metrics=None,
+        exceptions_enabled=False,
+        exceptions_max_frames=1,
+        exceptions_max_stack_chars=10,
+        serialize_in_flush=False,
+        num_workers=1,
+        level_gate=None,
+    )
+    monkeypatch.setattr(logger, "start", lambda: None)
+    return logger
+
+
+def test_legacy_sampling_emits_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _make_logger(monkeypatch, rate=0.5, random_value=0.9)
+
+    with pytest.warns(DeprecationWarning):
+        logger._enqueue("INFO", "legacy")
+
+    assert logger._submitted == 0
+
+
+def test_filter_sampling_path_suppresses_deprecation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _make_logger(
+        monkeypatch,
+        rate=0.5,
+        random_value=0.0,
+        filters=["sampling"],
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=DeprecationWarning)
+        logger._enqueue("INFO", "use-filter")
+
+    assert logger._submitted == 1

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -70,6 +70,25 @@ async def test_enabled_basic_counters_and_histograms() -> None:
 
 
 @pytest.mark.asyncio
+async def test_filter_sampling_and_rate_limit_gauges() -> None:
+    mc = MetricsCollector(enabled=True)
+
+    await mc.record_sample_rate("adaptive_sampling", 0.25)
+    await mc.record_rate_limit_keys_tracked(42)
+
+    reg = mc.registry
+    assert reg is not None
+    assert (
+        reg.get_sample_value(
+            "fapilog_filter_sample_rate",
+            {"filter": "adaptive_sampling"},
+        )
+        == 0.25
+    )
+    assert reg.get_sample_value("fapilog_rate_limit_keys_tracked") == 42.0
+
+
+@pytest.mark.asyncio
 async def test_plugin_timer_success_and_error() -> None:
     mc = MetricsCollector(enabled=True)
     # Success path


### PR DESCRIPTION
## Summary

Implements **Story 5.3: Enhanced Sampling and Rate Limiting Plugins**, building on the BaseFilter foundation from Story 5.2.

## New Filter Plugins

| Filter | Description |
|--------|-------------|
| `AdaptiveSamplingFilter` | Dynamically adjusts sample rate based on EPS with configurable bounds |
| `TraceSamplingFilter` | Deterministic sampling by trace_id hash (all-or-none per trace) |
| `FirstOccurrenceFilter` | First occurrence passes, subsequent duplicates sampled |

## RateLimitFilter Enhancements

- `max_keys`: Memory-bounded with LRU eviction
- `overflow_action`: "drop" (default) or "mark" (adds `rate_limited=True`)
- Health check warns at 90% capacity
- Diagnostic warning when approaching key limit

## Legacy Deprecation

- `observability.logging.sampling_rate` now emits `DeprecationWarning`
- Warning suppressed when filter-based sampling is configured
- Migration path documented in `docs/plugins/filters/sampling.md`

## Metrics

| Metric | Type | Description |
|--------|------|-------------|
| `fapilog_filter_sample_rate` | Gauge | Current sample rate by filter |
| `fapilog_rate_limit_keys_tracked` | Gauge | Keys tracked by rate limiter |

## Configuration

```yaml
core:
  filters: ["adaptive_sampling"]

filter_config:
  adaptive_sampling:
    config:
      target_eps: 100
      min_sample_rate: 0.01
      max_sample_rate: 1.0
      window_seconds: 10
      always_pass_levels: ["ERROR", "CRITICAL"]
```

## Files Changed

- **25 files changed**
- **1,140 insertions, 24 deletions**
- 5 new filter/test files
- 2 new documentation files

## Test Coverage

- `test_filters_adaptive_sampling.py` - Rate adjustment, window pruning, priority bypass
- `test_filters_trace_sampling.py` - Deterministic hash, field config, random fallback
- `test_filters_first_occurrence.py` - First pass, window expiration, LRU eviction
- `test_filters_rate_limit_enhanced.py` - LRU eviction, mark vs drop, health check
- `test_legacy_sampling_deprecation.py` - Deprecation warning, filter suppression

## Related

- Depends on: Story 5.2 (PR #189)
- Closes #53