### PR TITLE
feat(sinks): add batching support to HttpSink and WebhookSink (Story 5.6)

### DIFF
--- a/docs/api-reference/plugins/sinks.md
+++ b/docs/api-reference/plugins/sinks.md
@@ -57,6 +57,10 @@ HTTP sink:
 export FAPILOG_HTTP__ENDPOINT=https://logs.example.com/ingest
 export FAPILOG_HTTP__TIMEOUT_SECONDS=5
 export FAPILOG_HTTP__RETRY_MAX_ATTEMPTS=3
+export FAPILOG_HTTP__BATCH_SIZE=100
+export FAPILOG_HTTP__BATCH_TIMEOUT_SECONDS=5
+export FAPILOG_HTTP__BATCH_FORMAT=array   # array|ndjson|wrapped
+export FAPILOG_HTTP__BATCH_WRAPPER_KEY=logs
 ```
 
 ## Building Blocks

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -56,6 +56,10 @@
 | `FAPILOG__FILTER_CONFIG__RATE_LIMIT` | dict | PydanticUndefined | Configuration for rate_limit filter |
 | `FAPILOG__FILTER_CONFIG__SAMPLING` | dict | PydanticUndefined | Configuration for sampling filter |
 | `FAPILOG__FILTER_CONFIG__TRACE_SAMPLING` | dict | PydanticUndefined | Configuration for trace_sampling filter |
+| `FAPILOG__HTTP__BATCH_FORMAT` | str | array | Batch format: 'array', 'ndjson', or 'wrapped' |
+| `FAPILOG__HTTP__BATCH_SIZE` | int | 1 | Maximum events per HTTP request (1 = no batching) |
+| `FAPILOG__HTTP__BATCH_TIMEOUT_SECONDS` | float | 5.0 | Max seconds before flushing a partial batch |
+| `FAPILOG__HTTP__BATCH_WRAPPER_KEY` | str | logs | Wrapper key when batch_format='wrapped' |
 | `FAPILOG__HTTP__ENDPOINT` | str | None | — | HTTP endpoint to POST log events to |
 | `FAPILOG__HTTP__HEADERS` | dict | PydanticUndefined | Default headers to send with each request |
 | `FAPILOG__HTTP__HEADERS_JSON` | str | None | — | JSON-encoded headers map (e.g. '{"Authorization": "Bearer x"}') |
@@ -109,6 +113,10 @@
 | `FAPILOG__SECURITY__ENCRYPTION__MIN_TLS_VERSION` | Literal | 1.2 | Minimum TLS version for transport |
 | `FAPILOG__SECURITY__ENCRYPTION__ROTATE_INTERVAL_DAYS` | int | 90 | Recommended key rotation interval |
 | `FAPILOG__SINK_CONFIG__EXTRA` | dict | PydanticUndefined | Configuration for third-party sinks by name |
+| `FAPILOG__SINK_CONFIG__HTTP__BATCH_FORMAT` | str | array | Batch format: 'array', 'ndjson', or 'wrapped' |
+| `FAPILOG__SINK_CONFIG__HTTP__BATCH_SIZE` | int | 1 | Maximum events per HTTP request (1 = no batching) |
+| `FAPILOG__SINK_CONFIG__HTTP__BATCH_TIMEOUT_SECONDS` | float | 5.0 | Max seconds before flushing a partial batch |
+| `FAPILOG__SINK_CONFIG__HTTP__BATCH_WRAPPER_KEY` | str | logs | Wrapper key when batch_format='wrapped' |
 | `FAPILOG__SINK_CONFIG__HTTP__ENDPOINT` | str | None | — | HTTP endpoint to POST log events to |
 | `FAPILOG__SINK_CONFIG__HTTP__HEADERS` | dict | PydanticUndefined | Default headers to send with each request |
 | `FAPILOG__SINK_CONFIG__HTTP__HEADERS_JSON` | str | None | — | JSON-encoded headers map (e.g. '{"Authorization": "Bearer x"}') |
@@ -136,6 +144,8 @@
 | `FAPILOG__SINK_CONFIG__SEALED__SIGN_MANIFESTS` | bool | True | Sign manifests when keys are available |
 | `FAPILOG__SINK_CONFIG__SEALED__USE_KMS_SIGNING` | bool | False | Sign manifests via external KMS provider |
 | `FAPILOG__SINK_CONFIG__STDOUT_JSON` | dict | PydanticUndefined | Configuration for stdout_json sink |
+| `FAPILOG__SINK_CONFIG__WEBHOOK__BATCH_SIZE` | int | 1 | Maximum events per webhook request (1 = no batching) |
+| `FAPILOG__SINK_CONFIG__WEBHOOK__BATCH_TIMEOUT_SECONDS` | float | 5.0 | Max seconds before flushing a partial webhook batch |
 | `FAPILOG__SINK_CONFIG__WEBHOOK__ENDPOINT` | str | None | — | Webhook destination URL |
 | `FAPILOG__SINK_CONFIG__WEBHOOK__HEADERS` | dict | PydanticUndefined | Additional HTTP headers |
 | `FAPILOG__SINK_CONFIG__WEBHOOK__RETRY_BACKOFF_SECONDS` | float | None | — | Backoff between retries in seconds |

--- a/docs/examples/cloud-sinks/elastic.md
+++ b/docs/examples/cloud-sinks/elastic.md
@@ -6,9 +6,16 @@ Send JSON logs to Elastic Cloud or OpenSearch using the HTTP sink or a custom si
 
 ```python
 from fapilog import get_logger
-from fapilog.plugins.sinks.http_client import HttpSink, HttpSinkConfig
+from fapilog.plugins.sinks.http_client import BatchFormat, HttpSink, HttpSinkConfig
 
-sink = HttpSink(config=HttpSinkConfig(endpoint="https://elastic.example.com/_bulk"))
+sink = HttpSink(
+    config=HttpSinkConfig(
+        endpoint="https://elastic.example.com/_bulk",
+        batch_size=100,
+        batch_timeout_seconds=2.0,
+        batch_format=BatchFormat.NDJSON,
+    )
+)
 logger = get_logger(sinks=[sink])
 ```
 

--- a/docs/plugins/sinks.md
+++ b/docs/plugins/sinks.md
@@ -33,6 +33,41 @@ class MySink(BaseSink):
 - `http` (HTTP POST)
 - `mmap_persistence` (experimental; local persistence)
 
+### HTTP sink batching
+
+`HttpSink` now supports sink-level batching to reduce request volume:
+
+- `batch_size` (default: 1 for backward compatibility; set >1 to enable batching)
+- `batch_timeout_seconds` (default: 5.0) flush partial batches on timeout
+- `batch_format`: `array` (JSON array), `ndjson` (newline-delimited), `wrapped` (`{"logs": [...]}`)
+- `batch_wrapper_key`: wrapper key when `batch_format="wrapped"` (default: `logs`)
+
+Examples:
+
+```bash
+export FAPILOG_HTTP__ENDPOINT=https://logs.example.com/ingest
+export FAPILOG_HTTP__BATCH_SIZE=100
+export FAPILOG_HTTP__BATCH_TIMEOUT_SECONDS=2.0
+export FAPILOG_HTTP__BATCH_FORMAT=ndjson
+```
+
+```python
+from fapilog.plugins.sinks.http_client import HttpSink, HttpSinkConfig, BatchFormat
+
+sink = HttpSink(
+    HttpSinkConfig(
+        endpoint="https://logs.example.com/ingest",
+        batch_size=100,
+        batch_timeout_seconds=2.0,
+        batch_format=BatchFormat.NDJSON,
+    )
+)
+```
+
+### Webhook sink batching
+
+`WebhookSink` supports the same `batch_size` and `batch_timeout_seconds` fields to batch webhook POSTs (default `batch_size=1` for compatibility).
+
 ## Usage
 
 Sinks are discovered via entry points when plugin discovery is enabled. You can also wire custom sinks programmatically by passing them into the container/settings before creating a logger.

--- a/src/fapilog/__init__.py
+++ b/src/fapilog/__init__.py
@@ -109,6 +109,10 @@ def _sink_configs(settings: _Settings) -> dict[str, dict[str, Any]]:
                 if settings.http.retry_max_attempts
                 else None,
                 timeout_seconds=settings.http.timeout_seconds,
+                batch_size=settings.http.batch_size,
+                batch_timeout_seconds=settings.http.batch_timeout_seconds,
+                batch_format=settings.http.batch_format,
+                batch_wrapper_key=settings.http.batch_wrapper_key,
             )
         },
         "webhook": {
@@ -123,6 +127,8 @@ def _sink_configs(settings: _Settings) -> dict[str, dict[str, Any]]:
                 if scfg.webhook.retry_max_attempts
                 else None,
                 timeout_seconds=scfg.webhook.timeout_seconds,
+                batch_size=scfg.webhook.batch_size,
+                batch_timeout_seconds=scfg.webhook.batch_timeout_seconds,
             )
         },
         "sealed": scfg.sealed.model_dump(exclude_none=True),

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -70,6 +70,16 @@ class WebhookSettings(BaseModel):
     timeout_seconds: float = Field(
         default=5.0, gt=0.0, description="Request timeout in seconds"
     )
+    batch_size: int = Field(
+        default=1,
+        ge=1,
+        description="Maximum events per webhook request (1 = no batching)",
+    )
+    batch_timeout_seconds: float = Field(
+        default=5.0,
+        gt=0.0,
+        description="Max seconds before flushing a partial webhook batch",
+    )
 
 
 class SealedSinkSettings(BaseModel):
@@ -440,6 +450,24 @@ class HttpSinkSettings(BaseModel):
         default=5.0,
         gt=0.0,
         description="Request timeout for HTTP sink operations",
+    )
+    batch_size: int = Field(
+        default=1,
+        ge=1,
+        description="Maximum events per HTTP request (1 = no batching)",
+    )
+    batch_timeout_seconds: float = Field(
+        default=5.0,
+        gt=0.0,
+        description="Max seconds before flushing a partial batch",
+    )
+    batch_format: str = Field(
+        default="array",
+        description="Batch format: 'array', 'ndjson', or 'wrapped'",
+    )
+    batch_wrapper_key: str = Field(
+        default="logs",
+        description="Wrapper key when batch_format='wrapped'",
     )
 
     @field_validator("headers_json")

--- a/src/fapilog/plugins/sinks/_batching.py
+++ b/src/fapilog/plugins/sinks/_batching.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+
+class BatchingMixin:
+    """Mixin providing batch accumulation with size/timeout triggers."""
+
+    _batch: list[dict[str, Any]]
+    _batch_lock: asyncio.Lock
+    _batch_first_time: float | None
+    _flush_task: asyncio.Task[None] | None
+    _batch_size: int
+    _batch_timeout_seconds: float
+
+    def _init_batching(self, batch_size: int, batch_timeout_seconds: float) -> None:
+        self._batch = []
+        self._batch_lock = asyncio.Lock()
+        self._batch_first_time: float | None = None
+        self._flush_task = None
+        self._batch_size = max(1, int(batch_size))
+        self._batch_timeout_seconds = float(batch_timeout_seconds)
+
+    async def _start_batching(self) -> None:
+        if self._batch_size > 1:
+            self._flush_task = asyncio.create_task(self._flush_loop())
+
+    async def _stop_batching(self) -> None:
+        if self._flush_task:
+            self._flush_task.cancel()
+            try:
+                await self._flush_task
+            except asyncio.CancelledError:
+                pass
+            self._flush_task = None
+        await self._flush_batch()
+
+    async def _enqueue_for_batch(self, entry: dict[str, Any]) -> None:
+        if self._batch_size <= 1:
+            await self._send_batch([entry])
+            return
+
+        flush_now = False
+        async with self._batch_lock:
+            if not self._batch:
+                self._batch_first_time = time.monotonic()
+            self._batch.append(entry)
+            if len(self._batch) >= self._batch_size:
+                flush_now = True
+
+        if flush_now:
+            await self._flush_batch()
+
+    async def _flush_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._batch_timeout_seconds / 2)
+                batch: list[dict[str, Any]] | None = None
+                async with self._batch_lock:
+                    if not self._batch or self._batch_first_time is None:
+                        continue
+                    elapsed = time.monotonic() - self._batch_first_time
+                    if elapsed >= self._batch_timeout_seconds:
+                        batch = self._batch[:]
+                        self._batch = []
+                        self._batch_first_time = None
+                if batch:
+                    try:
+                        await self._send_batch(batch)
+                    except Exception:
+                        # Contain errors to keep flush loop alive
+                        pass
+        except asyncio.CancelledError:
+            return
+
+    async def _flush_batch(self) -> None:
+        async with self._batch_lock:
+            if not self._batch:
+                return
+            batch = self._batch[:]
+            self._batch = []
+            self._batch_first_time = None
+        await self._send_batch(batch)
+
+    async def _send_batch(
+        self, batch: list[dict[str, Any]]
+    ) -> None:  # pragma: no cover - abstract
+        raise NotImplementedError

--- a/tests/unit/test_http_sink_batching.py
+++ b/tests/unit/test_http_sink_batching.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from fapilog.plugins.sinks.http_client import HttpSink, HttpSinkConfig
+
+
+class _RecordingPool:
+    """Stub HttpClientPool that records POST calls."""
+
+    def __init__(self, outcomes: list[Any] | None = None) -> None:
+        self.started = False
+        self.stopped = False
+        self.calls: list[dict[str, Any]] = []
+        self._outcomes = outcomes or [
+            httpx.Response(200, request=httpx.Request("POST", "http://example.com"))
+        ]
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def acquire(self):
+        return self
+
+    async def __aenter__(self) -> _RecordingPool:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: Any | None = None,
+        content: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "content": content,
+                "headers": dict(headers or {}),
+            }
+        )
+        outcome = (
+            self._outcomes.pop(0)
+            if self._outcomes
+            else httpx.Response(200, request=httpx.Request("POST", url))
+        )
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.mark.asyncio
+async def test_batch_flushes_on_size_and_stop() -> None:
+    pool = _RecordingPool()
+    sink = HttpSink(
+        HttpSinkConfig(
+            endpoint="https://logs.example.com/api/logs",
+            batch_size=2,
+            batch_timeout_seconds=5.0,
+        ),
+        pool=pool,
+    )
+
+    await sink.start()
+    await sink.write({"n": 1})
+    await sink.write({"n": 2})
+    await sink.write({"n": 3})
+    await sink.stop()
+
+    assert pool.started is True
+    assert pool.stopped is True
+    assert len(pool.calls) == 2
+    assert pool.calls[0]["json"] == [{"n": 1}, {"n": 2}]
+    assert pool.calls[1]["json"] == [{"n": 3}]
+
+
+@pytest.mark.asyncio
+async def test_batch_flushes_on_timeout() -> None:
+    pool = _RecordingPool()
+    sink = HttpSink(
+        HttpSinkConfig(
+            endpoint="https://logs.example.com/api/logs",
+            batch_size=10,
+            batch_timeout_seconds=0.05,
+        ),
+        pool=pool,
+    )
+
+    await sink.start()
+    await sink.write({"n": 1})
+    await asyncio.sleep(0.12)  # allow flush loop to run
+    await sink.stop()
+
+    assert len(pool.calls) >= 1
+    assert pool.calls[0]["json"] == [{"n": 1}]
+
+
+@pytest.mark.asyncio
+async def test_batch_size_one_sends_immediately() -> None:
+    pool = _RecordingPool()
+    sink = HttpSink(
+        HttpSinkConfig(
+            endpoint="https://logs.example.com/api/logs",
+            batch_size=1,
+            batch_timeout_seconds=1.0,
+        ),
+        pool=pool,
+    )
+
+    await sink.start()
+    await sink.write({"msg": "immediate"})
+    await sink.stop()
+
+    assert len(pool.calls) == 1
+    assert pool.calls[0]["json"] == [{"msg": "immediate"}]
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_remaining_events() -> None:
+    pool = _RecordingPool()
+    sink = HttpSink(
+        HttpSinkConfig(
+            endpoint="https://logs.example.com/api/logs",
+            batch_size=4,
+            batch_timeout_seconds=5.0,
+        ),
+        pool=pool,
+    )
+
+    await sink.start()
+    await sink.write({"n": 1})
+    await sink.write({"n": 2})
+    await sink.stop()
+
+    assert len(pool.calls) == 1
+    assert pool.calls[0]["json"] == [{"n": 1}, {"n": 2}]

--- a/tests/unit/test_http_sink_formats.py
+++ b/tests/unit/test_http_sink_formats.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from fapilog.plugins.sinks.http_client import BatchFormat, HttpSink, HttpSinkConfig
+
+
+class _FormatPool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    def acquire(self):
+        return self
+
+    async def __aenter__(self) -> _FormatPool:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: Any | None = None,
+        content: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "content": content,
+                "headers": dict(headers or {}),
+            }
+        )
+        return httpx.Response(200, request=httpx.Request("POST", url))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fmt,expected_header",
+    [
+        (BatchFormat.ARRAY, "application/json"),
+        (BatchFormat.NDJSON, "application/x-ndjson"),
+        (BatchFormat.WRAPPED, "application/json"),
+    ],
+)
+async def test_batch_formats_apply_content_type(
+    fmt: BatchFormat, expected_header: str
+) -> None:
+    pool = _FormatPool()
+    sink = HttpSink(
+        HttpSinkConfig(
+            endpoint="https://logs.example.com/api/logs",
+            batch_size=2,
+            batch_timeout_seconds=5.0,
+            batch_format=fmt,
+        ),
+        pool=pool,
+    )
+
+    await sink.start()
+    await sink.write({"level": "INFO"})
+    await sink.write({"level": "INFO"})
+    await sink.stop()
+
+    assert pool.calls
+    headers = pool.calls[0]["headers"]
+    assert headers.get("Content-Type") == expected_header
+
+    if fmt == BatchFormat.NDJSON:
+        body = pool.calls[0]["content"]
+        assert isinstance(body, (bytes, bytearray))
+        assert b"\n" in body
+    elif fmt == BatchFormat.WRAPPED:
+        assert pool.calls[0]["json"] == {"logs": [{"level": "INFO"}, {"level": "INFO"}]}
+    else:
+        assert pool.calls[0]["json"] == [{"level": "INFO"}, {"level": "INFO"}]

--- a/tests/unit/test_http_sink_settings.py
+++ b/tests/unit/test_http_sink_settings.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fapilog import Settings, _sink_configs
+from fapilog.core.settings import HttpSinkSettings
+
+
+def test_http_sink_settings_defaults() -> None:
+    cfg = HttpSinkSettings()
+    assert cfg.batch_size == 1
+    assert cfg.batch_timeout_seconds == 5.0
+    assert cfg.batch_format == "array"
+    assert cfg.batch_wrapper_key == "logs"
+
+
+def test_http_sink_config_from_settings_includes_batch_fields() -> None:
+    settings = Settings(
+        http={
+            "endpoint": "https://logs.example.com",
+            "batch_size": 10,
+            "batch_timeout_seconds": 2.5,
+            "batch_format": "ndjson",
+            "batch_wrapper_key": "events",
+        }
+    )
+
+    cfgs = _sink_configs(settings)
+    http_cfg = cfgs["http"]["config"]
+
+    assert http_cfg.batch_size == 10
+    assert http_cfg.batch_timeout_seconds == 2.5
+    assert http_cfg.batch_format.value == "ndjson"
+    assert http_cfg.batch_wrapper_key == "events"

--- a/tests/unit/test_webhook_sink_settings.py
+++ b/tests/unit/test_webhook_sink_settings.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from fapilog import Settings, _sink_configs
+from fapilog.core.settings import WebhookSettings
+
+
+def test_webhook_settings_defaults() -> None:
+    cfg = WebhookSettings()
+    assert cfg.batch_size == 1
+    assert cfg.batch_timeout_seconds == 5.0
+
+
+def test_webhook_settings_to_config_carries_batch_fields() -> None:
+    settings = Settings(
+        sink_config={
+            "webhook": {
+                "endpoint": "https://hooks.example.com",
+                "batch_size": 5,
+                "batch_timeout_seconds": 1.5,
+            }
+        }
+    )
+
+    cfgs = _sink_configs(settings)
+    webhook_cfg = cfgs["webhook"]["config"]
+
+    assert webhook_cfg.batch_size == 5
+    assert webhook_cfg.batch_timeout_seconds == 1.5


### PR DESCRIPTION
## Summary

Implements Story 5.6: HTTP Sink Batching — reduces HTTP request volume by accumulating events into batches before sending.

## Problem

Without sink-level batching, each log event triggers a separate HTTP request:
- 256 events from worker batch → 256 HTTP requests
- High network overhead, poor throughput, higher cloud API costs

With batching:
- 256 events → as few as 3 HTTP requests (batch_size=100)

## Changes

### BatchingMixin (`_batching.py`)
- Reusable mixin for size/timeout-based batch accumulation
- Thread-safe with `asyncio.Lock`
- Graceful drain on stop

### HttpSink Batching
- `batch_size` (default: 1, no batching for backwards compat)
- `batch_timeout_seconds` (default: 5.0)
- `batch_format`: `array`, `ndjson`, `wrapped`
- `batch_wrapper_key` for wrapped format

### WebhookSink Batching
- `batch_size` and `batch_timeout_seconds` support
- Preserves single-event payload format when `batch_size=1`

### Settings Integration
- `HttpSinkSettings` and `WebhookSettings` extended with batch fields
- Environment variable support (e.g., `FAPILOG_HTTP__BATCH_SIZE=100`)

## Configuration Examples

```bash
export FAPILOG_HTTP__BATCH_SIZE=100
export FAPILOG_HTTP__BATCH_TIMEOUT_SECONDS=2.0
export FAPILOG_HTTP__BATCH_FORMAT=ndjson
```

```python
HttpSink(HttpSinkConfig(
    endpoint="https://logs.example.com/ingest",
    batch_size=100,
    batch_format=BatchFormat.NDJSON,
))
```

## Testing

- 23 tests covering batching, formats, timeouts, settings
- All tests pass

## Files Changed

- `src/fapilog/plugins/sinks/_batching.py` (new)
- `src/fapilog/plugins/sinks/http_client.py`
- `src/fapilog/plugins/sinks/webhook.py`
- `src/fapilog/core/settings.py`
- `src/fapilog/__init__.py`
- Documentation and tests

Closes #56