### PR TITLE
docs: Remove obsolete structlog references (Story 5.22)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,12 +345,14 @@ import os
 import sys
 
 # Third-party imports
-import structlog
 import pydantic
 
 # Local imports
-from fapilog import configure_logging
-from fapilog.settings import LoggingSettings
+from fapilog import get_logger
+from fapilog.core.settings import Settings
+
+logger = get_logger(settings=Settings())
+logger.info("Development server started", port=8000)
 ```
 
 ## Thank You!

--- a/docs/appendices.md
+++ b/docs/appendices.md
@@ -327,7 +327,7 @@ limitations under the License.
 
 fapilog builds on the work of many open source projects:
 
-- **structlog** - Structured logging foundation
+- **fapilog.core** - Native structured logging pipeline
 - **pydantic** - Data validation and settings
 - **anyio** - Async I/O utilities
 - **asyncio-mqtt** - MQTT client support

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,7 +153,7 @@ Based on your async-first requirements, performance targets, and enterprise comp
 | **Documentation**       | MkDocs Material    | 9.2+     | Documentation generation             | Beautiful docs for community adoption                            |
 | **CLI Framework**       | Typer              | 0.9+     | Command line interface               | FastAPI ecosystem, excellent async support                       |
 | **Metrics Collection**  | Prometheus Client  | 0.17+    | Performance metrics                  | Industry standard, enterprise SIEM integration                   |
-| **Structured Logging**  | structlog          | 23.1+    | Internal structured logging          | Async-first, zero-copy operations                                |
+| **Structured Logging**  | fapilog core       | N/A      | Native structured logging pipeline    | Async-first, zero-copy operations without external frameworks    |
 | **Plugin Packaging**    | setuptools         | 68.0+    | Plugin distribution                  | Standard Python packaging for marketplace                        |
 | **Container Platform**  | Docker             | 24.0+    | Containerization                     | Enterprise deployment requirements                               |
 | **CI/CD**               | GitHub Actions     | Latest   | Continuous integration               | Plugin marketplace automation                                    |

--- a/docs/architecture/tech-stack.md
+++ b/docs/architecture/tech-stack.md
@@ -22,7 +22,7 @@ Based on your async-first requirements, performance targets, and enterprise comp
 | **Documentation**       | MkDocs Material    | 9.2+     | Documentation generation             | Beautiful docs for community adoption                            |
 | **CLI Framework**       | Typer              | 0.9+     | Command line interface               | FastAPI ecosystem, excellent async support                       |
 | **Metrics Collection**  | Prometheus Client  | 0.17+    | Performance metrics                  | Industry standard, enterprise SIEM integration                   |
-| **Structured Logging**  | structlog          | 23.1+    | Internal structured logging          | Async-first, zero-copy operations                                |
+| **Structured Logging**  | fapilog core       | N/A      | Native structured logging pipeline    | Async-first, zero-copy operations without external frameworks    |
 | **Plugin Packaging**    | setuptools         | 68.0+    | Plugin distribution                  | Standard Python packaging for marketplace                        |
 | **Container Platform**  | Docker             | 24.0+    | Containerization                     | Enterprise deployment requirements                               |
 | **CI/CD**               | GitHub Actions     | Latest   | Continuous integration               | Plugin marketplace automation                                    |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -166,13 +166,15 @@ import sys
 from typing import Any, Dict, Optional
 
 # Third-party imports
-import structlog
 import pydantic
 from fastapi import FastAPI
 
 # Local imports
-from fapilog import configure_logging
-from fapilog.settings import LoggingSettings
+from fapilog import get_logger
+from fapilog.core.settings import Settings
+
+logger = get_logger(settings=Settings())
+logger.info("Development server started", port=8000)
 ```
 
 ### **Type Hints**
@@ -182,18 +184,17 @@ from fapilog.settings import LoggingSettings
 ```python
 from typing import Any, Dict, Optional
 
-def configure_logging(
-    settings: Optional[LoggingSettings] = None,
-    app: Optional[Any] = None
-) -> None:
-    """Configure logging with the given settings."""
-    pass
+from fapilog import get_logger
+from fapilog.core.settings import Settings
 
-async def write_log(
-    event_dict: Dict[str, Any]
-) -> None:
-    """Write log event to all configured sinks."""
-    pass
+
+def build_logger(settings: Optional[Settings] = None) -> Any:
+    """Create a logger with validated settings."""
+    return get_logger(settings=settings or Settings())
+
+def log_event(logger: Any, event_dict: Dict[str, Any]) -> None:
+    """Write a structured log event."""
+    logger.info("event received", **event_dict)
 ```
 
 ### **Docstrings**

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,6 @@ sphinx-copybutton>=0.5.0
 
 # Project dependencies needed for autodoc
 # These are required for Sphinx to import and document the code
-structlog
 pydantic>=2.11.0
 pydantic-settings>=2.0.0
 anyio


### PR DESCRIPTION
## Summary

Implements **Story 5.22**: Update documentation to reflect fapilog's native logging pipeline instead of referencing structlog as an external dependency.

## Changes

| File | Change |
|------|--------|
| `CONTRIBUTING.md` | Update import examples to use `fapilog.get_logger` |
| `docs/appendices.md` | Replace structlog credit with fapilog.core |
| `docs/architecture.md` | Update tech stack table |
| `docs/architecture/tech-stack.md` | Update tech stack table |
| `docs/contributing.md` | Update code examples |
| `docs/requirements.txt` | Remove structlog dependency |

## Context

Fapilog now has its own native async-first logging pipeline and no longer depends on structlog. These documentation updates ensure consistency and avoid confusion for new contributors.

## Type

- [x] Documentation only - no code changes