### PR TITLE
fix: correct Claude settings hook schema structure

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,9 +2,12 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "pre-commit install",
-        "description": "Install pre-commit hooks (per CONTRIBUTING.md)"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pre-commit install"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
Fixes the `.claude/settings.json` file to use the correct hook schema structure per Claude Code documentation.

## Changes
- `.claude/settings.json` (modified)

## Test Plan
- [x] JSON schema validation passes (no IDE warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)