### PR TITLE
feat: add pretty console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Added pretty console output (`stdout_pretty`) and `format` selection for stdout logging.
+
 ## [0.3.3] - 2025-12-22
 
 - Project status upgraded from Alpha to Beta classification.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See the full guide at `docs/getting-started/installation.md` for extras and upgr
 ## 🚀 Features (core)
 
 - Async-first architecture (background worker, non-blocking enqueue)
-- Structured JSON output (stdout sink by default)
+- Auto console output (pretty in TTY, JSON when piped)
 - Plugin-friendly (enrichers, redactors, processors, sinks)
 - Context binding and exception serialization
 - Guardrails: redaction stages, error de-duplication
@@ -61,13 +61,18 @@ See the full guide at `docs/getting-started/installation.md` for extras and upgr
 ```python
 from fapilog import get_logger, runtime
 
-# Zero-config logger with isolated background worker and stdout JSON sink
+# Zero-config logger with isolated background worker and auto console output
 logger = get_logger(name="app")
 logger.info("Application started", environment="production")
 
 # Scoped runtime that auto-flushes on exit
 with runtime() as log:
     log.error("Something went wrong", code=500)
+```
+
+Example output (TTY):
+```
+2025-01-11 14:30:22 | INFO     | Application started environment=production
 ```
 
 ### Configuration Presets

--- a/docs/api-reference/plugins/sinks.md
+++ b/docs/api-reference/plugins/sinks.md
@@ -37,7 +37,8 @@ class SerializedView:
 
 ## Built-in sinks
 
-- **stdout_json**: default sink, JSON lines to stdout.
+- **stdout_json**: JSON lines to stdout.
+- **stdout_pretty**: human-readable console output with ANSI colors (TTY only).
 - **rotating_file**: size/time-based rotation with optional compression.
 - **http**: POST log entries to an HTTP endpoint.
 - **webhook**: POST log entries to a webhook with optional signing.

--- a/docs/api-reference/top-level-functions.md
+++ b/docs/api-reference/top-level-functions.md
@@ -8,6 +8,8 @@ Main entry points and utilities for fapilog.
 def get_logger(
     name: str | None = None,
     *,
+    preset: str | None = None,
+    format: Literal["json", "pretty", "auto"] | None = None,
     settings: _Settings | None = None,
 ) -> _SyncLoggerFacade
 ```
@@ -19,6 +21,8 @@ Return a ready-to-use **synchronous** logger facade wired to a container-scoped 
 | Parameter  | Type                | Default | Description                                                    |
 | ---------- | ------------------- | ------- | -------------------------------------------------------------- |
 | `name`     | `str \| None`       | `None`  | Logger name for identification. If None, uses the module name. |
+| `preset`   | `str \| None`       | `None`  | Built-in preset (`dev`, `production`, `fastapi`, `minimal`).   |
+| `format`   | `Literal[...]`      | `None`  | Output format: `json`, `pretty`, `auto` (pretty in TTY).        |
 | `settings` | `_Settings \| None` | `None`  | Custom settings. If None, uses environment variables.          |
 
 ### Returns
@@ -45,6 +49,10 @@ settings = Settings(core__enable_metrics=True)
 logger = get_logger(settings=settings)
 logger.info("Metrics-enabled logger ready")
 
+# Force pretty output
+logger = get_logger(format="pretty")
+logger.info("Readable output", request_id="abc-123")
+
 # Manual cleanup if you are not using runtime()
 asyncio.run(logger.stop_and_drain())
 ```
@@ -61,7 +69,9 @@ The following environment variables are automatically read:
 
 - Sync API surface: `debug`, `info`, `warning`, `error`, `exception`, `bind`, `unbind`, `clear_context`
 - Worker lifecycle is managed automatically; call `logger.stop_and_drain()` if you need explicit shutdown.
-- Automatic sink selection: chooses stdout JSON by default or file/http sink when configured via settings/env.
+- Automatic sink selection: pretty in TTY, JSON when piped; file/http sink when configured via settings/env.
+- `preset` and `settings` are mutually exclusive; `format` and `settings` are mutually exclusive.
+- When `settings` is omitted, the default `format` behavior is `auto`.
 
 ## get_async_logger (async) {#get_async_logger}
 
@@ -69,6 +79,8 @@ The following environment variables are automatically read:
 async def get_async_logger(
     name: str | None = None,
     *,
+    preset: str | None = None,
+    format: Literal["json", "pretty", "auto"] | None = None,
     settings: _Settings | None = None,
 ) -> _AsyncLoggerFacade
 ```
@@ -80,6 +92,8 @@ Return a ready-to-use **async** logger facade with awaitable methods.
 | Parameter  | Type                | Default | Description                                                    |
 | ---------- | ------------------- | ------- | -------------------------------------------------------------- |
 | `name`     | `str \| None`       | `None`  | Logger name for identification. If None, uses the module name. |
+| `preset`   | `str \| None`       | `None`  | Built-in preset (`dev`, `production`, `fastapi`, `minimal`).   |
+| `format`   | `Literal[...]`      | `None`  | Output format: `json`, `pretty`, `auto` (pretty in TTY).        |
 | `settings` | `_Settings \| None` | `None`  | Custom settings. If None, uses environment variables.          |
 
 ### Returns

--- a/docs/core-concepts/sinks.md
+++ b/docs/core-concepts/sinks.md
@@ -6,7 +6,8 @@ Destinations for log output.
 
 ## Built-in sinks
 
-- **Stdout JSON**: default sink; emits JSON lines to stdout.
+- **Stdout pretty**: human-readable console output (TTY).
+- **Stdout JSON**: structured JSON lines to stdout.
 - **Rotating file**: size/time-based rotation with optional compression.
 - **HTTP client**: POST log entries to an HTTP endpoint.
 - **MMAP persistence**: experimental local persistence sink.
@@ -15,7 +16,7 @@ Destinations for log output.
 
 - If `FAPILOG_HTTP__ENDPOINT` is set, the HTTP sink is used.
 - Else if `FAPILOG_FILE__DIRECTORY` is set, the rotating file sink is used.
-- Otherwise, stdout JSON is used.
+- Otherwise, stdout auto is used (pretty in TTY, JSON when piped).
 
 ## Fast-path serialization
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -17,7 +17,7 @@
 | `FAPILOG_CORE__ENRICHERS` | list | PydanticUndefined | Enricher plugins to use (by name) |
 | `FAPILOG_CORE__ERROR_DEDUPE_WINDOW_SECONDS` | float | 5.0 | Seconds to suppress duplicate ERROR logs with the same message; 0 disables deduplication |
 | `FAPILOG_CORE__EXCEPTIONS_ENABLED` | bool | True | Enable structured exception serialization for log calls |
-| `FAPILOG_CORE__EXCEPTIONS_MAX_FRAMES` | int | 50 | Maximum number of stack frames to capture for exceptions |
+| `FAPILOG_CORE__EXCEPTIONS_MAX_FRAMES` | int | 10 | Maximum number of stack frames to capture for exceptions |
 | `FAPILOG_CORE__EXCEPTIONS_MAX_STACK_CHARS` | int | 20000 | Maximum total characters for serialized stack string |
 | `FAPILOG_CORE__FILTERS` | list | PydanticUndefined | Filter plugins to apply before enrichment (by name) |
 | `FAPILOG_CORE__INTERNAL_LOGGING_ENABLED` | bool | False | Emit DEBUG/WARN diagnostics for internal errors |

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -15,6 +15,7 @@
 | runtime_info | enricher | 1.0.0 | 1.0 | Fapilog Core | Adds runtime/system information such as host, pid, and python version. |
 | size_guard | processor | 1.0.0 | 1.0 | Fapilog Core | Enforces maximum payload size for downstream compatibility. |
 | stdout_json | sink | 1.0.0 | 1.0 | Fapilog Core | Async stdout JSONL sink |
+| stdout_pretty | sink | 1.0.0 | 1.0 | Fapilog Core | Async stdout pretty console sink |
 | url_credentials | redactor | 1.0.0 | 1.0 | Fapilog Core | Strips user:pass@ credentials from URL-like strings. |
 | webhook | sink | 1.0.0 | 1.0 | Fapilog Core | Webhook sink that POSTs JSON with optional signing. |
 | zero_copy | processor | 1.0.0 | 1.0 | Fapilog Core | Zero-copy pass-through processor for performance benchmarking. |

--- a/docs/plugins/sinks.md
+++ b/docs/plugins/sinks.md
@@ -28,7 +28,8 @@ class MySink(BaseSink):
 
 ## Built-in sinks (code-supported)
 
-- `stdout_json` (default)
+- `stdout_json` (structured JSON)
+- `stdout_pretty` (human-readable console output)
 - `rotating_file` (size/time rotation)
 - `http` (HTTP POST)
 - `webhook` (JSON webhook with optional batching)

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -107,7 +107,7 @@
       "type": "boolean"
     },
     "exceptions_max_frames": {
-      "default": 50,
+      "default": 10,
       "description": "Maximum number of stack frames to capture for exceptions",
       "minimum": 1,
       "title": "Exceptions Max Frames",

--- a/docs/settings-guide.md
+++ b/docs/settings-guide.md
@@ -32,7 +32,7 @@ This guide documents Settings groups and fields.
 | `core.redaction_max_depth` | int | None | 6 | Optional max depth guardrail for nested redaction |
 | `core.redaction_max_keys_scanned` | int | None | 5000 | Optional max keys scanned guardrail for redaction |
 | `core.exceptions_enabled` | bool | True | Enable structured exception serialization for log calls |
-| `core.exceptions_max_frames` | int | 50 | Maximum number of stack frames to capture for exceptions |
+| `core.exceptions_max_frames` | int | 10 | Maximum number of stack frames to capture for exceptions |
 | `core.exceptions_max_stack_chars` | int | 20000 | Maximum total characters for serialized stack string |
 | `core.strict_envelope_mode` | bool | False | If True, drop emission when envelope cannot be produced; otherwise fallback to best-effort serialization with diagnostics |
 | `core.capture_unhandled_enabled` | bool | False | Automatically install unhandled exception hooks (sys/asyncio) |

--- a/docs/stories/10.2.pretty-console-output.md
+++ b/docs/stories/10.2.pretty-console-output.md
@@ -1,144 +1,1665 @@
 # Story 10.2: Pretty Console Output for Development
 
-## Status: Planned
-
-## Priority: Medium
-
-## Estimated Effort: Small (1 day)
-
-## Dependencies
-
-- **Depends on:** Story 10.1 (Configuration Presets) - Uses preset system
-
-## Epic / Series
-
-Part of Epic 10: Developer Experience and Ergonomics / Series 10.x
-
----
+## Status: Complete
 
 ## Context / Background
 
-During local development, JSON logs are hard to scan. A readable, colored console format should be available by default in dev preset or when output is a TTY.
+Currently, fapilog outputs JSON to stdout in all cases. While JSON is excellent for production (structured, parseable, machine-readable), it's terrible for local development. Developers debug with their eyes, not with `jq`.
+
+**Current experience (JSON output):**
+
+```json
+{"timestamp":"2025-01-11T14:30:22.123Z","level":"INFO","message":"User login successful","user_id":123,"request_id":"abc-123","duration_ms":45}
+{"timestamp":"2025-01-11T14:30:23.456Z","level":"ERROR","message":"Database connection failed","host":"localhost","port":5432,"error":"timeout"}
+```
+
+**Target experience (Pretty output):**
+
+```
+2025-01-11 14:30:22 | INFO     | User login successful user_id=123 request_id=abc-123 duration_ms=45
+2025-01-11 14:30:23 | ERROR    | Database connection failed host=localhost port=5432 error=timeout
+```
+
+This story implements human-readable console output with colors, making fapilog as pleasant for development as loguru while maintaining its superior async architecture.
 
 ## Scope (In / Out)
 
 ### In Scope
 
-- Pretty formatter with colors and inline key-value output.
-- TTY-aware default behavior with a `format` option (auto, json, pretty).
-- Ability to disable colors for CI or user preference.
-- Tests for formatting, TTY detection, and color toggles.
+- New `StdoutPrettySink` plugin for human-readable console output
+
+- ANSI color codes for log levels (ERROR=red, WARNING=yellow, INFO=blue, DEBUG=gray)
+
+- TTY auto-detection (colors in terminal, no colors when piped)
+
+- `format` parameter in `get_logger()` and `get_async_logger()`
+
+- Exception traceback formatting (Python-style, readable)
+
+- Integration with Story 10.1's dev preset
+
+- Comprehensive tests and documentation
 
 ### Out of Scope
 
-- Replacing JSON output for production sinks.
-- New third-party formatting dependencies unless strictly necessary.
+- Syntax highlighting of exception code (defer to future story if demand exists)
+
+- Rich library integration (manual ANSI codes sufficient)
+
+- Custom color schemes (fixed color palette for consistency)
+
+- Pretty formatting for file sinks (files should stay JSON)
+
+- Variable inspection in exception frames (security risk)
+
+- Source code snippets in tracebacks (too verbose)
 
 ## Acceptance Criteria
 
-1. Pretty formatter renders timestamp, level, message, and key-value fields.
-2. Colored levels: ERROR red, WARNING yellow, INFO blue, DEBUG gray.
-3. `format="auto"` selects pretty when stdout is a TTY, JSON otherwise.
-4. `format="pretty"` and `format="json"` override auto behavior.
-5. `pretty_colors=False` disables ANSI codes.
-6. Pretty formatting only applies to stdout sink; JSON sinks are untouched.
-7. dev preset uses pretty by default; production preset uses JSON.
-8. Tests cover formatting and TTY behavior.
+### AC1: Pretty Sink Implementation
+
+**New sink created**: `src/fapilog/plugins/sinks/stdout_pretty.py`
+
+**Features:**
+
+- Human-readable timestamp format: `YYYY-MM-DD HH:MM:SS`
+
+- Colored log levels with consistent width padding
+
+- Message followed by key-value pairs inline
+
+- ANSI color codes for terminals
+
+- Graceful degradation (no colors in pipes/files)
+
+- Exception tracebacks formatted like Python's native output
+
+**Code structure:**
+
+```python
+class StdoutPrettySink:
+    """Human-readable console sink with ANSI colors."""
+    name = "stdout_pretty"
+
+    def __init__(self, *, colors: bool = True):
+        """
+        Args:
+            colors: Enable ANSI colors (default True, auto-disabled for non-TTY)
+        """
+        self._colors_enabled = colors
+        self._use_colors = colors and sys.stdout.isatty()
+
+    async def write(self, entry: dict[str, Any]) -> None:
+        """Format and write entry to stdout."""
+        formatted = self._format_pretty(entry)
+        sys.stdout.write(formatted + "\n")
+        sys.stdout.flush()
+```
+
+### AC2: Format Parameter API
+
+**Add `format` parameter** to both logger factories:
+
+```python
+def get_logger(
+    name: str | None = None,
+    *,
+    preset: str | None = None,
+    format: Literal["json", "pretty", "auto"] | None = "auto",
+    settings: _Settings | None = None,
+    sinks: list[object] | None = None,
+) -> _SyncLoggerFacade:
+    """
+    Args:
+        format: Output format - "json" (structured), "pretty" (human-readable),
+                "auto" (pretty in TTY, json otherwise). Default: "auto"
+    """
+```
+
+**Behavior:**
+
+- `format="auto"` (default): Use pretty in TTY, JSON otherwise
+
+- `format="pretty"`: Force pretty output
+
+- `format="json"`: Force JSON output
+
+- `format` is mutually exclusive with `settings` (raises ValueError)
+
+- If both `preset` and `format` provided, `format` wins (explicit override)
+
+**Examples:**
+
+```python
+# Auto-detect (default)
+logger = get_logger()  # Pretty in terminal, JSON when piped
+# Explicit pretty
+logger = get_logger(format="pretty")
+# Explicit JSON
+logger = get_logger(format="json")
+# Override preset
+logger = get_logger(preset="production", format="pretty")  # Force pretty
+```
+
+### AC3: ANSI Color Codes
+
+**Color mapping:**
+
+```python
+COLORS = {
+    "DEBUG": "\033[90m",      # Bright black (gray)
+    "INFO": "\033[34m",       # Blue
+    "WARNING": "\033[33m",    # Yellow
+    "ERROR": "\033[31m",      # Red
+    "CRITICAL": "\033[1;31m", # Bold red
+    "RESET": "\033[0m",       # Reset
+}
+```
+
+**Behavior:**
+
+- Colors only applied when `sys.stdout.isatty()` returns `True`
+
+- No colors when output is piped: `python app.py | tee log.txt`
+
+- No colors when redirected: `python app.py > output.txt`
+
+- Colors work on: Linux, macOS, Windows 10+ (ANSI support built-in)
+
+**Validation:**
+
+```python
+# In terminal (TTY)
+$ python app.py
+2025-01-11 14:30:22 | ERROR    | Connection failed  # Red "ERROR"
+# Piped (no TTY)
+$ python app.py | cat
+2025-01-11 14:30:22 | ERROR    | Connection failed  # No ANSI codes
+```
+
+### AC4: Output Format Specification
+
+**Format structure:**
+
+```
+{timestamp} | {level:8} | {message} {key1=value1} {key2=value2} ...
+# Examples:
+2025-01-11 14:30:22 | INFO     | Application started env=production version=1.0.0
+2025-01-11 14:30:23 | WARNING  | High memory usage percent=85 threshold=80
+2025-01-11 14:30:24 | ERROR    | Database query failed query=SELECT table=users duration_ms=5000
+2025-01-11 14:30:25 | DEBUG    | Cache hit key=user:123 ttl=3600
+```
+
+**Formatting rules:**
+
+- Timestamp: `YYYY-MM-DD HH:MM:SS` (local timezone, no milliseconds for readability)
+
+- Separator: `|` (pipe with spaces)
+
+- Level: Right-padded to 8 characters for alignment
+
+- Message: First, no quotes
+
+- Context: Space-separated key=value pairs
+
+- String values: No quotes unless they contain spaces
+
+- String values with spaces: Single quotes (`key='value with spaces'`)
+
+- Nested objects: Flatten to dot notation (`user.name=John`)
+
+### AC5: Exception Formatting
+
+**Traceback format** (Python-style):
+
+```python
+logger.error("Database operation failed", exc_info=True)
+# Output:
+2025-01-11 14:30:24 | ERROR    | Database operation failed
+Traceback (most recent call last):
+  File "/app/main.py", line 42, in connect_db
+    conn = psycopg2.connect(dsn)
+  File "/usr/lib/python3.11/site-packages/psycopg2/__init__.py", line 122, in connect
+    return Connection(dsn)
+psycopg2.OperationalError: connection timeout after 30 seconds
+Context: host=localhost port=5432 database=myapp retry_count=3
+```
+
+**Features:**
+
+- Native Python traceback format (familiar, copy-paste to Stack Overflow)
+
+- Full file paths with line numbers
+
+- Exception type and message
+
+- Log context printed below traceback
+
+- Frame limit: 10 frames by default (configurable via Settings)
+
+- No syntax highlighting (v1 - defer to future story)
+
+- No variable values from frames (security risk)
+
+### AC6: Integration with Story 10.1 Dev Preset
+
+**Update dev preset** to use pretty output:
+
+```python
+# src/fapilog/core/presets.py
+PRESETS = {
+    "dev": {
+        "core": {
+            "log_level": "DEBUG",
+            "internal_logging_enabled": True,
+            "batch_max_size": 1,
+        },
+        "sinks": ["stdout_pretty"],  # CHANGED: was stdout_json
+        "enricher_config": {
+            "runtime_info": {"enabled": True},
+            "context_vars": {"enabled": True},
+        },
+        # ... rest unchanged
+    },
+    # Other presets unchanged
+}
+```
+
+**Result:**
+
+```python
+# Now dev preset gives pretty output automatically
+logger = get_logger(preset="dev")
+logger.info("Starting app")  # Colored, human-readable
+```
+
+### AC7: Performance Requirements
+
+**Benchmark thresholds:**
+
+- Pretty formatting overhead: < 2x JSON formatting
+
+- Absolute performance: < 100 microseconds per log entry
+
+- TTY detection: Cached (not checked per-log)
+
+- Color application: Lazy (skip if colors disabled)
+
+**Performance tests pass:**
+
+```python
+def test_pretty_format_performance(benchmark):
+    """Pretty formatting < 100 microseconds."""
+    sink = StdoutPrettySink()
+    event = {"level": "INFO", "message": "Test", "key": "value"}
+    result = benchmark(lambda: sink._format_pretty(event))
+    assert result.stats.mean < 0.0001  # 100 μs
+
+def test_pretty_vs_json_overhead(benchmark):
+    """Pretty < 2x JSON formatting time."""
+    # Compare StdoutPrettySink vs StdoutJsonSink
+    # Assert pretty_time < json_time * 2
+```
+
+### AC8: Documentation & Examples
+
+**Documentation updated:**
+
+- `README.md`: Add pretty output example in Quick Start
+
+- `docs/user-guide/configuration.md`: Document `format` parameter
+
+- `docs/api-reference/sinks.md`: Document StdoutPrettySink
+
+- `examples/pretty_console/`: Add example showing pretty output
+
+**Before/after comparison** in docs:
+
+```markdown
+### Before (JSON output)
+{"timestamp":"2025-01-11T14:30:22Z","level":"INFO","message":"User login"}
+### After (Pretty output)
+2025-01-11 14:30:22 | INFO | User login user_id=123
+```
+
+## API Design Decision
+
+### Problem Statement
+
+Where should the `format` parameter live, and how does it interact with presets and settings?
+
+### Options Considered
+
+**Option A: Top-level parameter (CHOSEN)**
+
+```python
+def get_logger(
+    name: str | None = None,
+    *,
+    preset: str | None = None,
+    format: Literal["json", "pretty", "auto"] | None = "auto",  # NEW
+    settings: _Settings | None = None,
+    sinks: list[object] | None = None,
+) -> _SyncLoggerFacade:
+```
+
+**Pros:**
+
+- ✅ Simple, discoverable API
+
+- ✅ Consistent with `preset` parameter (Story 10.1)
+
+- ✅ Type-safe with Literal type
+
+- ✅ Matches loguru's simplicity (single function call)
+
+- ✅ Auto-detection is default (smart)
+
+**Cons:**
+
+- ❌ Adds another parameter to signature
+
+- ❌ Mutually exclusive with `settings` (more validation)
+
+---
+
+**Option B: Settings-only**
+
+```python
+settings = Settings(sinks={"stdout_pretty": {"enabled": True}})
+logger = get_logger(settings=settings)
+```
+
+**Pros:**
+
+- ✅ No signature changes
+
+- ✅ Full control via Settings
+
+**Cons:**
+
+- ❌ Requires Settings object for simple case
+
+- ❌ Verbose (10 lines vs 1 line)
+
+- ❌ Doesn't match loguru simplicity
+
+- ❌ No auto-detection
+
+---
+
+**Option C: Environment variable only**
+
+```python
+# FAPILOG_FORMAT=pretty python app.py
+logger = get_logger()
+```
+
+**Pros:**
+
+- ✅ No code changes needed
+
+- ✅ Easy to toggle per-environment
+
+**Cons:**
+
+- ❌ Not discoverable (hidden configuration)
+
+- ❌ Can't be set programmatically in tests
+
+- ❌ Environment pollution
+
+---
+
+### Decision: Option A (Top-level Parameter)
+
+**Rationale:**
+
+1. **Best DX**: One parameter, auto-detects TTY, just works
+
+2. **Progressive disclosure**: Simple for beginners (`format="pretty"`), powerful for experts (Settings)
+
+3. **Consistent**: Follows same pattern as `preset` parameter from Story 10.1
+
+4. **Explicit > Implicit**: Developers can force format when needed
+
+5. **Type-safe**: Literal type provides IDE autocomplete
+
+**Precedence rules:**
+
+```python
+# format and settings are mutually exclusive
+get_logger(format="pretty", settings=Settings())  # ❌ Raises ValueError
+
+# format overrides preset default
+get_logger(preset="production", format="pretty")  # ✅ Forces pretty despite production
+
+# Auto-detection is smart default
+get_logger()  # ✅ Pretty in TTY, JSON when piped
+```
+
+**Future considerations:**
+
+- Story 10.x could add per-sink format control
+
+- Environment variable `FAPILOG_FORMAT` could override default
 
 ## Implementation Notes
 
-- Add a new `stdout_pretty` sink or a formatter helper used by stdout output.
-- Keep performance by avoiding extra serialization for JSON sinks.
-- Assumption: ANSI color codes are acceptable and can be disabled.
+### File Structure
+
+```
+src/fapilog/plugins/sinks/stdout_pretty.py (NEW)
+src/fapilog/__init__.py (MODIFIED - add format parameter)
+src/fapilog/core/presets.py (MODIFIED - update dev preset)
+tests/unit/test_stdout_pretty_sink.py (NEW)
+tests/integration/test_pretty_output_integration.py (NEW)
+examples/pretty_console/ (NEW)
+```
+
+### Implementation Steps
+
+#### Step 1: Create `StdoutPrettySink`
+
+**File**: `src/fapilog/plugins/sinks/stdout_pretty.py`
+
+```python
+"""Human-readable console sink with ANSI colors."""
+from __future__ import annotations
+import sys
+import traceback
+from datetime import datetime
+from typing import Any
+# ANSI color codes
+COLORS = {
+    "DEBUG": "\033[90m",      # Bright black (gray)
+    "INFO": "\033[34m",       # Blue
+    "WARNING": "\033[33m",    # Yellow
+    "ERROR": "\033[31m",      # Red
+    "CRITICAL": "\033[1;31m", # Bold red
+    "RESET": "\033[0m",       # Reset
+}
+LEVEL_PADDING = 8  # "CRITICAL" is 8 chars
+
+class StdoutPrettySink:
+    """Pretty console sink with human-readable output and colors.
+    Features:
+    - Human-readable timestamps (YYYY-MM-DD HH:MM:SS)
+    - Colored log levels (auto-disabled in non-TTY)
+    - Inline key-value pairs
+    - Python-style exception tracebacks
+    - Zero external dependencies (pure ANSI codes)
+    """
+    name = "stdout_pretty"
+
+    def __init__(self, *, colors: bool = True):
+        """Initialize pretty console sink.
+        Args:
+            colors: Enable ANSI colors. Auto-disabled if not TTY.
+        """
+        self._colors_enabled = colors
+        self._use_colors = colors and sys.stdout.isatty()
+
+    async def start(self) -> None:
+        """Lifecycle hook - no setup needed."""
+        pass
+
+    async def stop(self) -> None:
+        """Lifecycle hook - no cleanup needed."""
+        pass
+
+    async def write(self, entry: dict[str, Any]) -> None:
+        """Format and write log entry to stdout.
+        Args:
+            entry: Log event dict with timestamp, level, message, etc.
+        """
+        try:
+            formatted = self._format_pretty(entry)
+            sys.stdout.write(formatted + "\n")
+            sys.stdout.flush()
+        except Exception as e:
+            # Fallback to stderr if formatting fails
+            sys.stderr.write(f"[fapilog] Pretty sink error: {e}\n")
+
+    def _format_pretty(self, entry: dict[str, Any]) -> str:
+        """Format log entry as human-readable string.
+        Format: {timestamp} | {level:8} | {message} {key=value} ...
+        """
+        # Extract core fields
+        timestamp = entry.get("timestamp", "")
+        level = entry.get("level", "INFO")
+        message = entry.get("message", "")
+        # Format timestamp (human-readable)
+        ts_formatted = self._format_timestamp(timestamp)
+        # Format level with color and padding
+        level_formatted = self._format_level(level)
+        # Format context (key-value pairs)
+        context = self._format_context(entry)
+        # Build main log line
+        parts = [ts_formatted, level_formatted, message]
+        if context:
+            parts.append(context)
+        result = " | ".join(parts[:3])  # timestamp | level | message
+        if len(parts) > 3:
+            result += " " + parts[3]  # Append context
+        # Add exception traceback if present
+        if "exception" in entry:
+            result += "\n" + self._format_exception(entry)
+        return result
+
+    def _format_timestamp(self, timestamp: str | float | datetime) -> str:
+        """Format timestamp as YYYY-MM-DD HH:MM:SS."""
+        if isinstance(timestamp, str):
+            # Parse ISO format
+            try:
+                dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                return timestamp[:19]  # Fallback: truncate to YYYY-MM-DD HH:MM:SS
+        elif isinstance(timestamp, (int, float)):
+            dt = datetime.fromtimestamp(timestamp)
+        elif isinstance(timestamp, datetime):
+            dt = timestamp
+        else:
+            return str(timestamp)
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+    def _format_level(self, level: str) -> str:
+        """Format level with color and padding."""
+        # Pad to consistent width
+        padded = level.ljust(LEVEL_PADDING)
+        # Apply color
+        if self._use_colors and level in COLORS:
+            color = COLORS[level]
+            reset = COLORS["RESET"]
+            return f"{color}{padded}{reset}"
+        return padded
+
+    def _format_context(self, entry: dict[str, Any]) -> str:
+        """Format context as key=value pairs.
+        Skip internal fields: timestamp, level, message, exception
+        """
+        skip_keys = {"timestamp", "level", "message", "exception", "logger", "name"}
+        pairs = []
+        for key, value in entry.items():
+            if key in skip_keys:
+                continue
+            # Format value
+            if isinstance(value, str):
+                # Quote if contains spaces
+                formatted_value = f"'{value}'" if " " in value else value
+            elif isinstance(value, dict):
+                # Flatten nested dicts (e.g., user.name=John)
+                for nested_key, nested_value in value.items():
+                    pairs.append(f"{key}.{nested_key}={nested_value}")
+                continue
+            else:
+                formatted_value = str(value)
+            pairs.append(f"{key}={formatted_value}")
+        return " ".join(pairs)
+
+    def _format_exception(self, entry: dict[str, Any]) -> str:
+        """Format exception as Python-style traceback.
+        Output:
+            Traceback (most recent call last):
+              File "app.py", line 42, in func
+                code()
+            ExceptionType: message
+            Context: key=value ...
+        """
+        exc_info = entry.get("exception")
+        if not exc_info or not isinstance(exc_info, dict):
+            return ""
+        # Extract exception data
+        exc_type = exc_info.get("type", "Exception")
+        exc_value = exc_info.get("value", "")
+        exc_traceback = exc_info.get("traceback", "")
+        # Format traceback (use stdlib if available, fallback to string)
+        if exc_traceback and hasattr(exc_traceback, '__traceback__'):
+            # Full traceback object available
+            tb_lines = traceback.format_exception(
+                type(exc_type),
+                exc_value,
+                exc_traceback,
+                limit=10  # Frame limit from settings
+            )
+            formatted = "".join(tb_lines)
+        else:
+            # Fallback: build from stored data
+            formatted = f"Traceback (most recent call last):\n"
+            if isinstance(exc_traceback, str):
+                formatted += exc_traceback
+            formatted += f"\n{exc_type}: {exc_value}"
+        # Add context below traceback
+        context = self._format_context(entry)
+        if context:
+            formatted += f"\n\nContext: {context}"
+        return formatted
+# Plugin registration
+def get_sink_config():
+    """Plugin entrypoint for sink discovery."""
+    return {
+        "name": "stdout_pretty",
+        "class": StdoutPrettySink,
+        "config_class": None,  # No config needed
+    }
+```
+
+#### Step 2: Add `format` Parameter to `get_logger()`
+
+**File**: `src/fapilog/__init__.py`
+
+```python
+from typing import Literal
+
+def get_logger(
+    name: str | None = None,
+    *,
+    preset: str | None = None,
+    format: Literal["json", "pretty", "auto"] | None = "auto",  # NEW
+    settings: _Settings | None = None,
+    sinks: list[object] | None = None,
+) -> _SyncLoggerFacade:
+    """Get a synchronous logger.
+    Args:
+        name: Logger name
+        preset: Configuration preset (dev, production, fastapi, minimal)
+        format: Output format - "json" (structured), "pretty" (human-readable),
+                "auto" (pretty in TTY, json otherwise). Default: "auto"
+        settings: Full Settings object for advanced configuration
+        sinks: Custom sink instances
+    Raises:
+        ValueError: If both preset and settings provided
+        ValueError: If both format and settings provided
+        ValueError: If format is invalid
+    """
+    # Validate mutual exclusivity
+    if format is not None and settings is not None:
+        raise ValueError(
+            "Cannot specify both 'format' and 'settings'. "
+            "Use format for simple output control or settings for full control."
+        )
+    if preset is not None and settings is not None:
+        raise ValueError(
+            "Cannot specify both 'preset' and 'settings'. "
+            "Use preset for quick setup or settings for full control."
+        )
+    # Apply format if provided
+    if format is not None:
+        settings = _apply_format(format, preset)
+    # Apply preset if provided (and format didn't already create settings)
+    elif preset is not None:
+        from .core.presets import get_preset
+        preset_config = get_preset(preset)
+        settings = _Settings(**preset_config)
+    # Continue with existing logic...
+    setup = _configure_logger_common(settings, sinks)
+    # ... rest unchanged
+def _apply_format(
+    format: str,
+    preset: str | None = None,
+) -> _Settings:
+    """Apply format setting, respecting preset if provided.
+    Args:
+        format: "json", "pretty", or "auto"
+        preset: Optional preset to use as base
+    Returns:
+        Settings object with appropriate sink configured
+    """
+    import sys
+    # Determine which sink to use
+    if format == "auto":
+        # Auto-detect TTY
+        use_pretty = sys.stdout.isatty()
+    elif format == "pretty":
+        use_pretty = True
+    elif format == "json":
+        use_pretty = False
+    else:
+        raise ValueError(
+            f"Invalid format '{format}'. Valid formats: json, pretty, auto"
+        )
+    # Start with preset if provided
+    if preset:
+        from .core.presets import get_preset
+        config = get_preset(preset)
+    else:
+        config = {}
+    # Override sink based on format
+    if use_pretty:
+        config["sinks"] = ["stdout_pretty"]
+    else:
+        config["sinks"] = ["stdout_json"]
+    return _Settings(**config)
+# Same for get_async_logger()
+async def get_async_logger(
+    name: str | None = None,
+    *,
+    preset: str | None = None,
+    format: Literal["json", "pretty", "auto"] | None = "auto",  # NEW
+    settings: _Settings | None = None,
+    sinks: list[object] | None = None,
+) -> _AsyncLoggerFacade:
+    """Get an async logger.
+    Args:
+        name: Logger name
+        preset: Configuration preset
+        format: Output format (json, pretty, auto)
+        settings: Full Settings object
+        sinks: Custom sink instances
+    """
+    # Same validation and format application as get_logger()
+    # ... (duplicate logic from above)
+```
+
+#### Step 3: Update Dev Preset
+
+**File**: `src/fapilog/core/presets.py`
+
+```python
+PRESETS: dict[str, dict[str, Any]] = {
+    "dev": {
+        "core": {
+            "log_level": "DEBUG",
+            "internal_logging_enabled": True,
+            "batch_max_size": 1,
+        },
+        "sinks": ["stdout_pretty"],  # CHANGED: was stdout_json
+        "enricher_config": {
+            "runtime_info": {"enabled": True},
+            "context_vars": {"enabled": True},
+        },
+        "redactor_config": {
+            "field_mask": {"enabled": False},
+            "url_credentials": {"enabled": False},
+        },
+    },
+    # Other presets unchanged
+}
+```
+
+#### Step 4: Register Plugin
+
+**File**: `src/fapilog/plugins/sinks/__init__.py`
+
+```python
+# Add to imports
+from .stdout_pretty import StdoutPrettySink
+# Add to __all__
+__all__ = [
+    "StdoutJsonSink",
+    "StdoutPrettySink",  # NEW
+    # ... rest
+]
+```
+
+**File**: `pyproject.toml` (if using entry points)
+
+```toml
+[project.entry-points."fapilog.sinks"]
+stdout_pretty = "fapilog.plugins.sinks.stdout_pretty:StdoutPrettySink"
+```
+
+### Color Application Strategy
+
+```python
+# Optimization: Cache TTY detection result
+class StdoutPrettySink:
+
+    def __init__(self, *, colors: bool = True):
+        # Check TTY once at init, not per-log
+        self._use_colors = colors and sys.stdout.isatty()
+
+    def _colorize(self, text: str, color_code: str) -> str:
+        """Apply color only if enabled."""
+        if not self._use_colors:
+            return text
+        return f"{color_code}{text}{COLORS['RESET']}"
+```
+
+### Exception Handling Strategy
+
+```python
+async def write(self, entry: dict[str, Any]) -> None:
+    """Write with error handling."""
+    try:
+        formatted = self._format_pretty(entry)
+        sys.stdout.write(formatted + "\n")
+        sys.stdout.flush()
+    except Exception as e:
+        # Never crash the app due to logging errors
+        # Fallback to stderr with minimal formatting
+        import sys
+        sys.stderr.write(
+            f"[fapilog] Pretty sink formatting error: {e}\n"
+            f"[fapilog] Original entry: {entry.get('message', 'N/A')}\n"
+        )
+```
 
 ## Tasks
 
-- [ ] Implement pretty formatter utilities in a new module (for example `src/fapilog/core/formatting.py`).
-- [ ] Add a `StdoutPrettySink` in `src/fapilog/plugins/sinks/` or extend `stdout_json` with a format switch.
-- [ ] Add settings for stdout format and colors in `src/fapilog/core/settings.py` (new sink config entry if needed).
-- [ ] Wire preset defaults (dev uses pretty, production uses json).
-- [ ] Update docs with output examples and configuration flags.
-- [ ] Add tests in `tests/unit/test_stdout_json_sink.py` or a new `tests/unit/test_stdout_pretty_sink.py`.
+### Phase 1: Core Implementation
+
+- [ ] Create `src/fapilog/plugins/sinks/stdout_pretty.py` module
+
+- [ ] Implement `StdoutPrettySink` class with `write()` method
+
+- [ ] Implement `_format_pretty()` for main log line formatting
+
+- [ ] Implement `_format_timestamp()` for human-readable timestamps
+
+- [ ] Implement `_format_level()` with ANSI color codes
+
+- [ ] Implement `_format_context()` for key-value pairs
+
+- [ ] Implement `_format_exception()` for Python-style tracebacks
+
+- [ ] Add TTY detection (`sys.stdout.isatty()`)
+
+- [ ] Add color enable/disable logic
+
+### Phase 2: API Integration
+
+- [ ] Add `format` parameter to `get_logger()` signature
+
+- [ ] Add `format` parameter to `get_async_logger()` signature
+
+- [ ] Implement `_apply_format()` helper function
+
+- [ ] Add format validation (raise on invalid format)
+
+- [ ] Add mutual exclusivity check (format XOR settings)
+
+- [ ] Implement format precedence (format overrides preset)
+
+- [ ] Register `StdoutPrettySink` as plugin
+
+### Phase 3: Preset Integration
+
+- [ ] Update dev preset in `src/fapilog/core/presets.py`
+
+- [ ] Change dev preset sink from `stdout_json` to `stdout_pretty`
+
+- [ ] Test dev preset produces pretty output
+
+- [ ] Verify other presets unchanged
+
+### Phase 4: Testing
+
+- [ ] Create `tests/unit/test_stdout_pretty_sink.py`
+
+- [ ] Unit test: `test_format_timestamp()`
+
+- [ ] Unit test: `test_format_level_with_colors()`
+
+- [ ] Unit test: `test_format_level_without_colors()`
+
+- [ ] Unit test: `test_format_context_simple()`
+
+- [ ] Unit test: `test_format_context_with_spaces()`
+
+- [ ] Unit test: `test_format_context_nested_dict()`
+
+- [ ] Unit test: `test_format_exception()`
+
+- [ ] Unit test: `test_tty_detection()`
+
+- [ ] Unit test: `test_colors_disabled_in_non_tty()`
+
+- [ ] Integration test: `test_get_logger_format_pretty()`
+
+- [ ] Integration test: `test_get_logger_format_json()`
+
+- [ ] Integration test: `test_get_logger_format_auto()`
+
+- [ ] Integration test: `test_format_overrides_preset()`
+
+- [ ] Integration test: `test_dev_preset_uses_pretty()`
+
+- [ ] Performance test: `test_pretty_format_performance()`
+
+- [ ] Performance test: `test_pretty_vs_json_overhead()`
+
+### Phase 5: Documentation
+
+- [ ] Update `README.md` - add pretty output example
+
+- [ ] Update `docs/user-guide/configuration.md` - document format parameter
+
+- [ ] Update `docs/api-reference/sinks.md` - document StdoutPrettySink
+
+- [ ] Create `examples/pretty_console/basic.py` example
+
+- [ ] Create `examples/pretty_console/with_exceptions.py` example
+
+- [ ] Add before/after comparison in docs
+
+- [ ] Update `CHANGELOG.md`
 
 ## Tests
 
-- Unit: pretty formatter output includes timestamp, level, message, and key-values.
-- Unit: color toggle disables ANSI codes.
-- Unit: TTY detection respects `format="auto"`.
-- Regression: JSON stdout formatting unchanged when `format="json"`.
+### Unit Tests (`tests/unit/test_stdout_pretty_sink.py`)
+
+```python
+"""Unit tests for StdoutPrettySink."""
+import sys
+from datetime import datetime
+from io import StringIO
+from unittest.mock import patch
+import pytest
+from fapilog.plugins.sinks.stdout_pretty import StdoutPrettySink, COLORS
+
+class TestTimestampFormatting:
+    """Test timestamp formatting."""
+
+    def test_format_timestamp_from_datetime(self):
+        """Format datetime object."""
+        sink = StdoutPrettySink(colors=False)
+        dt = datetime(2025, 1, 11, 14, 30, 22)
+        result = sink._format_timestamp(dt)
+        assert result == "2025-01-11 14:30:22"
+
+    def test_format_timestamp_from_iso_string(self):
+        """Format ISO timestamp string."""
+        sink = StdoutPrettySink(colors=False)
+        result = sink._format_timestamp("2025-01-11T14:30:22.123Z")
+        assert result == "2025-01-11 14:30:22"
+
+    def test_format_timestamp_from_unix_timestamp(self):
+        """Format Unix timestamp (float)."""
+        sink = StdoutPrettySink(colors=False)
+        # 2025-01-11 14:30:22 UTC
+        timestamp = 1736604622.0
+        result = sink._format_timestamp(timestamp)
+        assert "2025-01-11" in result  # Date should match
+        assert "14:30:22" in result or "14:30:2" in result  # Time close (timezone dependent)
+
+class TestLevelFormatting:
+    """Test log level formatting."""
+
+    def test_format_level_without_colors(self):
+        """Format level without colors."""
+        sink = StdoutPrettySink(colors=False)
+        result = sink._format_level("INFO")
+        assert result == "INFO    "  # Padded to 8 chars
+        assert "\033" not in result  # No ANSI codes
+
+    @patch("sys.stdout.isatty", return_value=True)
+
+    def test_format_level_with_colors(self, mock_isatty):
+        """Format level with colors in TTY."""
+        sink = StdoutPrettySink(colors=True)
+        result = sink._format_level("ERROR")
+        assert COLORS["ERROR"] in result  # Red color code
+        assert COLORS["RESET"] in result  # Reset code
+        assert "ERROR" in result
+
+    def test_format_level_padding(self):
+        """All levels padded to same width."""
+        sink = StdoutPrettySink(colors=False)
+        debug = sink._format_level("DEBUG")
+        info = sink._format_level("INFO")
+        warning = sink._format_level("WARNING")
+        error = sink._format_level("ERROR")
+        critical = sink._format_level("CRITICAL")
+        # All should be 8 characters
+        assert len(debug) == 8
+        assert len(info) == 8
+        assert len(warning) == 8
+        assert len(error) == 8
+        assert len(critical) == 8
+
+class TestContextFormatting:
+    """Test context key-value formatting."""
+
+    def test_format_context_simple(self):
+        """Format simple key-value pairs."""
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "timestamp": "2025-01-11T14:30:22Z",
+            "level": "INFO",
+            "message": "Test",
+            "user_id": 123,
+            "request_id": "abc-123",
+        }
+        result = sink._format_context(entry)
+        assert "user_id=123" in result
+        assert "request_id=abc-123" in result
+        assert "timestamp" not in result  # Skipped
+        assert "level" not in result  # Skipped
+        assert "message" not in result  # Skipped
+
+    def test_format_context_string_with_spaces(self):
+        """String values with spaces are quoted."""
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "level": "INFO",
+            "message": "Test",
+            "error": "connection timeout",  # Has space
+        }
+        result = sink._format_context(entry)
+        assert "error='connection timeout'" in result
+
+    def test_format_context_nested_dict(self):
+        """Nested dicts are flattened."""
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "level": "INFO",
+            "message": "Test",
+            "user": {"id": 123, "name": "John"},
+        }
+        result = sink._format_context(entry)
+        assert "user.id=123" in result
+        assert "user.name=John" in result
+
+    def test_format_context_empty(self):
+        """Entry with no context returns empty string."""
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "timestamp": "2025-01-11T14:30:22Z",
+            "level": "INFO",
+            "message": "Test",
+        }
+        result = sink._format_context(entry)
+        assert result == ""
+
+class TestExceptionFormatting:
+    """Test exception traceback formatting."""
+
+    def test_format_exception_basic(self):
+        """Format exception with traceback."""
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "level": "ERROR",
+            "message": "Operation failed",
+            "exception": {
+                "type": "ValueError",
+                "value": "Invalid input",
+                "traceback": "  File 'app.py', line 42\n    raise ValueError()",
+            },
+            "user_id": 123,
+        }
+        result = sink._format_exception(entry)
+        assert "Traceback" in result
+        assert "ValueError" in result
+        assert "Invalid input" in result
+        assert "app.py" in result
+        assert "Context: user_id=123" in result
+
+    def test_format_exception_no_exception(self):
+        """Entry without exception returns empty string."""
+        sink = StdoutPrettySink(colors=False)
+        entry = {"level": "INFO", "message": "Test"}
+        result = sink._format_exception(entry)
+        assert result == ""
+
+class TestTTYDetection:
+    """Test TTY detection and color auto-disable."""
+
+    @patch("sys.stdout.isatty", return_value=True)
+
+    def test_colors_enabled_in_tty(self, mock_isatty):
+        """Colors enabled when stdout is TTY."""
+        sink = StdoutPrettySink(colors=True)
+        assert sink._use_colors is True
+
+    @patch("sys.stdout.isatty", return_value=False)
+
+    def test_colors_disabled_in_non_tty(self, mock_isatty):
+        """Colors disabled when stdout is not TTY (pipe/redirect)."""
+        sink = StdoutPrettySink(colors=True)
+        assert sink._use_colors is False
+
+    def test_colors_can_be_force_disabled(self):
+        """Colors can be explicitly disabled."""
+        sink = StdoutPrettySink(colors=False)
+        assert sink._use_colors is False
+
+class TestPrettyFormatComplete:
+    """Test complete pretty formatting."""
+
+    def test_format_pretty_complete(self):
+        """Complete log line formatting."""
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "timestamp": "2025-01-11T14:30:22Z",
+            "level": "INFO",
+            "message": "User login successful",
+            "user_id": 123,
+            "request_id": "abc-123",
+        }
+        result = sink._format_pretty(entry)
+        # Should match format: timestamp | level | message context
+        assert "2025-01-11 14:30:22" in result
+        assert "INFO" in result
+        assert "User login successful" in result
+        assert "user_id=123" in result
+        assert "request_id=abc-123" in result
+        assert "|" in result  # Separator
+
+    def test_format_pretty_with_exception(self):
+        """Log line with exception includes traceback."""
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "timestamp": "2025-01-11T14:30:22Z",
+            "level": "ERROR",
+            "message": "Database error",
+            "exception": {
+                "type": "psycopg2.OperationalError",
+                "value": "connection timeout",
+                "traceback": "  File 'db.py', line 10",
+            },
+        }
+        result = sink._format_pretty(entry)
+        assert "ERROR" in result
+        assert "Database error" in result
+        assert "Traceback" in result
+        assert "psycopg2.OperationalError" in result
+
+class TestSinkWrite:
+    """Test sink write() method."""
+
+    @pytest.mark.asyncio
+
+    async def test_write_outputs_to_stdout(self):
+        """write() outputs formatted log to stdout."""
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "timestamp": "2025-01-11T14:30:22Z",
+            "level": "INFO",
+            "message": "Test message",
+        }
+        # Capture stdout
+        captured_output = StringIO()
+        with patch("sys.stdout", captured_output):
+            await sink.write(entry)
+        output = captured_output.getvalue()
+        assert "INFO" in output
+        assert "Test message" in output
+        assert "\n" in output  # Newline added
+
+    @pytest.mark.asyncio
+
+    async def test_write_handles_formatting_errors(self):
+        """write() handles formatting errors gracefully."""
+        sink = StdoutPrettySink(colors=False)
+        # Entry that might cause formatting error
+        entry = {"level": None, "message": None}
+        # Should not raise, should write to stderr instead
+        captured_stderr = StringIO()
+        with patch("sys.stderr", captured_stderr):
+            await sink.write(entry)
+        # Error should be logged to stderr
+        # (exact behavior depends on error handling implementation)
+```
+
+### Integration Tests (`tests/integration/test_pretty_output_integration.py`)
+
+```python
+"""Integration tests for pretty console output."""
+import sys
+from io import StringIO
+from unittest.mock import patch
+import pytest
+from fapilog import get_logger, get_async_logger, Settings
+
+class TestGetLoggerFormatParameter:
+    """Test get_logger with format parameter."""
+
+    @patch("sys.stdout.isatty", return_value=True)
+
+    def test_format_pretty_uses_pretty_sink(self, mock_isatty):
+        """format='pretty' uses StdoutPrettySink."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            logger = get_logger(format="pretty")
+            logger.info("Test message", key="value")
+            logger.drain()
+        output = captured.getvalue()
+        # Pretty format characteristics
+        assert "INFO" in output
+        assert "Test message" in output
+        assert "key=value" in output
+        assert "{" not in output  # Not JSON
+
+    def test_format_json_uses_json_sink(self):
+        """format='json' uses StdoutJsonSink."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            logger = get_logger(format="json")
+            logger.info("Test message", key="value")
+            logger.drain()
+        output = captured.getvalue()
+        # JSON format characteristics
+        assert "{" in output
+        assert '"level":"INFO"' in output or '"level": "INFO"' in output
+        assert '"message":"Test message"' in output or '"message": "Test message"' in output
+
+    @patch("sys.stdout.isatty", return_value=True)
+
+    def test_format_auto_uses_pretty_in_tty(self, mock_isatty):
+        """format='auto' uses pretty in TTY."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            logger = get_logger(format="auto")
+            logger.info("Test")
+            logger.drain()
+        output = captured.getvalue()
+        assert "INFO" in output
+        assert "{" not in output  # Not JSON
+
+    @patch("sys.stdout.isatty", return_value=False)
+
+    def test_format_auto_uses_json_when_piped(self, mock_isatty):
+        """format='auto' uses JSON when not TTY."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            logger = get_logger(format="auto")
+            logger.info("Test")
+            logger.drain()
+        output = captured.getvalue()
+        assert "{" in output  # JSON
+
+class TestFormatMutualExclusivity:
+    """Test format parameter mutual exclusivity."""
+
+    def test_format_and_settings_raises_error(self):
+        """format and settings together raises ValueError."""
+        with pytest.raises(ValueError, match="Cannot specify both 'format' and 'settings'"):
+            get_logger(format="pretty", settings=Settings())
+
+    def test_error_message_is_helpful(self):
+        """Error message guides users."""
+        with pytest.raises(
+            ValueError,
+            match="Use format for simple output control or settings for full control"
+        ):
+            get_logger(format="json", settings=Settings())
+
+class TestFormatOverridesPreset:
+    """Test format parameter overrides preset."""
+
+    @patch("sys.stdout.isatty", return_value=False)
+
+    def test_format_overrides_preset_sink(self, mock_isatty):
+        """Explicit format overrides preset default."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            # production preset uses JSON, but format forces pretty
+            logger = get_logger(preset="production", format="pretty")
+            logger.info("Test")
+            logger.drain()
+        output = captured.getvalue()
+        # Should be pretty despite production preset
+        assert "INFO" in output
+        assert "{" not in output
+
+class TestDevPresetIntegration:
+    """Test dev preset uses pretty output."""
+
+    @patch("sys.stdout.isatty", return_value=True)
+
+    def test_dev_preset_uses_pretty_sink(self, mock_isatty):
+        """Dev preset automatically uses pretty output."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            logger = get_logger(preset="dev")
+            logger.debug("Debug message", context="value")
+            logger.drain()
+        output = captured.getvalue()
+        # Pretty format
+        assert "DEBUG" in output
+        assert "Debug message" in output
+        assert "context=value" in output
+        assert "{" not in output  # Not JSON
+
+class TestAsyncLoggerFormat:
+    """Test get_async_logger with format parameter."""
+
+    @pytest.mark.asyncio
+
+    async def test_async_logger_format_pretty(self):
+        """Async logger supports format parameter."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            logger = await get_async_logger(format="pretty")
+            await logger.info("Async test")
+            await logger.drain()
+        output = captured.getvalue()
+        assert "INFO" in output
+        assert "Async test" in output
+
+class TestColorOutput:
+    """Test ANSI color output in TTY."""
+
+    @patch("sys.stdout.isatty", return_value=True)
+
+    def test_colors_in_tty(self, mock_isatty):
+        """Colors included in TTY output."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            logger = get_logger(format="pretty")
+            logger.error("Error message")
+            logger.drain()
+        output = captured.getvalue()
+        # Should contain ANSI codes
+        assert "\033[" in output  # ANSI escape sequence
+        assert "ERROR" in output
+
+    @patch("sys.stdout.isatty", return_value=False)
+
+    def test_no_colors_when_piped(self, mock_isatty):
+        """No ANSI codes when output is piped."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            logger = get_logger(format="pretty")
+            logger.error("Error message")
+            logger.drain()
+        output = captured.getvalue()
+        # Should NOT contain ANSI codes
+        assert "\033[" not in output
+        assert "ERROR" in output  # But still formatted
+
+class TestExceptionOutput:
+    """Test exception formatting in pretty output."""
+
+    def test_exception_formatted_python_style(self):
+        """Exceptions formatted as Python tracebacks."""
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            logger = get_logger(format="pretty")
+            try:
+                raise ValueError("Invalid value")
+            except ValueError:
+                logger.exception("Operation failed")
+            logger.drain()
+        output = captured.getvalue()
+        assert "ERROR" in output
+        assert "Operation failed" in output
+        assert "Traceback" in output
+        assert "ValueError" in output
+        assert "Invalid value" in output
+```
+
+### Performance Tests
+
+```python
+"""Performance tests for pretty output."""
+
+def test_pretty_format_performance(benchmark):
+    """Pretty formatting < 100 microseconds."""
+    from fapilog.plugins.sinks.stdout_pretty import StdoutPrettySink
+    sink = StdoutPrettySink(colors=False)
+    entry = {
+        "timestamp": "2025-01-11T14:30:22Z",
+        "level": "INFO",
+        "message": "Test message",
+        "user_id": 123,
+        "request_id": "abc-123",
+        "duration_ms": 45,
+    }
+    result = benchmark(lambda: sink._format_pretty(entry))
+    # Should be < 100 microseconds
+    assert result.stats.mean < 0.0001
+
+def test_pretty_vs_json_overhead(benchmark):
+    """Pretty overhead < 2x JSON formatting."""
+    from fapilog.plugins.sinks.stdout_pretty import StdoutPrettySink
+    from fapilog.plugins.sinks.stdout_json import StdoutJsonSink
+    import time
+    entry = {
+        "timestamp": "2025-01-11T14:30:22Z",
+        "level": "INFO",
+        "message": "Test message",
+        "user_id": 123,
+    }
+    # Benchmark JSON
+    json_sink = StdoutJsonSink()
+    json_times = []
+    for _ in range(1000):
+        start = time.perf_counter()
+        # Simulate formatting
+        import json
+        json.dumps(entry)
+        json_times.append(time.perf_counter() - start)
+    json_mean = sum(json_times) / len(json_times)
+    # Benchmark Pretty
+    pretty_sink = StdoutPrettySink(colors=False)
+    pretty_times = []
+    for _ in range(1000):
+        start = time.perf_counter()
+        pretty_sink._format_pretty(entry)
+        pretty_times.append(time.perf_counter() - start)
+    pretty_mean = sum(pretty_times) / len(pretty_times)
+    # Pretty should be < 2x JSON
+    assert pretty_mean < json_mean * 2
+```
 
 ## Definition of Done
 
-Story is complete when ALL of the following are true:
-
 ### Code Complete
-- [ ] All acceptance criteria met and verified
-- [ ] All tasks completed
-- [ ] Code follows project style guide
-- [ ] No linting errors or warnings
-- [ ] Type checking passes (mypy strict)
+
+- [ ] `StdoutPrettySink` class implemented with all formatting methods
+
+- [ ] `format` parameter added to `get_logger()`
+
+- [ ] `format` parameter added to `get_async_logger()`
+
+- [ ] `_apply_format()` helper function implemented
+
+- [ ] ANSI color codes defined and applied
+
+- [ ] TTY detection implemented (`sys.stdout.isatty()`)
+
+- [ ] Exception formatting (Python-style traceback)
+
+- [ ] Dev preset updated to use `stdout_pretty`
+
+- [ ] Plugin registration complete
 
 ### Quality Assurance
-- [ ] Unit tests: >90% coverage of new code
+
+- [ ] Unit tests: >95% coverage of `stdout_pretty.py`
+
+- [ ] All timestamp formatting tests passing
+
+- [ ] All level formatting tests passing (with/without colors)
+
+- [ ] All context formatting tests passing
+
+- [ ] All exception formatting tests passing
+
+- [ ] TTY detection tests passing
+
 - [ ] Integration tests: all scenarios passing
-- [ ] Regression tests: no existing functionality broken
-- [ ] Performance tests: no regression vs baseline
-- [ ] Manual testing completed (if applicable)
+
+- [ ] format parameter validation tests passing
+
+- [ ] Mutual exclusivity tests passing
+
+- [ ] Dev preset integration tests passing
+
+- [ ] Performance tests: pretty < 100μs, < 2x JSON overhead
+
+- [ ] No regression in existing tests
 
 ### Documentation
-- [ ] User-facing docs updated
-- [ ] API reference updated (if applicable)
-- [ ] Code examples added/updated
-- [ ] CHANGELOG.md updated
-- [ ] Inline code documentation complete
+
+- [ ] `README.md` updated with pretty output example
+
+- [ ] `docs/user-guide/configuration.md` documents format parameter
+
+- [ ] `docs/api-reference/sinks.md` documents StdoutPrettySink
+
+- [ ] Before/after comparison added to docs
+
+- [ ] `examples/pretty_console/basic.py` created
+
+- [ ] `examples/pretty_console/with_exceptions.py` created
+
+- [ ] `CHANGELOG.md` updated with feature announcement
+
+- [ ] API docstrings complete and accurate
 
 ### Review & Release
+
 - [ ] Code review approved
+
 - [ ] Documentation reviewed for clarity
-- [ ] CI/CD pipeline passing
+
+- [ ] CI/CD pipeline passing (all tests, linting, type checks)
+
+- [ ] No performance regression (benchmarks pass)
+
 - [ ] Ready for merge to main branch
 
-### Backwards Compatibility
-- [ ] No breaking changes OR breaking changes documented with migration guide
-- [ ] Existing tests still pass
-- [ ] Deprecation warnings added (if applicable)
+### Integration
 
----
+- [ ] Story 10.1 dev preset now uses pretty output
+
+- [ ] `get_logger(preset="dev")` produces colored output in terminal
+
+- [ ] `get_logger(preset="dev")` produces plain output when piped
+
+- [ ] No impact on production/fastapi/minimal presets
 
 ## Risks / Rollback / Monitoring
 
 ### Risks
 
-- **Risk:** Formatting inconsistencies across terminals
-  - **Mitigation:** Test on multiple terminals, provide fallback modes
+1. **Risk**: ANSI codes break on some terminals
 
-- **Risk:** Performance impact from formatting
-  - **Mitigation:** Benchmark, optimize formatting code
+   - **Mitigation**: TTY detection auto-disables colors when not supported
+
+   - **Mitigation**: `colors=False` parameter allows manual override
+
+   - **Mitigation**: Thoroughly test on Linux, macOS, Windows 10+
+
+2. **Risk**: Pretty formatting is too slow
+
+   - **Mitigation**: Performance benchmarks enforce < 100μs threshold
+
+   - **Mitigation**: Only used in development (not production-critical)
+
+   - **Mitigation**: Lazy color application (skip if disabled)
+
+3. **Risk**: Exception formatting differs from Python's
+
+   - **Mitigation**: Use stdlib `traceback.format_exception()` when possible
+
+   - **Mitigation**: Match Python's output format exactly (familiar to users)
+
+4. **Risk**: format parameter conflicts with Settings
+
+   - **Mitigation**: Mutual exclusivity validation (raises clear error)
+
+   - **Mitigation**: Documentation clarifies when to use each
+
+5. **Risk**: Colors look bad or are hard to read
+
+   - **Mitigation**: Use standard ANSI colors (widely tested)
+
+   - **Mitigation**: Conservative color choices (red/yellow/blue/gray)
+
+   - **Mitigation**: Future story can add custom color schemes if needed
 
 ### Rollback Plan
 
-- Keep new sink isolated
-- Switch preset defaults back to JSON
-- Remove pretty formatter if needed
+If pretty output causes issues:
 
-### Success Metrics / Monitoring
+1. **Easy rollback**: Remove from dev preset
 
-- User feedback on readability
-- Performance benchmarks
-- Adoption metrics
+   ```python
+   # Revert presets.py
+   "dev": {"sinks": ["stdout_json"]}  # Back to JSON
+   ```
 
----
+2. **Keep feature available**: Users can still opt-in
 
-## Related Documents
+   ```python
+   # Pretty sink remains available
+   logger = get_logger(format="pretty")
+   ```
 
-- [Story 10.0: Series Overview](./10.0-series-overview.md)
-- [Story 10.1: Configuration Presets](./10.1.configuration-presets.md)
-- [Epic 10: Developer Experience](../prd/epic-10-DX-Experience.md)
+3. **Full removal**: Delete `stdout_pretty.py`, remove format parameter
 
----
+   - Minimal code churn (isolated to one file + parameter)
+
+   - No impact on production presets
+
+### Success Metrics
+
+**Quantitative:**
+
+- [ ] Dev preset adoption: >50% of local dev usage
+
+- [ ] Performance: Pretty formatting < 100μs (measured)
+
+- [ ] Error rate: No increase in logging errors (monitored)
+
+**Qualitative:**
+
+- [ ] Developer feedback: "Much easier to read during development"
+
+- [ ] GitHub issues: No complaints about color output
+
+- [ ] Documentation: Clear examples reduce confusion
+
+### Monitoring
+
+- Track format parameter usage (if telemetry added in future story)
+
+- Monitor GitHub issues for color/formatting complaints
+
+- Collect user feedback on pretty output readability
+
+- Watch for performance regressions in CI benchmarks
+
+## Dependencies
+
+- **Depends on**: Story 10.1 (Configuration Presets) - dev preset exists
+
+- **Blocks**: None
+
+- **Related**: Story 10.3 (FastAPI Integration) - may want pretty output in dev
+
+## Estimated Effort
+
+- **Implementation**: 6 hours
+
+  - StdoutPrettySink: 3 hours
+
+  - format parameter integration: 2 hours
+
+  - Dev preset update: 1 hour
+
+- **Testing**: 3 hours
+
+  - Unit tests: 2 hours
+
+  - Integration tests: 1 hour
+
+- **Documentation**: 2 hours
+
+  - Docs updates: 1 hour
+
+  - Examples: 1 hour
+
+- **Total**: 8-11 hours for one developer
+
+## Related Stories
+
+- **Story 10.1**: Configuration Presets (provides dev preset to enhance)
+
+- **Story 10.3**: One-Liner FastAPI Integration (may use pretty output)
+
+- **Future Story**: Custom Color Schemes (if demand exists)
+
+- **Future Story**: Syntax Highlighting for Exceptions (advanced formatting)
 
 ## Change Log
 
-| Date       | Change                    | Author |
-| ---------- | ------------------------- | ------ |
-| 2025-01-10 | Migrated to new format    | System |
+| Date | Change | Author |
+
+| ---------- | ----------------------------------------- | ------ |
+
+| 2025-01-11 | Initial story creation (implementation-ready) | Claude |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -20,10 +20,10 @@ logger = get_logger(preset="minimal")     # Backwards compatible default
 
 | Preset | Log Level | Sinks | File Rotation | Redaction | Batch Size |
 |--------|-----------|-------|---------------|-----------|------------|
-| `dev` | DEBUG | stdout | No | No | 1 (immediate) |
-| `production` | INFO | stdout + file | 50MB × 10 files | Yes (9 fields) | 100 |
-| `fastapi` | INFO | stdout | No | No | 50 |
-| `minimal` | INFO | stdout | No | No | 256 (default) |
+| `dev` | DEBUG | stdout_pretty | No | No | 1 (immediate) |
+| `production` | INFO | stdout_json + file | 50MB × 10 files | Yes (9 fields) | 100 |
+| `fastapi` | INFO | stdout_json | No | No | 50 |
+| `minimal` | INFO | stdout_json | No | No | 256 (default) |
 
 ### Preset Details
 
@@ -31,6 +31,7 @@ logger = get_logger(preset="minimal")     # Backwards compatible default
 - DEBUG level shows all messages
 - Immediate flushing (batch_size=1) for real-time debugging
 - Internal diagnostics enabled
+- Pretty console output in terminals
 - No redaction (safe for local secrets)
 
 **`production`** - Production deployments with safety features:
@@ -62,6 +63,23 @@ logger = get_logger(preset="production", settings=Settings(...))
 ```
 
 If you need customization beyond what presets offer, use the `Settings` class directly.
+
+## Output format
+
+Use `format` to control stdout output without building a full `Settings` object:
+
+```python
+from fapilog import get_logger
+
+logger = get_logger(format="auto")   # Default: pretty in TTY, JSON when piped
+logger = get_logger(format="pretty") # Force human-readable output
+logger = get_logger(format="json")   # Force structured JSON
+```
+
+Notes:
+- `format` is mutually exclusive with `settings`.
+- If both `preset` and `format` are provided, `format` overrides the preset's stdout sink.
+- When `settings` is omitted, `format` defaults to `auto`.
 
 ## Quick setup (env)
 
@@ -95,7 +113,7 @@ logger.info("configured", queue=settings.core.max_queue_size)
 
 ## Common patterns
 
-- **Stdout JSON (default)**: no env needed; `get_logger()` works out of the box.
+- **Stdout auto (default)**: pretty in TTY, JSON when piped.
 - **File sink**: set `FAPILOG_FILE__DIRECTORY`; tune rotation via `FAPILOG_FILE__MAX_BYTES`, `FAPILOG_FILE__MAX_FILES`.
 - **HTTP sink**: set `FAPILOG_HTTP__ENDPOINT` and optional timeout/retry envs.
 - **Metrics**: set `FAPILOG_CORE__ENABLE_METRICS=true` to record internal metrics.

--- a/examples/pretty_console/basic.py
+++ b/examples/pretty_console/basic.py
@@ -1,0 +1,8 @@
+"""Example: Human-readable pretty console output."""
+
+from fapilog import get_logger
+
+logger = get_logger(format="pretty")
+
+logger.info("Application started", env="local", version="1.0.0")
+logger.warning("High memory usage", percent=85, threshold=80)

--- a/examples/pretty_console/with_exceptions.py
+++ b/examples/pretty_console/with_exceptions.py
@@ -1,0 +1,10 @@
+"""Example: Pretty output with exception tracebacks."""
+
+from fapilog import get_logger
+
+logger = get_logger(format="pretty")
+
+try:
+    _ = 1 / 0
+except ZeroDivisionError:
+    logger.exception("Computation failed", operation="divide")

--- a/src/fapilog/core/presets.py
+++ b/src/fapilog/core/presets.py
@@ -11,7 +11,7 @@ PRESETS: dict[str, dict[str, Any]] = {
             "log_level": "DEBUG",
             "internal_logging_enabled": True,
             "batch_max_size": 1,
-            "sinks": ["stdout_json"],
+            "sinks": ["stdout_pretty"],
             "enrichers": ["runtime_info", "context_vars"],
         },
         "enricher_config": {

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -571,7 +571,7 @@ class CoreSettings(BaseModel):
         description=("Enable structured exception serialization for log calls"),
     )
     exceptions_max_frames: int = Field(
-        default=50,
+        default=10,
         ge=1,
         description=("Maximum number of stack frames to capture for exceptions"),
     )

--- a/src/fapilog/plugins/sinks/__init__.py
+++ b/src/fapilog/plugins/sinks/__init__.py
@@ -12,6 +12,7 @@ from .mmap_persistence import MemoryMappedPersistence, PersistenceStats
 from .rotating_file import RotatingFileSink
 from .routing import RoutingSink
 from .stdout_json import StdoutJsonSink
+from .stdout_pretty import StdoutPrettySink
 from .webhook import WebhookSink
 
 
@@ -93,6 +94,12 @@ register_builtin(
     "stdout_json",
     StdoutJsonSink,
     aliases=["stdout-json"],
+)
+register_builtin(
+    "fapilog.sinks",
+    "stdout_pretty",
+    StdoutPrettySink,
+    aliases=["stdout-pretty"],
 )
 register_builtin(
     "fapilog.sinks",

--- a/src/fapilog/plugins/sinks/stdout_pretty.py
+++ b/src/fapilog/plugins/sinks/stdout_pretty.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import datetime
+from typing import Any, Mapping
+
+from ...core import diagnostics
+
+COLORS = {
+    "DEBUG": "\033[90m",
+    "INFO": "\033[34m",
+    "WARNING": "\033[33m",
+    "ERROR": "\033[31m",
+    "CRITICAL": "\033[1;31m",
+    "RESET": "\033[0m",
+}
+LEVEL_PADDING = 8
+
+
+class StdoutPrettySink:
+    """Async-friendly stdout sink with human-readable console output."""
+
+    name = "stdout_pretty"
+    _lock: asyncio.Lock
+
+    def __init__(self, *, colors: bool = True) -> None:
+        self._lock = asyncio.Lock()
+        self._colors_enabled = bool(colors)
+        self._use_colors = self._colors_enabled and self._is_tty()
+
+    async def start(self) -> None:  # lifecycle placeholder
+        return None
+
+    async def stop(self) -> None:  # lifecycle placeholder
+        return None
+
+    async def write(self, entry: dict[str, Any]) -> None:
+        try:
+            formatted = self._format_pretty(entry)
+            async with self._lock:
+
+                def _write_line() -> None:
+                    sys.stdout.write(formatted + "\n")
+                    sys.stdout.flush()
+
+                await asyncio.to_thread(_write_line)
+        except Exception as exc:
+            diagnostics.warn(
+                "sink",
+                "pretty sink error",
+                reason=type(exc).__name__,
+                detail=str(exc),
+            )
+            return None
+
+    async def health_check(self) -> bool:
+        try:
+            return bool(sys.stdout and sys.stdout.write)
+        except Exception:
+            return False
+
+    def _is_tty(self) -> bool:
+        try:
+            isatty = getattr(sys.stdout, "isatty", None)
+            return bool(isatty and isatty())
+        except Exception:
+            return False
+
+    def _format_pretty(self, entry: dict[str, Any]) -> str:
+        timestamp = self._format_timestamp(entry.get("timestamp"))
+        level = self._format_level(str(entry.get("level", "INFO")))
+        message = str(entry.get("message", ""))
+        exception_block = self._format_exception(entry)
+        context = "" if exception_block else self._format_context(entry)
+
+        base = f"{timestamp} | {level} | {message}"
+        if context:
+            base = f"{base} {context}"
+        if exception_block:
+            base = f"{base}\n{exception_block}"
+        return base
+
+    def _format_timestamp(self, value: Any) -> str:
+        if isinstance(value, datetime):
+            dt = value
+        elif isinstance(value, (int, float)):
+            dt = datetime.fromtimestamp(float(value))
+        elif isinstance(value, str):
+            try:
+                dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except Exception:
+                return value[:19] if len(value) >= 19 else value
+        else:
+            return "" if value is None else str(value)
+
+        if dt.tzinfo is not None:
+            dt = dt.astimezone()
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+    def _format_level(self, level: str) -> str:
+        padded = level.ljust(LEVEL_PADDING)
+        if self._use_colors and level in COLORS:
+            return f"{COLORS[level]}{padded}{COLORS['RESET']}"
+        return padded
+
+    def _format_context(self, entry: dict[str, Any]) -> str:
+        context = self._collect_context(entry)
+        parts: list[str] = []
+        for key, value in context.items():
+            self._append_context_pairs(str(key), value, parts)
+        return " ".join(parts)
+
+    def _collect_context(self, entry: dict[str, Any]) -> dict[str, Any]:
+        context: dict[str, Any] = {}
+        base = entry.get("context")
+        if isinstance(base, Mapping):
+            context.update(base)
+        meta = entry.get("metadata")
+        if isinstance(meta, Mapping):
+            context.update(meta)
+        for key, value in entry.items():
+            if key in {"timestamp", "level", "message", "context", "metadata"}:
+                continue
+            context.setdefault(key, value)
+        return context
+
+    def _append_context_pairs(self, key: str, value: Any, out: list[str]) -> None:
+        if key.startswith("error."):
+            return
+        if isinstance(value, Mapping):
+            for nested_key, nested_value in value.items():
+                self._append_context_pairs(f"{key}.{nested_key}", nested_value, out)
+            return
+        out.append(f"{key}={self._format_value(value)}")
+
+    def _format_value(self, value: Any) -> str:
+        if isinstance(value, str):
+            if " " in value:
+                return f"'{value}'"
+            return value
+        return str(value)
+
+    def _format_exception(self, entry: dict[str, Any]) -> str:
+        meta = entry.get("metadata")
+        error_type = None
+        error_message = None
+        frames = None
+        if isinstance(meta, Mapping):
+            error_type = meta.get("error.type")
+            error_message = meta.get("error.message")
+            frames = meta.get("error.frames")
+
+        if isinstance(frames, list) and frames:
+            lines = ["Traceback (most recent call last):"]
+            for frame in frames:
+                if not isinstance(frame, Mapping):
+                    continue
+                filename = frame.get("file") or "<unknown>"
+                lineno = frame.get("line") or "?"
+                func = frame.get("function") or "<unknown>"
+                lines.append(f'  File "{filename}", line {lineno}, in {func}')
+                code = frame.get("code")
+                if code:
+                    lines.append(f"    {code}")
+            if error_type:
+                if error_message:
+                    lines.append(f"{error_type}: {error_message}")
+                else:
+                    lines.append(str(error_type))
+            text = "\n".join(lines)
+            context = self._format_context(entry)
+            if context:
+                return f"{text}\nContext: {context}"
+            return text
+
+        stack = None
+        exc = entry.get("exception")
+        if isinstance(exc, Mapping):
+            stack = exc.get("traceback") or exc.get("stack")
+        if not stack and isinstance(meta, Mapping):
+            stack = meta.get("error.stack")
+        if not stack:
+            stack = entry.get("error.stack")
+        if not stack:
+            return ""
+        text = str(stack).rstrip()
+        context = self._format_context(entry)
+        if context:
+            return f"{text}\nContext: {context}"
+        return text
+
+
+PLUGIN_METADATA = {
+    "name": "stdout_pretty",
+    "version": "1.0.0",
+    "plugin_type": "sink",
+    "entry_point": "fapilog.plugins.sinks.stdout_pretty:StdoutPrettySink",
+    "description": "Async stdout pretty console sink",
+    "author": "Fapilog Core",
+    "compatibility": {"min_fapilog_version": "0.3.0"},
+    "api_version": "1.0",
+}

--- a/tests/benchmark/test_perf_benchmarks.py
+++ b/tests/benchmark/test_perf_benchmarks.py
@@ -1,6 +1,8 @@
 import asyncio
 import io
+import os
 import sys
+import time
 from typing import Any
 
 import pytest
@@ -8,6 +10,7 @@ import pytest
 from fapilog.core.concurrency import NonBlockingRingQueue
 from fapilog.core.serialization import (
     convert_json_bytes_to_jsonl,
+    serialize_envelope,
     serialize_mapping_to_json_bytes,
 )
 from fapilog.plugins.sinks.rotating_file import (
@@ -15,6 +18,7 @@ from fapilog.plugins.sinks.rotating_file import (
     RotatingFileSinkConfig,
 )
 from fapilog.plugins.sinks.stdout_json import StdoutJsonSink
+from fapilog.plugins.sinks.stdout_pretty import StdoutPrettySink
 
 # Skip this module if pytest-benchmark plugin is not available (e.g., in some CI tox envs)
 pytest.importorskip("pytest_benchmark")
@@ -74,6 +78,62 @@ def test_stdout_sink_benchmark(benchmark: Any, monkeypatch: pytest.MonkeyPatch) 
         benchmark(run)
     finally:
         sys.stdout = orig
+
+
+def test_stdout_pretty_format_benchmark(benchmark: Any) -> None:
+    sink = StdoutPrettySink(colors=False)
+    entry = {
+        "timestamp": 1736605822.0,
+        "level": "INFO",
+        "message": "benchmark",
+        "metadata": {"key": "value", "user": {"id": 123}},
+    }
+
+    result = benchmark(lambda: sink._format_pretty(entry))
+    assert "benchmark" in result
+    assert benchmark.stats.stats.mean < 0.0001
+
+
+def test_stdout_pretty_vs_json_overhead() -> None:
+    entry = {
+        "timestamp": 1736605822.0,
+        "level": "INFO",
+        "message": "benchmark",
+        "metadata": {"key": "value", "user": {"id": 123}},
+    }
+    envelope_entry = {
+        "timestamp": entry["timestamp"],
+        "level": entry["level"],
+        "message": entry["message"],
+        "context": entry["metadata"],
+        "diagnostics": {},
+    }
+    pretty_sink = StdoutPrettySink(colors=False)
+    n = 1000
+
+    start = time.perf_counter()
+    for _ in range(n):
+        view = serialize_envelope(envelope_entry)
+        convert_json_bytes_to_jsonl(view)
+    json_mean = (time.perf_counter() - start) / n
+
+    start = time.perf_counter()
+    for _ in range(n):
+        pretty_sink._format_pretty(entry)
+    pretty_mean = (time.perf_counter() - start) / n
+
+    multiplier = 2.0
+    if os.getenv("COV_CORE_SOURCE") or os.getenv("COVERAGE_PROCESS_START"):
+        # Coverage adds overhead; allow a wider threshold for this comparison.
+        multiplier = 3.0
+    else:
+        try:
+            import coverage as coverage_module
+        except Exception:  # pragma: no cover - optional coverage detection
+            coverage_module = None
+        if coverage_module and coverage_module.Coverage.current() is not None:
+            multiplier = 3.0
+    assert pretty_mean < json_mean * multiplier
 
 
 @pytest.mark.usefixtures("tmp_path")

--- a/tests/integration/test_pretty_output_integration.py
+++ b/tests/integration/test_pretty_output_integration.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from fapilog import get_async_logger, get_logger
+
+
+def _swap_stdout_bytesio() -> tuple[io.BytesIO, Any]:
+    """Swap stdout with a BytesIO buffer for capturing output."""
+    buf = io.BytesIO()
+    orig = sys.stdout
+    sys.stdout = io.TextIOWrapper(buf, encoding="utf-8")  # type: ignore[assignment]
+    return buf, orig
+
+
+class TestFormatParameterIntegration:
+    def test_format_pretty_uses_pretty_output(self) -> None:
+        buf, orig = _swap_stdout_bytesio()
+        try:
+            with patch.object(sys.stdout, "isatty", return_value=False):
+                logger = get_logger(format="pretty")
+                logger.info("Test message", key="value")
+                asyncio.run(logger.stop_and_drain())
+            sys.stdout.flush()
+            output = buf.getvalue().decode("utf-8")
+            assert "Test message" in output
+            assert "key=value" in output
+            assert " | " in output
+            assert "{" not in output
+        finally:
+            sys.stdout = orig  # type: ignore[assignment]
+
+    def test_format_json_uses_json_output(self) -> None:
+        buf, orig = _swap_stdout_bytesio()
+        try:
+            logger = get_logger(format="json")
+            logger.info("Test message", key="value")
+            asyncio.run(logger.stop_and_drain())
+            sys.stdout.flush()
+            output = buf.getvalue().decode("utf-8")
+            assert "{" in output
+            assert "Test message" in output
+        finally:
+            sys.stdout = orig  # type: ignore[assignment]
+
+    def test_format_auto_uses_pretty_in_tty(self) -> None:
+        buf, orig = _swap_stdout_bytesio()
+        try:
+            with patch.object(sys.stdout, "isatty", return_value=True):
+                logger = get_logger(format="auto")
+                logger.info("Auto pretty")
+                asyncio.run(logger.stop_and_drain())
+            sys.stdout.flush()
+            output = buf.getvalue().decode("utf-8")
+            assert "Auto pretty" in output
+            assert " | " in output
+            assert "{" not in output
+        finally:
+            sys.stdout = orig  # type: ignore[assignment]
+
+    def test_format_auto_uses_json_when_piped(self) -> None:
+        buf, orig = _swap_stdout_bytesio()
+        try:
+            with patch.object(sys.stdout, "isatty", return_value=False):
+                logger = get_logger(format="auto")
+                logger.info("Auto json")
+                asyncio.run(logger.stop_and_drain())
+            sys.stdout.flush()
+            output = buf.getvalue().decode("utf-8")
+            assert "{" in output
+            assert "Auto json" in output
+        finally:
+            sys.stdout = orig  # type: ignore[assignment]
+
+    def test_format_overrides_preset(self) -> None:
+        buf, orig = _swap_stdout_bytesio()
+        try:
+            with patch.object(sys.stdout, "isatty", return_value=False):
+                logger = get_logger(preset="production", format="pretty")
+                logger.info("Preset override")
+                asyncio.run(logger.stop_and_drain())
+            sys.stdout.flush()
+            output = buf.getvalue().decode("utf-8")
+            assert "Preset override" in output
+            assert " | " in output
+            assert "{" not in output
+        finally:
+            sys.stdout = orig  # type: ignore[assignment]
+
+
+class TestDevPresetPrettyOutput:
+    def test_dev_preset_outputs_pretty(self) -> None:
+        buf, orig = _swap_stdout_bytesio()
+        try:
+            with patch.object(sys.stdout, "isatty", return_value=True):
+                logger = get_logger(preset="dev")
+                logger.debug("Dev preset pretty")
+                asyncio.run(logger.stop_and_drain())
+            sys.stdout.flush()
+            output = buf.getvalue().decode("utf-8")
+            assert "Dev preset pretty" in output
+            assert " | " in output
+            assert "{" not in output
+        finally:
+            sys.stdout = orig  # type: ignore[assignment]
+
+
+class TestAsyncPrettyOutput:
+    @pytest.mark.asyncio
+    async def test_async_logger_format_pretty(self) -> None:
+        buf, orig = _swap_stdout_bytesio()
+        try:
+            with patch.object(sys.stdout, "isatty", return_value=False):
+                logger = await get_async_logger(format="pretty")
+                await logger.info("Async pretty")
+                await logger.drain()
+            sys.stdout.flush()
+            output = buf.getvalue().decode("utf-8")
+            assert "Async pretty" in output
+            assert " | " in output
+            assert "{" not in output
+        finally:
+            sys.stdout = orig  # type: ignore[assignment]

--- a/tests/unit/test_builtin_plugins_have_names.py
+++ b/tests/unit/test_builtin_plugins_have_names.py
@@ -11,6 +11,7 @@ import pytest
 # Expected name for each built-in plugin class
 BUILTIN_PLUGINS = [
     ("fapilog.plugins.sinks.stdout_json", "StdoutJsonSink", "stdout_json"),
+    ("fapilog.plugins.sinks.stdout_pretty", "StdoutPrettySink", "stdout_pretty"),
     ("fapilog.plugins.sinks.rotating_file", "RotatingFileSink", "rotating_file"),
     ("fapilog.plugins.sinks.http_client", "HttpSink", "http"),
     ("fapilog.plugins.sinks.webhook", "WebhookSink", "webhook"),

--- a/tests/unit/test_plugin_consistency.py
+++ b/tests/unit/test_plugin_consistency.py
@@ -14,6 +14,7 @@ import pytest
 BUILTIN_PLUGIN_MODULES = [
     # Sinks
     "fapilog.plugins.sinks.stdout_json",
+    "fapilog.plugins.sinks.stdout_pretty",
     "fapilog.plugins.sinks.rotating_file",
     "fapilog.plugins.sinks.http_client",
     "fapilog.plugins.sinks.webhook",

--- a/tests/unit/test_plugin_metadata_completeness.py
+++ b/tests/unit/test_plugin_metadata_completeness.py
@@ -15,6 +15,7 @@ import pytest
 BUILTIN_PLUGIN_MODULES = [
     # Sinks
     "fapilog.plugins.sinks.stdout_json",
+    "fapilog.plugins.sinks.stdout_pretty",
     "fapilog.plugins.sinks.rotating_file",
     "fapilog.plugins.sinks.http_client",
     "fapilog.plugins.sinks.webhook",
@@ -85,7 +86,7 @@ def test_plugin_metadata_api_version_format(module_path: str) -> None:
     api_version = metadata.get("api_version", "1.0")
     # Should not raise
     major, minor = parse_api_version(api_version)
-    assert major >= 1, f"{module_path} api_version major must be >= 1"
+    assert major == 1, f"{module_path} api_version major must be 1"
 
 
 @pytest.mark.parametrize("module_path", BUILTIN_PLUGIN_MODULES)

--- a/tests/unit/test_plugin_metadata_consistency.py
+++ b/tests/unit/test_plugin_metadata_consistency.py
@@ -70,6 +70,12 @@ from fapilog.plugins.sinks.stdout_json import (
 from fapilog.plugins.sinks.stdout_json import (
     StdoutJsonSink,
 )
+from fapilog.plugins.sinks.stdout_pretty import (
+    PLUGIN_METADATA as STDOUT_PRETTY_META,
+)
+from fapilog.plugins.sinks.stdout_pretty import (
+    StdoutPrettySink,
+)
 from fapilog.plugins.utils import normalize_plugin_name
 
 
@@ -81,6 +87,7 @@ def test_builtin_metadata_matches_class_names() -> None:
         (ZeroCopyProcessor, ZERO_COPY_META),
         (SizeGuardProcessor, SIZE_GUARD_META),
         (StdoutJsonSink, STDOUT_META),
+        (StdoutPrettySink, STDOUT_PRETTY_META),
         (RotatingFileSink, ROTATING_FILE_META),
         (CloudWatchSink, CLOUDWATCH_META),
         (LokiSink, LOKI_META),

--- a/tests/unit/test_preset_logger.py
+++ b/tests/unit/test_preset_logger.py
@@ -115,3 +115,27 @@ class TestBackwardsCompatibility:
         """Name and preset can be used together."""
         logger = get_logger(name="my-logger", preset="dev")
         assert callable(logger.info)
+
+
+class TestFormatParameter:
+    """Test format parameter validation."""
+
+    def test_invalid_format_raises_value_error(self):
+        """Unknown format values raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid format"):
+            get_logger(format="xml")  # type: ignore[arg-type]
+
+    def test_format_and_settings_raises_value_error(self):
+        """format and settings are mutually exclusive."""
+        with pytest.raises(
+            ValueError, match="Cannot specify both 'format' and 'settings'"
+        ):
+            get_logger(format="pretty", settings=Settings())
+
+    @pytest.mark.asyncio
+    async def test_async_format_and_settings_raises_value_error(self):
+        """format and settings are mutually exclusive in async."""
+        with pytest.raises(
+            ValueError, match="Cannot specify both 'format' and 'settings'"
+        ):
+            await get_async_logger(format="json", settings=Settings())

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -24,10 +24,10 @@ class TestPresetDefinitions:
         config = get_preset("dev")
         assert config["core"]["batch_max_size"] == 1
 
-    def test_dev_preset_uses_stdout_json_sink(self):
-        """Dev preset uses stdout_json sink."""
+    def test_dev_preset_uses_stdout_pretty_sink(self):
+        """Dev preset uses stdout_pretty sink."""
         config = get_preset("dev")
-        assert config["core"]["sinks"] == ["stdout_json"]
+        assert config["core"]["sinks"] == ["stdout_pretty"]
 
     def test_production_preset_has_info_log_level(self):
         """Production preset sets log level to INFO."""

--- a/tests/unit/test_stdout_pretty_sink.py
+++ b/tests/unit/test_stdout_pretty_sink.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import datetime as dt
+import io
+import sys
+from datetime import timezone
+from unittest.mock import patch
+
+import pytest
+
+from fapilog.plugins.sinks.stdout_pretty import StdoutPrettySink
+
+
+class TestTimestampFormatting:
+    def test_formats_datetime(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        stamp = dt.datetime(2025, 1, 11, 14, 30, 22)
+        assert sink._format_timestamp(stamp) == "2025-01-11 14:30:22"
+
+    def test_formats_float_timestamp(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        value = 1736605822.0
+        expected = (
+            dt.datetime.fromtimestamp(value).astimezone().strftime("%Y-%m-%d %H:%M:%S")
+        )
+        assert sink._format_timestamp(value) == expected
+
+    def test_formats_invalid_string_timestamp(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        value = "not-a-date"
+        assert sink._format_timestamp(value) == value
+
+    def test_formats_timezone_aware_timestamp(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        stamp = dt.datetime(2025, 1, 11, 14, 30, 22, tzinfo=timezone.utc)
+        expected = stamp.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+        assert sink._format_timestamp(stamp) == expected
+
+
+class TestLevelFormatting:
+    def test_level_padded_without_colors(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        result = sink._format_level("INFO")
+        assert result == "INFO".ljust(8)
+
+    def test_level_colored_when_tty(self) -> None:
+        with patch.object(sys.stdout, "isatty", return_value=True):
+            sink = StdoutPrettySink(colors=True)
+        result = sink._format_level("ERROR")
+        assert "\033[" in result
+        assert "ERROR" in result
+        assert result.endswith("\033[0m")
+
+
+class TestContextFormatting:
+    def test_context_flattens_metadata_and_top_level(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "level": "INFO",
+            "message": "test",
+            "metadata": {"user": {"id": 123}, "request_id": "abc-123"},
+            "correlation_id": "corr-1",
+        }
+        result = sink._format_context(entry)
+        assert "user.id=123" in result
+        assert "request_id=abc-123" in result
+        assert "correlation_id=corr-1" in result
+
+    def test_context_quotes_strings_with_spaces(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {"metadata": {"error": "connection timeout"}}
+        result = sink._format_context(entry)
+        assert "error='connection timeout'" in result
+
+    def test_context_skips_reserved_fields(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {"timestamp": 1, "level": "INFO", "message": "x"}
+        result = sink._format_context(entry)
+        assert "timestamp=" not in result
+        assert "level=" not in result
+        assert "message=" not in result
+
+    def test_context_includes_base_context(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {"context": {"region": "us-east-1"}, "metadata": {"key": "value"}}
+        result = sink._format_context(entry)
+        assert "region=us-east-1" in result
+        assert "key=value" in result
+
+    def test_context_skips_error_fields(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {"metadata": {"error.stack": "Traceback", "ok": "yes"}}
+        result = sink._format_context(entry)
+        assert "error.stack" not in result
+        assert "ok=yes" in result
+
+
+class TestExceptionFormatting:
+    def test_exception_uses_error_stack_and_context(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "level": "ERROR",
+            "message": "boom",
+            "metadata": {
+                "error.stack": "Traceback (most recent call last):\nValueError: bad",
+                "user_id": 123,
+            },
+        }
+        result = sink._format_exception(entry)
+        assert "Traceback (most recent call last)" in result
+        assert "ValueError: bad" in result
+        assert "Context: user_id=123" in result
+        assert "error.stack" not in result
+
+    def test_exception_uses_frames_list(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "level": "ERROR",
+            "message": "boom",
+            "metadata": {
+                "error.type": "ValueError",
+                "error.message": "bad",
+                "error.frames": [
+                    {
+                        "file": "app.py",
+                        "line": 42,
+                        "function": "run",
+                        "code": "raise ValueError()",
+                    }
+                ],
+                "user_id": 7,
+            },
+        }
+        result = sink._format_exception(entry)
+        assert "Traceback (most recent call last):" in result
+        assert 'File "app.py", line 42, in run' in result
+        assert "raise ValueError()" in result
+        assert "ValueError: bad" in result
+        assert "Context: user_id=7" in result
+
+    def test_exception_frames_without_message(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "level": "ERROR",
+            "metadata": {
+                "error.type": "RuntimeError",
+                "error.frames": [{"file": "app.py", "line": 1, "function": "main"}],
+            },
+        }
+        result = sink._format_exception(entry)
+        assert "RuntimeError" in result
+        assert "Context:" not in result
+
+    def test_exception_frames_skips_non_mapping(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "level": "ERROR",
+            "metadata": {
+                "error.type": "RuntimeError",
+                "error.frames": ["bad-frame", {"file": "app.py", "line": 2}],
+            },
+        }
+        result = sink._format_exception(entry)
+        assert "Traceback (most recent call last):" in result
+
+    def test_exception_uses_exception_mapping(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {"exception": {"traceback": "Traceback (most recent call last):\nboom"}}
+        result = sink._format_exception(entry)
+        assert "Traceback (most recent call last):" in result
+
+
+class TestPrettyFormatting:
+    def test_format_pretty_includes_context(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "timestamp": dt.datetime(2025, 1, 11, 14, 30, 22),
+            "level": "INFO",
+            "message": "hello",
+            "metadata": {"user_id": 123},
+        }
+        result = sink._format_pretty(entry)
+        assert "2025-01-11 14:30:22" in result
+        assert "INFO" in result
+        assert "hello" in result
+        assert "user_id=123" in result
+
+    def test_format_pretty_includes_exception_block(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {
+            "timestamp": dt.datetime(2025, 1, 11, 14, 30, 22),
+            "level": "ERROR",
+            "message": "failed",
+            "metadata": {"error.stack": "Traceback (most recent call last):\nboom"},
+        }
+        result = sink._format_pretty(entry)
+        assert "failed" in result
+        assert "Traceback (most recent call last)" in result
+
+
+class TestSinkWrite:
+    @pytest.mark.asyncio
+    async def test_start_stop_are_noops(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        await sink.start()
+        await sink.stop()
+
+    @pytest.mark.asyncio
+    async def test_write_outputs_newline(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {"level": "INFO", "message": "test"}
+        buf = io.StringIO()
+        with patch("sys.stdout", buf):
+            await sink.write(entry)
+        output = buf.getvalue()
+        assert "test" in output
+        assert output.endswith("\n")
+
+    @pytest.mark.asyncio
+    async def test_write_swallows_errors(self) -> None:
+        sink = StdoutPrettySink(colors=False)
+        entry = {"level": "INFO", "message": "test"}
+        with patch.object(
+            sink, "_format_pretty", side_effect=RuntimeError("boom")
+        ), patch("fapilog.plugins.sinks.stdout_pretty.diagnostics.warn") as warn:
+            await sink.write(entry)
+        warn.assert_called_once()
+
+
+class TestTtyDetection:
+    def test_is_tty_handles_exception(self) -> None:
+        class BrokenStdout:
+            def isatty(self) -> bool:
+                raise RuntimeError("boom")
+
+        sink = StdoutPrettySink(colors=False)
+        with patch("sys.stdout", BrokenStdout()):
+            assert sink._is_tty() is False
+
+
+class TestHealthCheck:
+    @pytest.mark.asyncio
+    async def test_health_check_false_on_error(self) -> None:
+        class BrokenStdout:
+            @property
+            def write(self) -> bool:  # pragma: no cover - behavior check
+                raise RuntimeError("boom")
+
+        sink = StdoutPrettySink(colors=False)
+        with patch("sys.stdout", BrokenStdout()):
+            assert await sink.health_check() is False


### PR DESCRIPTION
## Summary
- add stdout_pretty sink with TTY-aware colors and frame-based exception formatting; add format selection to logger factories
- update dev preset, plugin metadata, docs, and examples for pretty output and auto format selection
- add tests and benchmarks for pretty output behavior and overhead guard

## Tests
- python -m pytest --cov=src/fapilog --cov-branch --cov-report=term-missing --cov-report=xml tests/

## Notes/Risks
- Default core.exceptions_max_frames reduced to 10