### PR TITLE
docs: add HTTP context correlation patterns for FastAPI

### DIFF
--- a/docs/examples/fastapi-logging.md
+++ b/docs/examples/fastapi-logging.md
@@ -1,6 +1,23 @@
 # FastAPI Logging
 
-Request-scoped logging with dependency injection.
+Request-scoped logging with dependency injection and automatic correlation.
+
+## Basic Setup with Middleware
+
+```python
+from fastapi import FastAPI
+from fapilog.fastapi import RequestContextMiddleware, LoggingMiddleware
+
+app = FastAPI()
+
+# Sets request_id for correlation (from X-Request-ID header or UUID)
+app.add_middleware(RequestContextMiddleware)
+
+# Logs request completion with method, path, status, latency_ms
+app.add_middleware(LoggingMiddleware)
+```
+
+## Request-Scoped Logger
 
 ```python
 from fastapi import FastAPI, Depends
@@ -14,10 +31,41 @@ async def logger_dep():
 @app.get("/users/{user_id}")
 async def get_user(user_id: str, logger = Depends(logger_dep)):
     await logger.info("User lookup", user_id=user_id)
+    # Log includes request_id automatically via ContextVarsEnricher
     return {"user_id": user_id}
 ```
 
-Notes:
-- Use the async logger in FastAPI apps.
-- Bind additional context (request_id/user_id) per request if needed.
-- Logger methods are awaitable; drain is handled when the app shuts down if you keep a long-lived logger.
+## Binding HTTP Context to All Logs
+
+If you need HTTP method/path in every log (not just the completion log):
+
+```python
+from fastapi import FastAPI, Request
+from fapilog import get_async_logger
+
+app = FastAPI()
+logger = await get_async_logger("api")
+
+@app.middleware("http")
+async def bind_http_context(request: Request, call_next):
+    with logger.bind(http_method=request.method, http_path=request.url.path):
+        return await call_next(request)
+```
+
+## Log Correlation
+
+All logs during a request share the same `request_id`:
+
+```json
+{"message": "User lookup", "request_id": "abc-123", "user_id": "42"}
+{"message": "request_completed", "request_id": "abc-123", "method": "GET", "path": "/users/42", "status": 200}
+```
+
+Query by `request_id` to see all logs for a request, including the HTTP context from the completion log.
+
+## Notes
+
+- Use the async logger in FastAPI apps
+- `request_id` flows automatically when using `RequestContextMiddleware` + `ContextVarsEnricher`
+- The completion log has method/path/status—use `request_id` to correlate
+- Use `logger.bind()` only if you specifically need HTTP context in every log entry

--- a/docs/user-guide/fastapi.md
+++ b/docs/user-guide/fastapi.md
@@ -61,3 +61,72 @@ async def get_user(user_id: int, logger = Depends(get_logger)):
 - **Async apps (FastAPI/ASGI, asyncio workers)**: prefer `get_async_logger` or `runtime_async`.
 - **Sync apps/scripts**: `get_logger` or `runtime`.
 - Migration from sync to async: replace `get_logger` with `await get_async_logger`, and ensure log calls are awaited.
+
+## HTTP Context Correlation
+
+### How request_id Works
+
+When using `RequestContextMiddleware`, every request gets a `request_id` that automatically flows through to all logs:
+
+```
+Request starts → RequestContextMiddleware sets request_id="abc-123"
+  ↓
+Your code logs: {"message": "Fetching user", "request_id": "abc-123", "user_id": 42}
+  ↓
+Request ends → LoggingMiddleware logs: {"method": "GET", "path": "/users/42", "status": 200, "request_id": "abc-123"}
+```
+
+The `request_id` correlates all logs to the request. Use it to:
+- Find all logs for a specific request
+- Link errors to their HTTP context (method, path, status in the completion log)
+- Trace requests across services (pass `X-Request-ID` header)
+
+### Binding HTTP Context Explicitly
+
+If you need HTTP method/path in every log entry (not just the completion log), use `logger.bind()`:
+
+```python
+from fastapi import FastAPI, Request
+from fapilog import get_async_logger
+
+app = FastAPI()
+logger = await get_async_logger("api")
+
+@app.middleware("http")
+async def bind_http_context(request: Request, call_next):
+    # Bind HTTP context for all logs during this request
+    with logger.bind(http_method=request.method, http_path=request.url.path):
+        return await call_next(request)
+
+@app.get("/users/{user_id}")
+async def get_user(user_id: int):
+    await logger.info("Fetching user", user_id=user_id)
+    # Log includes: http_method="GET", http_path="/users/42"
+    return {"user_id": user_id}
+```
+
+### Querying Correlated Logs
+
+In your log aggregator (Loki, Elasticsearch, CloudWatch):
+
+```
+# Find all logs for a specific request
+request_id="abc-123"
+
+# Find requests to a specific endpoint (completion logs)
+message="request_completed" AND path="/api/users/*"
+
+# Then drill into a specific request
+request_id="<id from above>"
+```
+
+### When to Use Each Pattern
+
+| Use Case | Recommended Approach |
+|----------|---------------------|
+| Debugging a specific error | Query by `request_id` from error log |
+| Finding slow endpoints | Query completion logs by `latency_ms > 1000` |
+| Security audit by IP | Query completion logs (include `client_ip`) |
+| Adding HTTP context to every log | Use `logger.bind()` in middleware |
+
+**Note:** The `request_id` correlation pattern is usually sufficient. Adding method/path to every log increases log size without significant benefit—the completion log already has this data with the same `request_id`.


### PR DESCRIPTION
## Summary

Document existing patterns for HTTP request context instead of implementing a new enricher (story 5.20 cancelled).

## Rationale

After analysis, story 5.20 (HTTP Request Context Enricher) was cancelled because:

1. **`LoggingMiddleware`** already logs request completion with `method`, `path`, `status`, `latency_ms`
2. **`RequestContextMiddleware`** sets `request_id` in contextvars for every request
3. **`ContextVarsEnricher`** adds `request_id` to every log entry automatically
4. **`logger.bind()`** allows manual HTTP context binding when needed

The `request_id` correlation pattern is sufficient—adding `http_method`/`http_path` to every log provides marginal value over querying the completion log.

## Documentation Updates

### docs/user-guide/fastapi.md
- Added "HTTP Context Correlation" section explaining:
  - How `request_id` correlation works
  - How to use `logger.bind()` for explicit HTTP context
  - Best practices for querying correlated logs
  - When to use each pattern

### docs/examples/fastapi-logging.md
- Expanded with:
  - Middleware setup example
  - HTTP context binding pattern
  - Log correlation explanation
  - Clear notes on when each approach is appropriate