### PR TITLE
chore: update gitignore to ignore .claude/ directory and CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,5 +255,7 @@ htmlcov/
 # Test artifacts
 .pytest_cache/
 .tox/ 
-.claude/review-work.md
+
+# Claude commands
+.claude/
 CLAUDE.md


### PR DESCRIPTION
Updates .gitignore to ignore the entire `.claude/` directory instead of a specific file, and also ignores `CLAUDE.md`.