### PR TITLE
feat(docs): Story 5.17 - BaseFilter Export and Import Consistency

### DIFF
--- a/docs/api-reference/plugins/index.md
+++ b/docs/api-reference/plugins/index.md
@@ -1,6 +1,6 @@
 # Plugins
 
-Extensible sinks, enrichers, redactors, and processors for fapilog.
+Extensible sinks, enrichers, redactors, processors, and filters for fapilog.
 
 ```{toctree}
 :maxdepth: 2
@@ -14,12 +14,13 @@ processors
 
 ## Overview
 
-fapilog's plugin system provides base protocols for extending functionality in four key areas:
+fapilog's plugin system provides base protocols for extending functionality in five key areas:
 
 - **Sinks** - Output destinations for log messages
 - **Enrichers** - Add context and metadata to messages
 - **Redactors** - Remove or mask sensitive information
 - **Processors** - Transform and optimize messages
+- **Filters** - Drop or reshape events before enrichment
 
 ## Built-in Plugins
 
@@ -144,6 +145,7 @@ from fapilog.plugins import (
     BaseEnricher,
     BaseRedactor,
     BaseProcessor,
+    BaseFilter,
 )
 ```
 

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -72,7 +72,13 @@ PLUGIN_METADATA = {
 Author implementations should satisfy the runtime-checkable Protocol for their type:
 
 ```
-from fapilog.plugins import BaseSink, BaseProcessor, BaseEnricher, BaseRedactor
+from fapilog.plugins import (
+    BaseSink,
+    BaseProcessor,
+    BaseEnricher,
+    BaseRedactor,
+    BaseFilter,
+)
 ```
 
 All interfaces are async-first and must contain errors rather than raising into the core pipeline.

--- a/docs/plugins/filters.md
+++ b/docs/plugins/filters.md
@@ -10,6 +10,26 @@ filters/sampling
 filters/rate-limiting
 ```
 
+## Implementing a filter
+
+```python
+from fapilog.plugins import BaseFilter
+
+class MyFilter(BaseFilter):
+    name = "my_filter"
+
+    async def filter(self, event: dict) -> dict | None:
+        # Return None to drop, or return (possibly modified) event
+        if event.get("level") == "DEBUG":
+            return None  # drop debug events
+        return event
+```
+
+## Registering a filter
+
+- Declare an entry point under `fapilog.filters` in `pyproject.toml`.
+- Add a `PLUGIN_METADATA` dict with `plugin_type: "filter"` and an API version compatible with `fapilog.plugins.versioning.PLUGIN_API_VERSION`.
+
 ## Contract
 
 - `name: str`

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -24,7 +24,7 @@ error-handling
 
 fapilog provides a comprehensive plugin system that allows you to:
 
-- **Extend functionality** with custom sinks, processors, and enrichers
+- **Extend functionality** with custom sinks, processors, enrichers, redactors, and filters
 - **Customize behavior** for your specific use cases
 - **Integrate external systems** through plugin interfaces
 - **Maintain compatibility** through versioned plugin contracts
@@ -42,6 +42,10 @@ Transform serialized log data (compression, encryption, format conversion).
 ### [Enrichers](enrichers.md)
 
 Data enrichment and augmentation.
+
+### [Filters](filters.md)
+
+Drop or reshape events before enrichment and processing pipelines.
 
 ### [Redactors](redactors.md)
 

--- a/tests/unit/test_public_api_init.py
+++ b/tests/unit/test_public_api_init.py
@@ -67,3 +67,28 @@ def test_public_version_constant():
     from fapilog import VERSION
 
     assert isinstance(VERSION, str) and VERSION
+
+
+def test_basefilter_importable_from_plugins() -> None:
+    """BaseFilter should be importable from the public plugins package."""
+    from fapilog.plugins import BaseFilter
+
+    assert hasattr(BaseFilter, "filter")
+    assert "name" in getattr(BaseFilter, "__annotations__", {})
+
+
+def test_all_base_protocols_importable() -> None:
+    """All base protocols should be importable from fapilog.plugins."""
+    from fapilog.plugins import (
+        BaseEnricher,
+        BaseFilter,
+        BaseProcessor,
+        BaseRedactor,
+        BaseSink,
+    )
+
+    assert hasattr(BaseSink, "write")
+    assert hasattr(BaseProcessor, "process")
+    assert hasattr(BaseEnricher, "enrich")
+    assert hasattr(BaseRedactor, "redact")
+    assert hasattr(BaseFilter, "filter")


### PR DESCRIPTION
## Summary

Implements Story 5.17: BaseFilter Export and Import Consistency

## Changes

### Documentation Updates
- **docs/api-reference/plugins/index.md**: Added `BaseFilter` to protocol imports, updated overview to mention 5 plugin types (was 4), added Filters to the overview list
- **docs/plugins/filters.md**: Added "Implementing a filter" section with `BaseFilter` import example, following the pattern of sinks.md, enrichers.md, etc.
- **docs/plugins/authoring.md**: Updated protocol import example to include all 5 protocols
- **docs/plugins/index.md**: Added Filters section to the plugin types overview

### Test Additions
- **tests/unit/test_public_api_init.py**: Added `test_basefilter_importable_from_plugins()` and `test_all_base_protocols_importable()` to verify import paths

## Acceptance Criteria

- [x] AC1: Documentation Consistency - All docs updated to include BaseFilter
- [x] AC2: Example Code Consistency - All protocol import examples include BaseFilter; filter implementation example added
- [x] AC3: Test Import Consistency - Tests added verifying BaseFilter import from fapilog.plugins

## Testing

```bash
pytest tests/unit/test_public_api_init.py -v  # 7 passed
pytest -q                                      # 1447 passed, 5 skipped
```

## Backwards Compatibility

No breaking changes - documentation-only updates plus non-breaking test additions.