### PR TITLE
docs(stories): clarify dependencies and mark story 5.25 ready

### DIFF
--- a/docs/stories/5.25.extract-config-builders-from-init.md
+++ b/docs/stories/5.25.extract-config-builders-from-init.md
@@ -1,6 +1,6 @@
 # Story 5.25: Extract Config Builder Functions from __init__.py
 
-**Status:** Draft
+**Status:** Ready
 **Priority:** Critical
 **Depends on:** None
 
@@ -104,6 +104,36 @@ _default_sink_names()     # Lines 354-359 (~6 lines)
 _default_env_sink_cfg()   # Lines 407-436 (~30 lines)
 _build_pipeline()         # Lines 468-535 (~68 lines)
 ```
+
+### Dependencies Remaining in __init__.py
+
+The extracted functions depend on helpers that stay in `__init__.py`:
+
+- `_normalize()` (line 85) - Used throughout; keep in `__init__.py`
+- `_plugin_allowed()` (lines 89-100) - Plugin allowlist/denylist check
+- `_load_plugins()` (lines 439-465) - Plugin loading orchestration
+
+**Approach:** Pass `_load_plugins` as a callable parameter to `_build_pipeline()`:
+
+```python
+# In config_builders.py
+def _build_pipeline(
+    settings: _Settings,
+    load_plugins: Callable[[str, list[str], _Settings, dict], list[object]],
+) -> tuple[...]:
+    # Use load_plugins() instead of _load_plugins()
+    sinks = load_plugins("fapilog.sinks", sink_names, settings, sink_cfgs)
+```
+
+```python
+# In __init__.py
+from .core.config_builders import _build_pipeline
+
+# Call with injected dependency
+result = _build_pipeline(settings, _load_plugins)
+```
+
+This avoids circular imports and keeps plugin loading logic centralized.
 
 ---
 


### PR DESCRIPTION
Add implementation notes documenting helper functions that remain in __init__.py (_normalize, _plugin_allowed, _load_plugins) and the dependency injection approach for _build_pipeline to avoid circular imports.