### PR TITLE
chore: rename tdd-python skill to implement

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -15,12 +15,12 @@ Generate a GitHub Pull Request URL with pre-filled title and body, derived from 
 ## When to Apply
 
 - User explicitly requests `/create-pr`
-- After `tdd-python` implementation is complete
+- After `implement` workflow is complete
 - After `code-review` has passed
 
 ## Prerequisites
 
-- Implementation committed and pushed (via `tdd-python`)
+- Implementation committed and pushed (via `implement`)
 - Code review passed (via `code-review`)
 - On a feature branch (see `CLAUDE.md` for branch naming format)
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: tdd-python
-description: Use when implementing features, fixing bugs, writing new code, or making changes to Python files. Enforces red-green-refactor TDD workflow with tests-first approach.
+name: implement
+description: Use when implementing features, fixing bugs, writing new code, or making changes to Python files. Manages branch creation, TDD workflow, quality gates, and commit/push.
 version: 1.0.0
 license: Apache-2.0
 ---
 
-# TDD Python (Lean + Enforced)
+# Implement (Python)
 
 **Author:** Chris Haste
 **GitHub:** https://github.com/chris-haste

--- a/.claude/skills/implement/references/legacy-code.md
+++ b/.claude/skills/implement/references/legacy-code.md
@@ -1,4 +1,4 @@
-# Working with Legacy Code (ref: tdd-python)
+# Working with Legacy Code (ref: implement)
 
 ## Characterization Tests
 

--- a/.claude/skills/implement/references/patterns.md
+++ b/.claude/skills/implement/references/patterns.md
@@ -1,4 +1,4 @@
-# Common Testing Patterns (ref: tdd-python)
+# Common Testing Patterns (ref: implement)
 
 ## Parametrized Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 ## Development Workflow
 
 ```
-tdd-python → code-review → create-pr
+implement → code-review → create-pr
 ```
 
-1. **tdd-python**: Implement with TDD (RED/GREEN/REFACTOR), commit, push
+1. **implement**: Implement with TDD (RED/GREEN/REFACTOR), commit, push
 2. **code-review**: Review against story acceptance criteria
 3. **create-pr**: Generate PR with pre-filled content from story
 


### PR DESCRIPTION
## Summary

Renames the `tdd-python` skill to `implement` for clarity. The name "tdd-python" implied the skill was only for TDD scenarios, causing it to be skipped for documentation-only tasks when it should have been invoked to manage the full implementation workflow.

## Changes

- `.claude/skills/tdd-python/` → `.claude/skills/implement/` (renamed)
- `.claude/skills/create-pr/SKILL.md` (modified)
- `CLAUDE.md` (modified)

## Test Plan

- [x] No code changes - skill configuration only
- [x] All references to tdd-python updated