### PR TITLE
feat(tests): standardize Hypothesis property test settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+- Standardized Hypothesis property test settings: removed per-test `max_examples` overrides so all tests respect `HYPOTHESIS_MAX_EXAMPLES` env var.
 - Added fluent builder API (`LoggerBuilder`, `AsyncLoggerBuilder`) for chainable logger configuration with IDE autocomplete support.
 - Added pretty console output (`stdout_pretty`) and `format` selection for stdout logging.
 - Added one-liner FastAPI setup helpers (`setup_logging`, `get_request_logger`) with lifespan support.

--- a/docs/patterns/property-based-tests.md
+++ b/docs/patterns/property-based-tests.md
@@ -7,16 +7,17 @@ selection.
 ## Guidelines
 
 - Keep strategies focused and JSON-safe when targeting serialization paths.
-- Limit input sizes and use `@settings(max_examples=...)` to control runtime.
+- Limit input sizes to keep tests fast.
 - Prefer deterministic assertions over inspecting private state.
 - Use shared strategies from `tests/property/strategies.py` when possible.
-- CI caps example counts via `HYPOTHESIS_MAX_EXAMPLES` (see `tox.ini`).
+- Do NOT use per-test `@settings(max_examples=...)` overrides. CI controls
+  example counts via `HYPOTHESIS_MAX_EXAMPLES` (see `tox.ini`).
 
 ## Example
 
 ```python
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 
 from fapilog.core.serialization import serialize_mapping_to_json_bytes
 
@@ -25,7 +26,6 @@ from tests.property.strategies import json_dicts
 
 @pytest.mark.property
 @given(payload=json_dicts)
-@settings(max_examples=200)
 def test_json_serialization_round_trip(payload: dict) -> None:
     view = serialize_mapping_to_json_bytes(payload)
     assert view.data
@@ -34,5 +34,12 @@ def test_json_serialization_round_trip(payload: dict) -> None:
 ## Running Locally
 
 ```bash
-python -m pytest -m property
+# Default (uses tox.ini value of 100 examples):
+pytest -m property
+
+# Quick smoke test:
+HYPOTHESIS_MAX_EXAMPLES=10 pytest -m property
+
+# Thorough local testing:
+HYPOTHESIS_MAX_EXAMPLES=500 pytest -m property
 ```

--- a/docs/stories/11.3.standardize-hypothesis-settings.md
+++ b/docs/stories/11.3.standardize-hypothesis-settings.md
@@ -1,6 +1,6 @@
 # Story 11.3: Standardize Hypothesis Test Settings
 
-**Status:** Ready
+**Status:** Complete
 **Priority:** High
 **Depends on:** None
 

--- a/tests/property/test_enrichment_properties.py
+++ b/tests/property/test_enrichment_properties.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from fapilog.plugins.enrichers import enrich_parallel
@@ -32,7 +32,6 @@ class _StaticEnricher:
 
 @pytest.mark.asyncio
 @given(event=prefixed_dict("orig_"), extra=prefixed_dict("extra_"))
-@settings(max_examples=200)
 async def test_enrichment_preserves_original_fields(
     event: dict[str, object], extra: dict[str, object]
 ) -> None:

--- a/tests/property/test_filter_properties.py
+++ b/tests/property/test_filter_properties.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from fapilog.plugins.filters.level import LEVEL_PRIORITY, LevelFilter
@@ -20,7 +20,6 @@ level_names = st.sampled_from(LEVEL_NAMES).flatmap(maybe_lower)
 
 @pytest.mark.asyncio
 @given(min_level=level_names, event_level=level_names)
-@settings(max_examples=200)
 async def test_level_filter_respects_hierarchy(
     min_level: str, event_level: str
 ) -> None:
@@ -39,7 +38,6 @@ async def test_level_filter_respects_hierarchy(
 
 @pytest.mark.asyncio
 @given(min_level=level_names, event_level=level_names)
-@settings(max_examples=120)
 async def test_level_filter_drop_below_false_keeps_event(
     min_level: str, event_level: str
 ) -> None:

--- a/tests/property/test_redaction_properties.py
+++ b/tests/property/test_redaction_properties.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from fapilog.plugins.redactors.field_mask import FieldMaskRedactor
@@ -33,7 +33,6 @@ path_segment = st.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1, max_si
 
 @pytest.mark.asyncio
 @given(secret_value=sensitive_values, field_name=sensitive_field_names)
-@settings(max_examples=200)
 async def test_sensitive_value_never_in_output(
     secret_value: str, field_name: str
 ) -> None:
@@ -50,7 +49,6 @@ async def test_sensitive_value_never_in_output(
     secret_value=sensitive_values,
     nesting_path=st.lists(path_segment, min_size=1, max_size=4),
 )
-@settings(max_examples=150)
 async def test_nested_secrets_redacted(
     secret_value: str, nesting_path: list[str]
 ) -> None:

--- a/tests/property/test_serialization_properties.py
+++ b/tests/property/test_serialization_properties.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from fapilog.core.serialization import (
@@ -46,7 +46,6 @@ envelope_logs = st.fixed_dictionaries(
 
 
 @given(payload=json_dicts)
-@settings(max_examples=200)
 def test_json_serialization_round_trip(payload: dict) -> None:
     view = serialize_mapping_to_json_bytes(payload)
     parsed = json.loads(view.data)
@@ -54,7 +53,6 @@ def test_json_serialization_round_trip(payload: dict) -> None:
 
 
 @given(event=envelope_logs)
-@settings(max_examples=200)
 def test_serialize_envelope_preserves_required_fields(event: dict) -> None:
     view = serialize_envelope(event)
     parsed = json.loads(view.data)


### PR DESCRIPTION
Remove per-test @settings(max_examples=...) overrides from all property tests so they respect the HYPOTHESIS_MAX_EXAMPLES environment variable.

- Remove 7 max_examples overrides across 4 test files
- Update docs/patterns/property-based-tests.md to prohibit per-test overrides and document env var usage
- Add CHANGELOG entry

Story: 11.3