### PR TITLE
docs(stories): fix accuracy issues in story 5.26 and mark ready

### DIFF
--- a/docs/stories/5.26.dry-env-alias-validators.md
+++ b/docs/stories/5.26.dry-env-alias-validators.md
@@ -1,6 +1,6 @@
 # Story 5.26: DRY Environment Variable Alias Validators
 
-**Status:** Draft
+**Status:** Ready
 **Priority:** Critical
 **Depends on:** None
 
@@ -8,12 +8,13 @@
 
 ## Context / Background
 
-The `src/fapilog/core/settings.py` file contains four nearly identical environment variable alias validators (lines 1003-1228):
+The `src/fapilog/core/settings.py` file contains five nearly identical environment variable alias validators (lines 971-1228):
 
-1. `_apply_cloudwatch_env_aliases()` - ~52 lines
-2. `_apply_loki_env_aliases()` - ~65 lines
-3. `_apply_postgres_env_aliases()` - ~70 lines
-4. `_apply_sink_routing_env_aliases()` - ~32 lines
+1. `_apply_size_guard_env_aliases()` - ~25 lines
+2. `_apply_cloudwatch_env_aliases()` - ~52 lines
+3. `_apply_loki_env_aliases()` - ~65 lines
+4. `_apply_postgres_env_aliases()` - ~70 lines
+5. `_apply_sink_routing_env_aliases()` - ~32 lines
 
 Each follows the same pattern:
 1. Build an `env_map` dict mapping field names to `os.getenv()` calls
@@ -21,13 +22,13 @@ Each follows the same pattern:
 3. Handle special cases (booleans, durations, lists)
 
 This creates problems:
-- **Maintenance debt:** ~200 lines of similar-but-different code
+- **Maintenance debt:** ~244 lines of similar-but-different code
 - **Bug propagation risk:** Fixes in one may not be applied to others
 - **Extension cost:** Adding a new sink config requires copying ~50 lines
 
 The Human Understandability Audit identified this as a **P0 issue**.
 
-Reference: `src/fapilog/core/settings.py:1003-1228`
+Reference: `src/fapilog/core/settings.py:971-1228`
 
 ---
 
@@ -36,8 +37,8 @@ Reference: `src/fapilog/core/settings.py:1003-1228`
 ### In Scope
 
 - Create generic `_apply_env_aliases()` function
-- Refactor all four validators to use it
-- Support type conversions: `str`, `int`, `bool`, `float`, duration, list
+- Refactor all five validators to use it
+- Support type conversions: `str`, `int`, `bool`, `float`, `duration`, `list`, `size`, `dict`, `enum`, `routing_rules`
 - Reduce total validator code by at least 60%
 
 ### Out of Scope
@@ -73,8 +74,8 @@ _apply_env_aliases(self.sink_config.cloudwatch, CLOUDWATCH_ENV_FIELDS)
 
 **Validation:**
 ```bash
-# Before: ~220 lines across 4 validators
-# After: <90 lines (generic function + 4 mappings)
+# Before: ~244 lines across 5 validators
+# After: <100 lines (generic function + 5 mappings)
 ```
 
 ### AC3: All Env Vars Still Work
@@ -94,7 +95,7 @@ FAPILOG_CLOUDWATCH__LOG_GROUP_NAME=/test pytest tests/unit/core/test_settings.py
 
 ```
 src/fapilog/core/settings.py (MODIFIED - refactor validators)
-tests/unit/core/test_env_aliases.py (NEW)
+tests/unit/test_settings_env_aliases.py (MODIFIED - extend existing tests)
 ```
 
 ### Key Code
@@ -104,8 +105,13 @@ class EnvFieldType(Enum):
     STRING = "string"
     INT = "int"
     BOOL = "bool"
+    FLOAT = "float"
     DURATION = "duration"
     LIST = "list"
+    SIZE = "size"  # Human-readable bytes ("1 MB", "500 KB")
+    DICT = "dict"  # JSON object parsing (e.g., Loki labels)
+    ENUM = "enum"  # Constrained choices (e.g., "truncate"|"drop"|"warn")
+    ROUTING_RULES = "routing_rules"  # Complex RoutingRule.model_validate()
 
 def _apply_env_aliases(
     target: BaseModel,
@@ -134,6 +140,8 @@ def _apply_env_aliases(
 
 ### Phase 2: Migration
 
+- [ ] Define `SIZE_GUARD_ENV_FIELDS` mapping
+- [ ] Refactor `_apply_size_guard_env_aliases()`
 - [ ] Define `CLOUDWATCH_ENV_FIELDS` mapping
 - [ ] Refactor `_apply_cloudwatch_env_aliases()`
 - [ ] Repeat for Loki, Postgres, SinkRouting
@@ -150,11 +158,14 @@ def _apply_env_aliases(
 
 ### Unit Tests
 
-- `tests/unit/core/test_env_aliases.py`
+- `tests/unit/test_settings_env_aliases.py` (extend existing)
   - `_apply_env_aliases()` with string fields
   - `_apply_env_aliases()` with int fields
   - `_apply_env_aliases()` with bool fields (true/false/1/0/yes/no)
   - `_apply_env_aliases()` with duration fields ("5s", "1m", 30.0)
+  - `_apply_env_aliases()` with size fields ("1 MB", "500 KB")
+  - `_apply_env_aliases()` with dict fields (JSON parsing)
+  - `_apply_env_aliases()` with enum fields (constrained choices)
   - Missing env vars are skipped
   - Invalid values don't crash
 
@@ -217,3 +228,4 @@ If issues occur:
 | Date | Change | Author |
 |------|--------|--------|
 | 2026-01-14 | Initial draft | Claude |
+| 2026-01-15 | Added missing size_guard validator, fixed line counts/ranges, expanded EnvFieldType enum, referenced existing test file, marked Ready | Claude |


### PR DESCRIPTION
- Add missing 5th validator (_apply_size_guard_env_aliases)
- Fix line range from 1003-1228 to 971-1228
- Fix line count from ~200 to ~244 lines
- Expand EnvFieldType enum with size, dict, enum, routing_rules
- Reference existing test file (test_settings_env_aliases.py)
- Update status to Ready