### PR TITLE
feat: skip code tests for documentation-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,55 @@ permissions:
   contents: read
 
 jobs:
+  detect-docs-only:
+    name: Detect Documentation-Only Changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.check.outputs.docs-only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if PR is documentation-only
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "docs-only=false" >> $GITHUB_OUTPUT
+            echo "Not a pull request, running all checks"
+            exit 0
+          fi
+          
+          # Get the list of changed files
+          git diff --name-only origin/${{ github.base_ref }}...HEAD > changed_files.txt
+          
+          # Define documentation file patterns
+          # Documentation files include:
+          # - Any .md files (but NOT .rst files - we guard against those)
+          # - Files in docs/ directory
+          # - Root level docs: README*, CHANGELOG*, CONTRIBUTING*, LICENSE*
+          # - Documentation in .github/ and .claude/ directories
+          # - api-reference/ directory (if it exists at root)
+          # Exclude: .py, .yml (workflow files), .toml, .json, .rst, etc.
+          
+          # Check if any non-documentation files changed
+          # Note: .rst files are intentionally excluded - we guard against them being committed
+          non_docs_changed=$(grep -v -E '\.md$|^docs/|^(README|CHANGELOG|CONTRIBUTING|LICENSE)(\.|$)|^\.github/.*\.md$|^\.claude/.*\.md$|^api-reference/.*\.md$' changed_files.txt || true)
+          
+          if [ -z "$non_docs_changed" ]; then
+            echo "docs-only=true" >> $GITHUB_OUTPUT
+            echo "✅ PR contains only documentation changes"
+          else
+            echo "docs-only=false" >> $GITHUB_OUTPUT
+            echo "📝 PR contains code changes:"
+            echo "$non_docs_changed"
+          fi
+
   lint:
     name: Build & Lint
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs-only != 'true'
+    needs: [detect-docs-only]
     steps:
       - uses: actions/checkout@v4
 
@@ -32,6 +78,8 @@ jobs:
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs-only != 'true'
+    needs: [detect-docs-only]
     steps:
       - uses: actions/checkout@v4
 
@@ -51,6 +99,8 @@ jobs:
   test:
     name: Test & Coverage
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs-only != 'true'
+    needs: [detect-docs-only]
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -106,6 +156,8 @@ jobs:
   tox:
     name: Tox (Compatibility)
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs-only != 'true'
+    needs: [detect-docs-only]
     strategy:
       matrix:
         python-version: ["3.11"]

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+# Guard against .rst files being committed (we use .md for documentation)
+*.rst
 
 # PyBuilder
 .pybuilder/


### PR DESCRIPTION
- Add detect-docs-only job to identify PRs with only documentation changes
- Skip lint, typecheck, test, and tox jobs for docs-only PRs
- Add .rst files to .gitignore to prevent them from being committed
- All code-based jobs still run for PRs with code changes or on pushes