### PR TITLE
docs(stories): mark story 5.29 ready after review

### DIFF
--- a/docs/stories/5.29.refactor-sink-writer-to-class.md
+++ b/docs/stories/5.29.refactor-sink-writer-to-class.md
@@ -1,6 +1,6 @@
 # Story 5.29: Refactor Sink Writer Closures to Class
 
-**Status:** Draft
+**Status:** Ready
 **Priority:** High
 **Depends on:** Story 5.25 (Extract Config Builders)
 


### PR DESCRIPTION
Verified all codebase claims:
- _fanout_writer() at lines 568-710 with 5 nested closures
- Lazy imports confirmed at 4 locations
- Dependency story 5.25 is Ready
- Proposed core/ directory location is valid