### PR TITLE
feat: add smart environment auto-detection (Story 10.8)

### DIFF
--- a/src/fapilog/core/__init__.py
+++ b/src/fapilog/core/__init__.py
@@ -52,6 +52,11 @@ from .defaults import (
     should_fallback_sink,
 )
 from .encryption import EncryptionSettings, validate_encryption_async
+from .environment import (
+    EnvironmentType,
+    detect_environment,
+    get_environment_config,
+)
 from .errors import (
     AsyncErrorContext,
     AuthenticationError,
@@ -186,6 +191,10 @@ __all__ = [
     "is_ci_environment",
     "is_tty_environment",
     "should_fallback_sink",
+    # Environment detection (Story 10.8)
+    "EnvironmentType",
+    "detect_environment",
+    "get_environment_config",
     # Compliance configuration validation
     "AuditConfig",
     "DataHandlingSettings",

--- a/src/fapilog/core/environment.py
+++ b/src/fapilog/core/environment.py
@@ -1,0 +1,182 @@
+"""Smart environment auto-detection (Story 10.8).
+
+Provides comprehensive environment detection for automatic logger configuration.
+Detects: Lambda, Kubernetes, Docker, CI, and Local environments.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal
+
+from .defaults import is_ci_environment
+
+EnvironmentType = Literal["local", "docker", "kubernetes", "lambda", "ci"]
+
+# Path constants (allow mocking in tests)
+_K8S_SA_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount")
+_DOCKERENV_PATH = Path("/.dockerenv")
+_CGROUP_PATH = Path("/proc/1/cgroup")
+
+# Module-level cache for detection result
+_ENV_CACHE: EnvironmentType | None = None
+
+
+def detect_environment(*, use_cache: bool = True) -> EnvironmentType:
+    """Detect deployment environment.
+
+    Detection priority order (highest to lowest):
+    1. Lambda (AWS_LAMBDA_FUNCTION_NAME env var)
+    2. Kubernetes (serviceaccount path or POD_NAME env var)
+    3. Docker (/.dockerenv file or /proc/1/cgroup contains "docker")
+    4. CI (uses is_ci_environment() from Story 10.6)
+    5. Local (default)
+
+    Args:
+        use_cache: Use cached result if available (default True).
+            Set to False to force re-detection.
+
+    Returns:
+        Detected environment type.
+    """
+    global _ENV_CACHE
+    if use_cache and _ENV_CACHE is not None:
+        return _ENV_CACHE
+
+    # Priority 1: Lambda (highest - Lambda can run in containers)
+    if os.getenv("AWS_LAMBDA_FUNCTION_NAME"):
+        result: EnvironmentType = "lambda"
+        _ENV_CACHE = result
+        return result
+
+    # Priority 2: Kubernetes
+    if _detect_kubernetes():
+        result = "kubernetes"
+        _ENV_CACHE = result
+        return result
+
+    # Priority 3: Docker
+    if _detect_docker():
+        result = "docker"
+        _ENV_CACHE = result
+        return result
+
+    # Priority 4: CI (uses Story 10.6 helper)
+    if is_ci_environment():
+        result = "ci"
+        _ENV_CACHE = result
+        return result
+
+    # Priority 5: Local (default)
+    result = "local"
+    _ENV_CACHE = result
+    return result
+
+
+def _detect_kubernetes() -> bool:
+    """Detect Kubernetes environment.
+
+    Uses two detection methods:
+    1. Service account path (most reliable - only exists in K8s pods)
+    2. POD_NAME env var (common in K8s deployments via Downward API)
+
+    Returns:
+        True if running in Kubernetes, False otherwise.
+    """
+    # Method 1: Service account path (most reliable)
+    if _K8S_SA_PATH.exists():
+        return True
+
+    # Method 2: POD_NAME env var (common in K8s via Downward API)
+    if os.getenv("POD_NAME"):
+        return True
+
+    return False
+
+
+def _detect_docker() -> bool:
+    """Detect Docker environment.
+
+    Uses two detection methods:
+    1. /.dockerenv file (Docker creates this file in containers)
+    2. /proc/1/cgroup contains "docker" (checks cgroup hierarchy)
+
+    Note: This may also match in Kubernetes pods (which run in containers),
+    but Kubernetes detection takes priority in detect_environment().
+
+    Returns:
+        True if running in Docker, False otherwise.
+    """
+    # Method 1: /.dockerenv file (Docker-specific)
+    if _DOCKERENV_PATH.exists():
+        return True
+
+    # Method 2: /proc/1/cgroup contains "docker"
+    try:
+        if _CGROUP_PATH.exists():
+            content = _CGROUP_PATH.read_text()
+            if "docker" in content.lower():
+                return True
+    except (OSError, PermissionError, UnicodeDecodeError):
+        # Handle cases where file doesn't exist, can't be read, or has binary data
+        pass
+
+    return False
+
+
+def get_environment_config(env: EnvironmentType) -> dict[str, Any]:
+    """Get configuration for detected environment.
+
+    Returns Settings-compatible dict with environment-specific settings.
+    Designed to be merged with Story 10.6 defaults.
+
+    Args:
+        env: Environment type to get config for.
+
+    Returns:
+        Configuration dict with 'core' and 'enrichers' keys.
+    """
+    configs: dict[EnvironmentType, dict[str, Any]] = {
+        "lambda": {
+            "core": {
+                "log_level": "INFO",
+                "batch_max_size": 10,  # Smaller batches for Lambda timeouts
+                "batch_timeout_seconds": 0.1,  # Faster flushing
+                "max_queue_size": 1000,  # Smaller queue for Lambda memory
+            },
+            "enrichers": [
+                "runtime_info"
+            ],  # Lambda-specific enricher not yet implemented
+        },
+        "kubernetes": {
+            "core": {
+                "log_level": "INFO",
+            },
+            "enrichers": ["runtime_info", "kubernetes"],  # Auto-enable K8s enricher
+        },
+        "docker": {
+            "core": {
+                "log_level": "INFO",
+            },
+            "enrichers": ["runtime_info"],  # Container metadata via runtime_info
+        },
+        "ci": {
+            "core": {
+                "log_level": "INFO",
+            },
+            "enrichers": ["runtime_info"],
+        },
+        "local": {
+            # No log_level override - uses Story 10.6 defaults (DEBUG if TTY)
+            "enrichers": ["runtime_info"],
+        },
+    }
+    return configs.get(env, {"enrichers": ["runtime_info"]})
+
+
+__all__ = [
+    "EnvironmentType",
+    "detect_environment",
+    "get_environment_config",
+]

--- a/tests/integration/test_auto_config.py
+++ b/tests/integration/test_auto_config.py
@@ -1,0 +1,299 @@
+"""Integration tests for auto-configuration (Story 10.8)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fapilog import Settings, get_async_logger, get_logger
+from fapilog.core import environment as env_module
+from fapilog.plugins.filters.level import LEVEL_PRIORITY
+
+
+def _drain_logger(logger) -> None:
+    asyncio.run(logger.stop_and_drain())
+
+
+@pytest.fixture(autouse=True)
+def clear_env_cache():
+    """Clear environment detection cache before each test."""
+    env_module._ENV_CACHE = None
+    yield
+    env_module._ENV_CACHE = None
+
+
+class TestAutoDetectParameter:
+    """Test auto_detect parameter in get_logger()."""
+
+    def test_auto_detect_true_detects_lambda(self) -> None:
+        """auto_detect=True detects Lambda environment."""
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "my-function"}):
+            with patch(
+                "fapilog.core.environment._K8S_SA_PATH",
+                Path("/nonexistent/path"),
+            ):
+                with patch(
+                    "fapilog.core.environment._DOCKERENV_PATH",
+                    Path("/nonexistent/.dockerenv"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        logger = get_logger(auto_detect=True)
+                        try:
+                            # Lambda should set INFO level
+                            assert logger._level_gate == LEVEL_PRIORITY["INFO"]
+                        finally:
+                            _drain_logger(logger)
+
+    def test_auto_detect_true_detects_kubernetes(self) -> None:
+        """auto_detect=True detects Kubernetes and enables enricher."""
+        with patch.dict(os.environ, {"POD_NAME": "my-pod-abc123"}, clear=True):
+            with patch(
+                "fapilog.core.environment._K8S_SA_PATH",
+                Path("/nonexistent/path"),
+            ):
+                with patch(
+                    "fapilog.core.environment._DOCKERENV_PATH",
+                    Path("/nonexistent/.dockerenv"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        logger = get_logger(auto_detect=True)
+                        try:
+                            # K8s should set INFO level
+                            assert logger._level_gate == LEVEL_PRIORITY["INFO"]
+                            # Should have kubernetes enricher enabled
+                            enricher_names = [
+                                getattr(e, "name", type(e).__name__)
+                                for e in logger._enrichers
+                            ]
+                            assert "kubernetes" in enricher_names
+                        finally:
+                            _drain_logger(logger)
+
+    def test_auto_detect_false_uses_defaults_only(self) -> None:
+        """auto_detect=False uses Story 10.6 defaults only."""
+        with patch.dict(os.environ, {"POD_NAME": "my-pod"}, clear=True):
+            with patch(
+                "fapilog.core.environment._K8S_SA_PATH",
+                Path("/nonexistent/path"),
+            ):
+                with patch(
+                    "fapilog.core.defaults.is_ci_environment", return_value=False
+                ):
+                    with patch(
+                        "fapilog.core.defaults.is_tty_environment", return_value=True
+                    ):
+                        logger = get_logger(auto_detect=False)
+                        try:
+                            # Should use TTY default (DEBUG) not K8s config
+                            assert logger._level_gate is None  # DEBUG has no gate
+                        finally:
+                            _drain_logger(logger)
+
+    def test_auto_detect_default_is_true(self) -> None:
+        """auto_detect defaults to True when no explicit settings."""
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "func"}, clear=True):
+            with patch(
+                "fapilog.core.environment._K8S_SA_PATH",
+                Path("/nonexistent/path"),
+            ):
+                with patch(
+                    "fapilog.core.environment._DOCKERENV_PATH",
+                    Path("/nonexistent/.dockerenv"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        # No auto_detect param - should default to True
+                        logger = get_logger()
+                        try:
+                            assert logger._level_gate == LEVEL_PRIORITY["INFO"]
+                        finally:
+                            _drain_logger(logger)
+
+
+class TestEnvironmentParameter:
+    """Test environment parameter in get_logger()."""
+
+    def test_explicit_environment_overrides_detection(self) -> None:
+        """Explicit environment parameter overrides auto-detection."""
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "func"}):
+            # Even though Lambda is detected, use kubernetes config
+            logger = get_logger(environment="kubernetes")
+            try:
+                # Should have kubernetes enricher enabled
+                enricher_names = [
+                    getattr(e, "name", type(e).__name__) for e in logger._enrichers
+                ]
+                assert "kubernetes" in enricher_names
+            finally:
+                _drain_logger(logger)
+
+    def test_environment_lambda(self) -> None:
+        """environment='lambda' applies Lambda config."""
+        with patch.dict(os.environ, {}, clear=True):
+            logger = get_logger(environment="lambda")
+            try:
+                assert logger._level_gate == LEVEL_PRIORITY["INFO"]
+            finally:
+                _drain_logger(logger)
+
+    def test_environment_docker(self) -> None:
+        """environment='docker' applies Docker config."""
+        with patch.dict(os.environ, {}, clear=True):
+            logger = get_logger(environment="docker")
+            try:
+                assert logger._level_gate == LEVEL_PRIORITY["INFO"]
+            finally:
+                _drain_logger(logger)
+
+    def test_environment_ci(self) -> None:
+        """environment='ci' applies CI config."""
+        with patch.dict(os.environ, {}, clear=True):
+            logger = get_logger(environment="ci")
+            try:
+                assert logger._level_gate == LEVEL_PRIORITY["INFO"]
+            finally:
+                _drain_logger(logger)
+
+    def test_environment_local_uses_defaults(self) -> None:
+        """environment='local' uses Story 10.6 defaults."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("fapilog.core.defaults.is_ci_environment", return_value=False):
+                with patch(
+                    "fapilog.core.defaults.is_tty_environment", return_value=True
+                ):
+                    logger = get_logger(environment="local")
+                    try:
+                        # Local + TTY = DEBUG (no gate)
+                        assert logger._level_gate is None
+                    finally:
+                        _drain_logger(logger)
+
+
+class TestParameterPriority:
+    """Test parameter priority order."""
+
+    def test_explicit_settings_disables_auto_detect(self) -> None:
+        """Explicit settings parameter disables auto-detection."""
+        settings = Settings(core={"log_level": "ERROR"})
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "func"}):
+            logger = get_logger(settings=settings)
+            try:
+                # Should use explicit ERROR, not Lambda's INFO
+                assert logger._level_gate == LEVEL_PRIORITY["ERROR"]
+            finally:
+                _drain_logger(logger)
+
+    def test_explicit_preset_disables_auto_detect(self) -> None:
+        """Explicit preset parameter disables auto-detection."""
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "func"}):
+            logger = get_logger(preset="dev")
+            try:
+                # dev preset uses DEBUG level
+                assert logger._level_gate is None  # DEBUG has no gate
+            finally:
+                _drain_logger(logger)
+
+    def test_environment_takes_priority_over_auto_detect(self) -> None:
+        """Explicit environment overrides auto-detection."""
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "func"}):
+            logger = get_logger(environment="docker")
+            try:
+                # Should use docker config, not auto-detected lambda
+                # Both have INFO, but docker shouldn't have lambda's batch settings
+                assert logger._level_gate == LEVEL_PRIORITY["INFO"]
+            finally:
+                _drain_logger(logger)
+
+
+class TestLambdaOptimizations:
+    """Test Lambda-specific optimizations (AC5)."""
+
+    def test_lambda_batch_settings(self) -> None:
+        """Lambda environment gets optimized batch settings."""
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "func"}, clear=True):
+            with patch(
+                "fapilog.core.environment._K8S_SA_PATH",
+                Path("/nonexistent/path"),
+            ):
+                with patch(
+                    "fapilog.core.environment._DOCKERENV_PATH",
+                    Path("/nonexistent/.dockerenv"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        logger = get_logger(auto_detect=True)
+                        try:
+                            # Lambda optimizations
+                            assert logger._batch_max_size == 10
+                            assert logger._batch_timeout_seconds == 0.1
+                            assert logger._queue.capacity == 1000
+                        finally:
+                            _drain_logger(logger)
+
+
+class TestAsyncLogger:
+    """Test auto-detection with async logger."""
+
+    @pytest.mark.asyncio
+    async def test_async_logger_auto_detect(self) -> None:
+        """get_async_logger() supports auto_detect parameter."""
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "func"}, clear=True):
+            with patch(
+                "fapilog.core.environment._K8S_SA_PATH",
+                Path("/nonexistent/path"),
+            ):
+                with patch(
+                    "fapilog.core.environment._DOCKERENV_PATH",
+                    Path("/nonexistent/.dockerenv"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        logger = await get_async_logger(auto_detect=True)
+                        try:
+                            assert logger._level_gate == LEVEL_PRIORITY["INFO"]
+                        finally:
+                            await logger.stop_and_drain()
+
+    @pytest.mark.asyncio
+    async def test_async_logger_environment_param(self) -> None:
+        """get_async_logger() supports environment parameter."""
+        with patch.dict(os.environ, {}, clear=True):
+            logger = await get_async_logger(environment="kubernetes")
+            try:
+                enricher_names = [
+                    getattr(e, "name", type(e).__name__) for e in logger._enrichers
+                ]
+                assert "kubernetes" in enricher_names
+            finally:
+                await logger.stop_and_drain()
+
+
+class TestMutualExclusivity:
+    """Test mutual exclusivity of parameters."""
+
+    def test_environment_and_settings_mutually_exclusive(self) -> None:
+        """Cannot specify both environment and settings."""
+        settings = Settings()
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            get_logger(environment="lambda", settings=settings)
+
+    def test_environment_and_preset_mutually_exclusive(self) -> None:
+        """Cannot specify both environment and preset."""
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            get_logger(environment="lambda", preset="dev")

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -74,10 +74,13 @@ class TestIsTtyEnvironment:
 
 
 class TestDefaultLogLevelIntegration:
+    """Test Story 10.6 defaults (with auto_detect=False to isolate behavior)."""
+
     def test_default_log_level_uses_tty(self) -> None:
         with patch("fapilog.core.defaults.is_ci_environment", return_value=False):
             with patch("fapilog.core.defaults.is_tty_environment", return_value=True):
-                logger = get_logger()
+                # Use auto_detect=False to test Story 10.6 defaults in isolation
+                logger = get_logger(auto_detect=False)
                 try:
                     assert logger._level_gate is None  # noqa: SLF001
                 finally:
@@ -86,7 +89,7 @@ class TestDefaultLogLevelIntegration:
     def test_default_log_level_non_tty(self) -> None:
         with patch("fapilog.core.defaults.is_ci_environment", return_value=False):
             with patch("fapilog.core.defaults.is_tty_environment", return_value=False):
-                logger = get_logger()
+                logger = get_logger(auto_detect=False)
                 try:
                     assert logger._level_gate == LEVEL_PRIORITY["INFO"]  # noqa: SLF001
                 finally:
@@ -95,7 +98,7 @@ class TestDefaultLogLevelIntegration:
     def test_ci_overrides_tty_default(self) -> None:
         with patch("fapilog.core.defaults.is_ci_environment", return_value=True):
             with patch("fapilog.core.defaults.is_tty_environment", return_value=True):
-                logger = get_logger()
+                logger = get_logger(auto_detect=False)
                 try:
                     assert logger._level_gate == LEVEL_PRIORITY["INFO"]  # noqa: SLF001
                 finally:

--- a/tests/unit/test_environment_detection.py
+++ b/tests/unit/test_environment_detection.py
@@ -1,0 +1,361 @@
+"""Unit tests for environment detection (Story 10.8)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from fapilog.core.environment import (
+    EnvironmentType,
+    detect_environment,
+    get_environment_config,
+)
+
+
+class TestDetectLambda:
+    """Test Lambda environment detection."""
+
+    def test_lambda_detected_via_env_var(self) -> None:
+        """Lambda detected via AWS_LAMBDA_FUNCTION_NAME."""
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "my-function"}):
+            result = detect_environment(use_cache=False)
+            assert result == "lambda"
+
+    def test_no_lambda_env_var_not_detected(self) -> None:
+        """No Lambda env var does not detect lambda."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "fapilog.core.environment._detect_kubernetes", return_value=False
+            ):
+                with patch(
+                    "fapilog.core.environment._detect_docker", return_value=False
+                ):
+                    with patch(
+                        "fapilog.core.environment.is_ci_environment", return_value=False
+                    ):
+                        result = detect_environment(use_cache=False)
+                        assert result != "lambda"
+
+
+class TestDetectKubernetes:
+    """Test Kubernetes environment detection."""
+
+    def test_k8s_detected_via_serviceaccount_path(self, tmp_path: Path) -> None:
+        """Kubernetes detected via serviceaccount path."""
+        sa_path = (
+            tmp_path / "var" / "run" / "secrets" / "kubernetes.io" / "serviceaccount"
+        )
+        sa_path.mkdir(parents=True, exist_ok=True)
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "fapilog.core.environment._K8S_SA_PATH",
+                sa_path,
+            ):
+                result = detect_environment(use_cache=False)
+                assert result == "kubernetes"
+
+    def test_k8s_detected_via_pod_name_env(self) -> None:
+        """Kubernetes detected via POD_NAME env var."""
+        with patch.dict(os.environ, {"POD_NAME": "my-pod-abc123"}, clear=True):
+            result = detect_environment(use_cache=False)
+            assert result == "kubernetes"
+
+    def test_no_k8s_indicators_not_detected(self) -> None:
+        """No Kubernetes indicators does not detect kubernetes."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "fapilog.core.environment._K8S_SA_PATH",
+                Path("/nonexistent/path"),
+            ):
+                with patch(
+                    "fapilog.core.environment._detect_docker", return_value=False
+                ):
+                    with patch(
+                        "fapilog.core.environment.is_ci_environment", return_value=False
+                    ):
+                        result = detect_environment(use_cache=False)
+                        assert result != "kubernetes"
+
+
+class TestDetectDocker:
+    """Test Docker environment detection."""
+
+    def test_docker_detected_via_dockerenv(self, tmp_path: Path) -> None:
+        """Docker detected via /.dockerenv file."""
+        dockerenv = tmp_path / ".dockerenv"
+        dockerenv.touch()
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "fapilog.core.environment._DOCKERENV_PATH",
+                dockerenv,
+            ):
+                with patch(
+                    "fapilog.core.environment._K8S_SA_PATH",
+                    Path("/nonexistent/path"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        result = detect_environment(use_cache=False)
+                        assert result == "docker"
+
+    def test_docker_detected_via_cgroup(self, tmp_path: Path) -> None:
+        """Docker detected via /proc/1/cgroup containing docker."""
+        cgroup = tmp_path / "cgroup"
+        cgroup.write_text("1:name=systemd:/docker/abc123def456\n")
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "fapilog.core.environment._DOCKERENV_PATH",
+                Path("/nonexistent/.dockerenv"),
+            ):
+                with patch(
+                    "fapilog.core.environment._K8S_SA_PATH",
+                    Path("/nonexistent/path"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        cgroup,
+                    ):
+                        result = detect_environment(use_cache=False)
+                        assert result == "docker"
+
+    def test_no_docker_indicators_not_detected(self) -> None:
+        """No Docker indicators does not detect docker."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "fapilog.core.environment._DOCKERENV_PATH",
+                Path("/nonexistent/.dockerenv"),
+            ):
+                with patch(
+                    "fapilog.core.environment._K8S_SA_PATH",
+                    Path("/nonexistent/path"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        with patch(
+                            "fapilog.core.environment.is_ci_environment",
+                            return_value=False,
+                        ):
+                            result = detect_environment(use_cache=False)
+                            assert result != "docker"
+
+
+class TestDetectCI:
+    """Test CI environment detection."""
+
+    def test_ci_detected_via_ci_var(self) -> None:
+        """CI detected when CI env var present."""
+        with patch.dict(os.environ, {"CI": "true"}, clear=True):
+            with patch(
+                "fapilog.core.environment._DOCKERENV_PATH",
+                Path("/nonexistent/.dockerenv"),
+            ):
+                with patch(
+                    "fapilog.core.environment._K8S_SA_PATH",
+                    Path("/nonexistent/path"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        result = detect_environment(use_cache=False)
+                        assert result == "ci"
+
+    def test_ci_detected_via_github_actions(self) -> None:
+        """CI detected when GITHUB_ACTIONS env var present."""
+        with patch.dict(os.environ, {"GITHUB_ACTIONS": "true"}, clear=True):
+            with patch(
+                "fapilog.core.environment._DOCKERENV_PATH",
+                Path("/nonexistent/.dockerenv"),
+            ):
+                with patch(
+                    "fapilog.core.environment._K8S_SA_PATH",
+                    Path("/nonexistent/path"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        result = detect_environment(use_cache=False)
+                        assert result == "ci"
+
+
+class TestDetectLocal:
+    """Test local environment detection (default)."""
+
+    def test_local_is_default(self) -> None:
+        """Local is the default when no indicators present."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "fapilog.core.environment._DOCKERENV_PATH",
+                Path("/nonexistent/.dockerenv"),
+            ):
+                with patch(
+                    "fapilog.core.environment._K8S_SA_PATH",
+                    Path("/nonexistent/path"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        result = detect_environment(use_cache=False)
+                        assert result == "local"
+
+
+class TestDetectionPriority:
+    """Test environment detection priority order."""
+
+    def test_lambda_takes_priority_over_kubernetes(self) -> None:
+        """Lambda detection takes priority over Kubernetes."""
+        with patch.dict(
+            os.environ,
+            {"AWS_LAMBDA_FUNCTION_NAME": "func", "POD_NAME": "pod"},
+        ):
+            result = detect_environment(use_cache=False)
+            assert result == "lambda"
+
+    def test_kubernetes_takes_priority_over_docker(self) -> None:
+        """Kubernetes detection takes priority over Docker."""
+        with patch.dict(os.environ, {"POD_NAME": "my-pod"}, clear=True):
+            with patch("fapilog.core.environment._detect_docker", return_value=True):
+                result = detect_environment(use_cache=False)
+                assert result == "kubernetes"
+
+    def test_docker_takes_priority_over_ci(self) -> None:
+        """Docker detection takes priority over CI."""
+        with patch.dict(os.environ, {"CI": "true"}, clear=True):
+            with patch(
+                "fapilog.core.environment._K8S_SA_PATH",
+                Path("/nonexistent/path"),
+            ):
+                with patch(
+                    "fapilog.core.environment._detect_docker", return_value=True
+                ):
+                    result = detect_environment(use_cache=False)
+                    assert result == "docker"
+
+
+class TestDetectionCaching:
+    """Test detection result caching."""
+
+    def test_detection_is_cached(self) -> None:
+        """Detection results are cached by default."""
+        from fapilog.core import environment
+
+        # Clear any existing cache
+        environment._ENV_CACHE = None
+
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "func"}):
+            result1 = detect_environment(use_cache=True)
+            assert result1 == "lambda"
+
+        # Clear env but cache should still return lambda
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "fapilog.core.environment._DOCKERENV_PATH",
+                Path("/nonexistent/.dockerenv"),
+            ):
+                with patch(
+                    "fapilog.core.environment._K8S_SA_PATH",
+                    Path("/nonexistent/path"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        result2 = detect_environment(use_cache=True)
+                        assert result2 == "lambda"  # Still cached
+
+        # Clean up
+        environment._ENV_CACHE = None
+
+    def test_cache_can_be_bypassed(self) -> None:
+        """Cache can be bypassed with use_cache=False."""
+        from fapilog.core import environment
+
+        # Clear any existing cache
+        environment._ENV_CACHE = None
+
+        with patch.dict(os.environ, {"AWS_LAMBDA_FUNCTION_NAME": "func"}):
+            detect_environment(use_cache=True)  # Cache as lambda
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "fapilog.core.environment._DOCKERENV_PATH",
+                Path("/nonexistent/.dockerenv"),
+            ):
+                with patch(
+                    "fapilog.core.environment._K8S_SA_PATH",
+                    Path("/nonexistent/path"),
+                ):
+                    with patch(
+                        "fapilog.core.environment._CGROUP_PATH",
+                        Path("/nonexistent/cgroup"),
+                    ):
+                        result = detect_environment(use_cache=False)
+                        assert result == "local"  # Re-detected as local
+
+        # Clean up
+        environment._ENV_CACHE = None
+
+
+class TestGetEnvironmentConfig:
+    """Test get_environment_config() function."""
+
+    def test_lambda_config(self) -> None:
+        """Lambda config has optimized batch settings."""
+        config = get_environment_config("lambda")
+        assert config["core"]["log_level"] == "INFO"
+        assert config["core"]["batch_max_size"] == 10
+        assert config["core"]["batch_timeout_seconds"] == 0.1
+        assert config["core"]["max_queue_size"] == 1000
+        assert "runtime_info" in config["enrichers"]
+
+    def test_kubernetes_config(self) -> None:
+        """Kubernetes config auto-enables kubernetes enricher."""
+        config = get_environment_config("kubernetes")
+        assert config["core"]["log_level"] == "INFO"
+        assert "kubernetes" in config["enrichers"]
+        assert "runtime_info" in config["enrichers"]
+
+    def test_docker_config(self) -> None:
+        """Docker config uses runtime_info enricher."""
+        config = get_environment_config("docker")
+        assert config["core"]["log_level"] == "INFO"
+        assert "runtime_info" in config["enrichers"]
+
+    def test_ci_config(self) -> None:
+        """CI config uses INFO level."""
+        config = get_environment_config("ci")
+        assert config["core"]["log_level"] == "INFO"
+        assert "runtime_info" in config["enrichers"]
+
+    def test_local_config(self) -> None:
+        """Local config uses defaults (no log_level override)."""
+        config = get_environment_config("local")
+        assert "log_level" not in config.get("core", {})
+        assert "runtime_info" in config["enrichers"]
+
+
+class TestEnvironmentType:
+    """Test EnvironmentType type alias."""
+
+    def test_environment_type_values(self) -> None:
+        """EnvironmentType includes all expected values."""
+        valid_types: list[EnvironmentType] = [
+            "local",
+            "docker",
+            "kubernetes",
+            "lambda",
+            "ci",
+        ]
+        for env_type in valid_types:
+            # Should not raise type errors
+            assert isinstance(env_type, str)


### PR DESCRIPTION
Implement automatic environment detection and configuration for Lambda, Kubernetes, Docker, CI, and local environments.

- Add detect_environment() with priority order: Lambda > K8s > Docker > CI > Local
- Add get_environment_config() for environment-specific settings
- Add auto_detect and environment parameters to get_logger/get_async_logger
- Auto-enable kubernetes enricher when K8s detected
- Apply Lambda-specific optimizations (batch_max_size=10, batch_timeout=0.1)
- Detection results cached per-process for performance
- Enforce mutual exclusivity: environment param vs settings/preset

Tests: 22 unit tests for detection, 17 integration tests for auto-config