### PR TITLE
docs(stories): mark story 5.31 ready after review

### DIFF
--- a/docs/stories/5.31.explicit-plugin-name-normalization.md
+++ b/docs/stories/5.31.explicit-plugin-name-normalization.md
@@ -1,6 +1,6 @@
 # Story 5.31: Explicit Plugin Name Normalization
 
-**Status:** Draft
+**Status:** Ready
 **Priority:** High
 **Depends on:** None
 
@@ -113,10 +113,9 @@ def register_builtin(group: str, name: str, cls: type, ...):
     if name != canonical:
         diagnostics.warn(
             "plugins",
-            "plugin registered with non-canonical name",
-            registered_name=name,
-            canonical_name=canonical,
-            hint="Use underscores and lowercase for plugin names",
+            "non-canonical plugin name",
+            registered=name,
+            canonical=canonical,
         )
     registry[canonical] = cls
 ```
@@ -137,7 +136,7 @@ def register_builtin(group: str, name: str, cls: type, ...):
 
 ```
 src/fapilog/plugins/loader.py (MODIFIED - docstrings, error messages, validation)
-tests/unit/plugins/test_loader.py (MODIFIED - test improved errors)
+tests/unit/test_plugin_loader.py (MODIFIED - test improved errors)
 docs/plugins/naming.md (NEW - plugin naming guide)
 ```
 
@@ -230,7 +229,7 @@ def register_builtin(group: str, name: str, cls: type, ...) -> None:
 
 ### Unit Tests
 
-- `tests/unit/plugins/test_loader.py`
+- `tests/unit/test_plugin_loader.py`
   - Test error message includes normalized name
   - Test error message lists available plugins
   - Test warning emitted for non-canonical registration


### PR DESCRIPTION
- Fix test file path: tests/unit/plugins/test_loader.py -> tests/unit/test_plugin_loader.py
- Standardize diagnostic field names in AC3 to match implementation notes