### PR TITLE
feat: clean up public API exports with explicit __all__

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing to fapilog! This document provides g
 
 - [Project Setup](#project-setup)
 - [Development Workflow](#development-workflow)
+- [Public API Policy](#public-api-policy)
 - [Commit & PR Guidelines](#commit--pr-guidelines)
 - [Release Process](#release-process)
 - [How to Get Help or Suggest Features](#how-to-get-help-or-suggest-features)
@@ -115,6 +116,21 @@ The hooks will run automatically on staged files when you commit. They include:
 - **Ruff** - Linting and code formatting
 - **MyPy** - Type checking
 - **Vulture** - Dead code detection
+
+## Public API Policy
+
+The stable public API is defined by each module's `__all__`. Symbols listed in `__all__` are versioned; anything else is internal and may change without notice. Conventions:
+
+- Use leading underscores (`as _Alias`) for internal imports to keep them out of the public namespace.
+- Add new public symbols to the module's `__all__` and keep it in sync with the intended surface.
+- Verify with `from fapilog import *` — only items in `__all__` should import.
+
+Inspect the current public surface:
+
+```python
+from fapilog import __all__
+print(__all__)
+```
 
 ### 5. Update CHANGELOG.md
 

--- a/src/fapilog/core/__init__.py
+++ b/src/fapilog/core/__init__.py
@@ -85,6 +85,7 @@ from .errors import (
     set_error_context,
     user_id_var,
 )
+from .events import LogEvent
 from .fallback import (
     AsyncFallbackWrapper,
     CacheFallback,
@@ -101,6 +102,7 @@ from .fallback import (
     get_fallback_manager,
     with_fallback,
 )
+from .logger import DrainResult
 from .marketplace import MarketplaceSettings
 from .observability import ObservabilitySettings, validate_observability
 from .plugin_config import (
@@ -236,6 +238,9 @@ __all__ = [
     # Concurrency utilities
     "BackpressurePolicy",
     "NonBlockingRingQueue",
+    # Event model and drain result
+    "LogEvent",
+    "DrainResult",
     # Audit trails
     "AuditEvent",
     "AuditEventType",

--- a/tests/unit/test_public_api_exports.py
+++ b/tests/unit/test_public_api_exports.py
@@ -1,0 +1,13 @@
+def test_import_star_exports_only_public_symbols():
+    ns: dict[str, object] = {}
+    exec("from fapilog import *", ns, ns)
+    # Exclude __builtins__ which is injected by exec(), keep __version__
+    exported = {name for name in ns if name != "__builtins__"}
+
+    import fapilog
+
+    assert exported == set(fapilog.__all__)
+    assert {"DrainResult", "LogEvent", "Settings", "__version__"} <= exported
+    # Ensure config classes and typing helpers aren't exported
+    assert "AuditSinkConfig" not in exported
+    assert "Any" not in exported


### PR DESCRIPTION
## Story 6.6: Add Explicit Public API Exports

### Summary
Clean up the public API exports to ensure `__all__` accurately reflects the stable public contract, hide internal imports, and document the API stability policy.

### Changes
- **Hide internal imports with `_` prefix**: Config classes (`AuditSinkConfig`, `CloudWatchSinkConfig`, etc.) and stdlib/typing imports (`Any`, `Path`, `asyncio`, etc.) are now prefixed to keep them out of the public namespace
- **Add `DrainResult` and `LogEvent` to main `__all__`**: These types are needed by plugin authors for type hints
- **Export `__version__` alongside `VERSION`**: Maintains backward compatibility
- **Add Public API Policy section to CONTRIBUTING.md**: Documents conventions for public vs internal imports
- **Add test verifying `import *` only exports `__all__` symbols**

### Acceptance Criteria
- [x] Config class imports use `_` prefix
- [x] `DrainResult` added to main `__all__` and importable from `fapilog`
- [x] `LogEvent` added to main `__all__` and importable from `fapilog`
- [x] Python stdlib/typing imports hidden with `_` prefix
- [x] CONTRIBUTING.md updated with "Public API Policy" section
- [x] `python -c "from fapilog import *"` only imports symbols from `__all__`

### Testing
```bash
python -c "from fapilog import *; print([x for x in dir() if x != '__builtins__'])"
# Output: ['DrainResult', 'LogEvent', 'Settings', 'VERSION', '__version__', 'get_async_logger', 'get_logger', 'runtime', 'runtime_async']
```

Closes: Story 6.6