### PR TITLE
feat(sinks): add rotating file factory and docs

### DIFF
--- a/docs/api-reference/modules.md
+++ b/docs/api-reference/modules.md
@@ -46,6 +46,10 @@ Data redaction and masking utilities.
 
 Output destination management.
 
+### fapilog.sinks
+
+Convenience sink factories (e.g., `rotating_file()`).
+
 ### fapilog.plugins.processors
 
 Data processing and transformation.

--- a/docs/api-reference/plugins/sinks.md
+++ b/docs/api-reference/plugins/sinks.md
@@ -43,6 +43,29 @@ class SerializedView:
 - **http**: POST log entries to an HTTP endpoint.
 - **webhook**: POST log entries to a webhook with optional signing.
 
+## Convenience factories
+
+### rotating_file (fapilog.sinks)
+
+```python
+from fapilog.sinks import rotating_file
+
+sink = rotating_file(
+    "logs/app.log",
+    rotation="10 MB",
+    retention=7,
+    compression=True,
+    mode="json",
+)
+```
+
+Parameters:
+- `path`: file path (directory is created if missing)
+- `rotation`: size-based rotation (string or int bytes)
+- `retention`: max rotated files to keep
+- `compression`: gzip rotated files
+- `mode`: `json` or `text`
+
 ## Configuration (env)
 
 Rotating file:

--- a/docs/guides/migration-file-rotation.md
+++ b/docs/guides/migration-file-rotation.md
@@ -1,0 +1,59 @@
+# Migration Guide: Simplified Rotating File Setup
+
+This guide shows how to migrate from the verbose `RotatingFileSinkConfig` pattern
+to the new `fapilog.sinks.rotating_file()` convenience factory.
+
+## Before (Verbose Configuration)
+
+```python
+from fapilog import get_logger
+from fapilog.plugins.sinks.rotating_file import RotatingFileSink, RotatingFileSinkConfig
+from pathlib import Path
+
+config = RotatingFileSinkConfig(
+    directory=Path("logs"),
+    filename_prefix="app",
+    max_bytes=10485760,
+    max_files=7,
+    compress_rotated=True,
+)
+sink = RotatingFileSink(config)
+logger = get_logger(sinks=[sink])
+```
+
+## After (Convenience Factory)
+
+```python
+from fapilog import get_logger
+from fapilog.sinks import rotating_file
+
+logger = get_logger(
+    sinks=[rotating_file("logs/app.log", rotation="10 MB", retention=7, compression=True)]
+)
+```
+
+## Notes
+
+- The factory parses the path into directory + filename prefix automatically.
+- Rotation values accept human-readable strings (e.g., `"10 MB"`).
+- Behavior is additive; the old configuration path still works.
+
+## Settings Alternative
+
+```python
+from fapilog import Settings, get_logger
+from fapilog.core.settings import RotatingFileSettings
+
+settings = Settings(
+    sink_config=Settings.SinkConfig(
+        rotating_file=RotatingFileSettings(
+            directory="logs",
+            filename_prefix="app",
+            max_bytes="10 MB",
+            max_files=7,
+            compress_rotated=True,
+        )
+    )
+)
+logger = get_logger(settings=settings)
+```

--- a/docs/stories/10.5.simplified-file-rotation-api.md
+++ b/docs/stories/10.5.simplified-file-rotation-api.md
@@ -1,7 +1,7 @@
 # Story 10.5: Simplified File Sink Configuration
 
 **Epic**: Epic 10 - Developer Experience & Ergonomics Improvements
-**Status**: Implementation-Ready
+**Status**: Complete
 **Priority**: High (Phase 2: API Improvements)
 **Estimated Complexity**: Low (2-3 days)
 

--- a/docs/user-guide/rotating-file-sink.md
+++ b/docs/user-guide/rotating-file-sink.md
@@ -3,6 +3,28 @@
 
 Write logs to disk with size/time rotation.
 
+## Quick Start (Convenience Function)
+
+```python
+from fapilog import get_logger
+from fapilog.sinks import rotating_file
+
+# Simple file logging
+logger = get_logger(sinks=[rotating_file("logs/app.log")])
+
+# With rotation and retention
+logger = get_logger(
+    sinks=[
+        rotating_file(
+            "logs/app.log",
+            rotation="10 MB",
+            retention=7,
+            compression=True,
+        )
+    ]
+)
+```
+
 ## Enable via environment
 
 ```bash
@@ -16,6 +38,27 @@ export FAPILOG_FILE__INTERVAL_SECONDS="daily"
 
 `"daily"`/`"hourly"`/`"weekly"` are fixed intervals (e.g., 24 hours), not wall-clock boundaries.
 
+## Programmatic settings
+
+```python
+from fapilog import Settings, get_logger
+from fapilog.core.settings import RotatingFileSettings
+
+settings = Settings(
+    sink_config=Settings.SinkConfig(
+        rotating_file=RotatingFileSettings(
+            directory="logs",
+            filename_prefix="app",
+            max_bytes="10 MB",
+            max_files=7,
+            compress_rotated=True,
+        )
+    )
+)
+logger = get_logger(settings=settings)
+logger.info("configured via Settings")
+```
+
 ## Usage
 
 ```python
@@ -25,10 +68,15 @@ logger = get_logger()
 logger.info("to file", event="startup")
 ```
 
+## Migration
+
+See `docs/guides/migration-file-rotation.md` for a before/after conversion from
+`RotatingFileSinkConfig` to the `rotating_file()` convenience factory.
+
 ## What to expect
 
-- Files named `fapilog.log`, `fapilog.log.1`, `fapilog.log.2.gz`, etc.
-- Rotation by size (`max_bytes`); optional max file count and compression.
+- Files named like `fapilog-20250111-120000.jsonl` (or `.log` in text mode).
+- Rotation by size (`max_bytes`) or interval; optional retention and compression.
 
 ## Tips
 

--- a/src/fapilog/__init__.py
+++ b/src/fapilog/__init__.py
@@ -22,6 +22,7 @@ from typing import Iterator as _Iterator
 from typing import Literal as _Literal
 from typing import cast as _cast
 
+from . import sinks as sinks
 from .core.events import LogEvent
 from .core.logger import AsyncLoggerFacade as _AsyncLoggerFacade
 from .core.logger import DrainResult
@@ -69,6 +70,7 @@ __all__ = [
     "DrainResult",
     "LogEvent",
     "list_presets",
+    "sinks",
     "__version__",
     "VERSION",
 ]

--- a/src/fapilog/sinks/__init__.py
+++ b/src/fapilog/sinks/__init__.py
@@ -1,0 +1,61 @@
+"""Convenience factories for common sinks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from ..core.types import _parse_size
+from ..plugins.sinks.rotating_file import RotatingFileSink, RotatingFileSinkConfig
+
+
+def rotating_file(
+    path: str | Path,
+    *,
+    rotation: str | int | None = None,
+    retention: int | None = None,
+    compression: bool = False,
+    mode: Literal["json", "text"] = "json",
+) -> RotatingFileSink:
+    """Create a rotating file sink with human-readable configuration.
+
+    Args:
+        path: File path like "logs/app.log" (directory is created if missing).
+        rotation: Size-based rotation, e.g. "10 MB" or 10485760 (bytes).
+        retention: Number of rotated files to keep (None = unlimited).
+        compression: If True, compress rotated files with gzip.
+        mode: Output format ("json" or "text").
+
+    Examples:
+        >>> from fapilog import get_logger
+        >>> from fapilog.sinks import rotating_file
+        >>> logger = get_logger(sinks=[rotating_file("logs/app.log")])
+        >>> logger.info("started")
+
+        >>> logger = get_logger(
+        ...     sinks=[rotating_file("logs/app.log", rotation="10 MB", retention=7)]
+        ... )
+    """
+
+    path_obj = Path(path)
+    directory = path_obj.parent
+    filename_prefix = path_obj.stem
+
+    parsed_bytes = 10 * 1024 * 1024 if rotation is None else _parse_size(rotation)
+    if parsed_bytes is None:
+        raise ValueError("rotation must be a size string or integer")
+    max_bytes = parsed_bytes
+
+    config = RotatingFileSinkConfig(
+        directory=directory,
+        filename_prefix=filename_prefix,
+        mode=mode,
+        max_bytes=max_bytes,
+        max_files=retention,
+        compress_rotated=compression,
+    )
+
+    return RotatingFileSink(config)
+
+
+__all__ = ["rotating_file"]

--- a/tests/integration/test_rotating_file_factory_integration.py
+++ b/tests/integration/test_rotating_file_factory_integration.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from fapilog import get_logger
+from fapilog.sinks import rotating_file
+
+pytestmark = pytest.mark.integration
+
+
+def test_get_logger_with_rotating_file_factory(tmp_path: Path) -> None:
+    log_path = tmp_path / "app.log"
+    logger = get_logger(sinks=[rotating_file(log_path)])
+    logger.info("factory integration test", event="startup")
+    asyncio.run(logger.stop_and_drain())
+
+    log_files = list(tmp_path.glob("app-*.jsonl"))
+    assert log_files, "expected rotating file output to be created"
+    assert "factory integration test" in log_files[0].read_text(encoding="utf-8")

--- a/tests/unit/test_sinks_module.py
+++ b/tests/unit/test_sinks_module.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+from fapilog.plugins.sinks.rotating_file import RotatingFileSink
+from fapilog.sinks import rotating_file
+
+
+class TestRotatingFileFactory:
+    """Tests for rotating_file() convenience function."""
+
+    def test_rotating_file_minimal(self) -> None:
+        sink = rotating_file("logs/app.log")
+
+        assert isinstance(sink, RotatingFileSink)
+        assert sink._cfg.directory == Path("logs")
+        assert sink._cfg.filename_prefix == "app"
+        assert sink._cfg.max_bytes == 10 * 1024 * 1024
+        assert sink._cfg.max_files is None
+        assert sink._cfg.compress_rotated is False
+        assert sink._cfg.mode == "json"
+
+    def test_rotating_file_with_rotation_string(self) -> None:
+        sink = rotating_file("logs/app.log", rotation="50 MB")
+
+        assert sink._cfg.max_bytes == 50 * 1024 * 1024
+
+    def test_rotating_file_with_quoted_rotation_string(self) -> None:
+        sink = rotating_file("logs/app.log", rotation='"10 MB"')
+
+        assert sink._cfg.max_bytes == 10 * 1024 * 1024
+
+    def test_rotating_file_with_rotation_int(self) -> None:
+        sink = rotating_file("logs/app.log", rotation=1024)
+
+        assert sink._cfg.max_bytes == 1024
+
+    def test_rotating_file_with_retention(self) -> None:
+        sink = rotating_file("logs/app.log", retention=5)
+
+        assert sink._cfg.max_files == 5
+
+    def test_rotating_file_with_compression(self) -> None:
+        sink = rotating_file("logs/app.log", compression=True)
+
+        assert sink._cfg.compress_rotated is True
+
+    def test_rotating_file_mode_text(self) -> None:
+        sink = rotating_file("logs/app.log", mode="text")
+
+        assert sink._cfg.mode == "text"
+
+    def test_rotating_file_nested_path(self) -> None:
+        sink = rotating_file("logs/api/requests.log")
+
+        assert sink._cfg.directory == Path("logs/api")
+        assert sink._cfg.filename_prefix == "requests"
+
+    def test_rotating_file_path_object(self) -> None:
+        sink = rotating_file(Path("logs/app.log"))
+
+        assert sink._cfg.directory == Path("logs")
+        assert sink._cfg.filename_prefix == "app"
+
+    def test_rotating_file_full_config(self) -> None:
+        sink = rotating_file(
+            "logs/app.log",
+            rotation="100 MB",
+            retention=10,
+            compression=True,
+            mode="text",
+        )
+
+        assert sink._cfg.directory == Path("logs")
+        assert sink._cfg.filename_prefix == "app"
+        assert sink._cfg.max_bytes == 100 * 1024 * 1024
+        assert sink._cfg.max_files == 10
+        assert sink._cfg.compress_rotated is True
+        assert sink._cfg.mode == "text"


### PR DESCRIPTION
## Summary
- add fapilog.sinks.rotating_file factory and export it in public API
- add unit/integration coverage for the factory
- document the factory with API reference + migration guide updates

## Tests
- pytest -q tests/unit/test_sinks_module.py
- pytest -q tests/unit/test_sinks_module.py --cov=src/fapilog/sinks --cov-branch --cov-report=term-missing
- pytest -q tests/integration/test_rotating_file_sink_integration.py
- pytest -q tests/integration/test_rotating_file_factory_integration.py

## Notes/Risks
- None