### PR TITLE
feat(validators): make lifecycle and health_check optional for all plugin types

### DIFF
--- a/docs/plugins/filters.md
+++ b/docs/plugins/filters.md
@@ -32,10 +32,10 @@ class MyFilter(BaseFilter):
 
 ## Contract
 
-- `name: str`
-- `async start()/stop()` optional lifecycle hooks
-- `async filter(event: dict) -> dict | None` (return `None` to drop)
-- `async health_check() -> bool` (optional)
+- `name: str` — **required**
+- `async filter(event: dict) -> dict | None` — **required** (return `None` to drop)
+- `async start()/stop()` — optional lifecycle hooks
+- `async health_check() -> bool` — optional (defaults to healthy when absent)
 
 ## Built-in filters
 

--- a/docs/plugins/testing.md
+++ b/docs/plugins/testing.md
@@ -51,13 +51,22 @@ from fapilog.testing import validate_filter
 
 class MyFilter:
     name = "my-filter"
-    async def start(self): ...
-    async def stop(self): ...
     async def filter(self, event: dict): ...
-    async def health_check(self): return True
 
 validate_filter(MyFilter()).raise_if_invalid()
 ```
+
+### Required vs optional methods
+
+Validators treat lifecycle and health checks as optional and surface warnings when a method exists but is not async. Core methods remain required:
+
+- **Sinks:** required `write`; optional `start`, `stop`, `health_check`, `write_serialized`
+- **Enrichers:** required `enrich`; optional `start`, `stop`, `health_check`
+- **Redactors:** required `redact`; optional `start`, `stop`, `health_check`
+- **Processors:** required `process`; optional `start`, `stop`, `health_check`, `process_many`
+- **Filters:** required `filter`; optional `start`, `stop`, `health_check` (defaults to healthy when absent)
+
+Missing `health_check` yields a warning (not an error); validators assume `True` when it is not implemented.
 
 ## pytest Fixtures
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -616,4 +616,9 @@ ignore_names = [
   "wrap_sink",
   # Audit compliance API - public helper function
   "emit_compliance_alert",
+  # Size guard processor metrics - used for observability via MetricsCollector
+  "_size_guard_truncated",
+  "_size_guard_dropped",
+  "_truncated_count",
+  "_dropped_count",
 ]

--- a/tests/unit/test_testing_fixtures.py
+++ b/tests/unit/test_testing_fixtures.py
@@ -69,8 +69,7 @@ def test_assert_valid_helpers(
         async def stop(self) -> None:
             pass
 
-        async def filter(self, event: dict) -> dict | None:
-            return event
+        # Missing required filter() method
 
     assert_valid_sink(mock_sink)
     assert_valid_enricher(mock_enricher)
@@ -82,4 +81,4 @@ def test_assert_valid_helpers(
         assert_valid_sink(InvalidSink())
 
     with pytest.raises(ProtocolViolationError):
-        assert_valid_filter(InvalidFilter())  # Missing health_check
+        assert_valid_filter(InvalidFilter())  # Missing required filter method


### PR DESCRIPTION
## Story 5.18: Make health_check Optional in Filter Validator

### Summary

Updates all 5 plugin validators to correctly treat lifecycle methods (`start`, `stop`) and `health_check` as optional, aligning validator behavior with the protocol contracts.

### Changes

**Validators Updated** (`src/fapilog/testing/validators.py`):
- `validate_sink`: required = `write`; optional = `start`, `stop`, `health_check`
- `validate_enricher`: required = `enrich`; optional = `start`, `stop`, `health_check`
- `validate_redactor`: required = `redact`; optional = `start`, `stop`, `health_check`
- `validate_processor`: required = `process`; optional = `start`, `stop`, `health_check`, `process_many`
- `validate_filter`: required = `filter`; optional = `start`, `stop`, `health_check`

**Behavior**:
- Missing optional methods → validation passes
- Missing `health_check` → informational warning "defaulting to healthy"
- Sync optional methods → warning (not error)

### Tests Added

10 new tests in `TestOptionalMethodsValidation` class:
- Minimal plugins (only required methods) pass validation for all 5 types
- Sync optional methods generate warnings, not errors
- Missing `health_check` is valid with warning

### Documentation

- `docs/plugins/filters.md`: Updated contract with required vs optional
- `docs/plugins/testing.md`: Added "Required vs optional methods" section

### Acceptance Criteria

- [x] AC1: Fix health_check validation (warning, not error)
- [x] AC2: Fix start/stop validation (optional for all types)
- [x] AC3: Consistency across all 5 validators
- [x] AC4: Update documentation

### Test Results

```
1457 passed, 5 skipped, 4 warnings in 49.84s
```

Closes #518