### PR TITLE
chore: drop Python 3.9 support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   full-test-suite:
@@ -15,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ This directory contains the complete documentation for the fapilog project, buil
 
 ### Prerequisites
 
-- Python 3.8 or higher
+- Python 3.10 or higher
 - pip (Python package installer)
 
 ### Building Documentation
@@ -105,7 +105,7 @@ Custom styling is applied through:
 
 The documentation is automatically built and deployed via GitHub Actions:
 
-- **Build**: Runs on all Python versions (3.9-3.12)
+- **Build**: Runs on all Python versions (3.10-3.12)
 - **Validation**: Checks for broken links and build issues
 - **Deployment**: Automatically deploys to GitHub Pages on main branch
 - **Quality Checks**: Runs on pull requests

--- a/docs/architecture/decisions/001-drop-python-3.9-support.md
+++ b/docs/architecture/decisions/001-drop-python-3.9-support.md
@@ -1,0 +1,70 @@
+# ADR-001: Drop Python 3.9 Support
+
+**Status:** Accepted
+**Date:** 2026-01-16
+**Decision Makers:** Chris Haste
+
+## Context
+
+The nightly CI build for fapilog began failing on Python 3.9 due to type annotation syntax incompatibility. The codebase uses modern union syntax (`X | None`) which is only supported at runtime in Python 3.10+.
+
+While `from __future__ import annotations` defers annotation evaluation for most Python code, Pydantic v2 evaluates type annotations at runtime for model validation. This causes failures when importing modules containing Pydantic models with union syntax on Python 3.9.
+
+### Options Considered
+
+1. **Replace `X | None` with `Optional[X]`** in all Pydantic models
+   - Pros: No new dependencies, backwards compatible
+   - Cons: Requires changing many files, mixes syntax styles, ongoing maintenance burden
+
+2. **Add `eval_type_backport` dependency**
+   - Pros: Minimal code changes
+   - Cons: Adds runtime dependency for all users, including those on Python 3.10+ who don't need it
+
+3. **Drop Python 3.9 support**
+   - Pros: Clean modern syntax, no dependency bloat, reduced maintenance
+   - Cons: Users still on 3.9 would need to upgrade
+
+## Decision
+
+**Drop Python 3.9 support.** Minimum supported version is now Python 3.10.
+
+## Rationale
+
+1. **Python 3.9 reached end-of-life in October 2025.** It no longer receives security patches, and users should upgrade to supported versions.
+
+2. **Pydantic v2 pushes toward modern Python.** The library ecosystem is moving forward, and fapilog already requires Pydantic v2.11+.
+
+3. **Reduced maintenance burden.** Supporting EOL Python versions requires ongoing workarounds and prevents using modern language features.
+
+4. **Library best practice.** Supporting only maintained Python versions aligns with community standards and security best practices.
+
+## Consequences
+
+### Positive
+
+- Codebase can freely use Python 3.10+ syntax features (union types, pattern matching, etc.)
+- No additional dependencies required for type annotation compatibility
+- Cleaner, more consistent codebase
+- Aligns with Python community security recommendations
+
+### Negative
+
+- Users on Python 3.9 must upgrade before using newer fapilog versions
+- Existing users on 3.9 are locked to older fapilog releases
+
+### Neutral
+
+- CI matrix reduced by one version (minor build time improvement)
+
+## Implementation
+
+1. Update `pyproject.toml`: `requires-python = ">=3.10"`
+2. Remove Python 3.9 classifier from pyproject.toml
+3. Remove Python 3.9 from CI workflow matrices
+4. Update documentation to reflect new minimum version
+
+## References
+
+- [Python 3.9 EOL](https://devguide.python.org/versions/) - October 2025
+- [PEP 604](https://peps.python.org/pep-0604/) - Union types with `X | Y` syntax (Python 3.10+)
+- [Pydantic v2 Type Annotation Handling](https://docs.pydantic.dev/latest/concepts/types/)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,7 +45,7 @@ We welcome all types of contributions:
 
 ### **Prerequisites**
 
-- **Python 3.8+** (project supports 3.8, 3.9, 3.10, 3.11, 3.12)
+- **Python 3.10+** (project supports 3.10, 3.11, 3.12)
 - **Git** - Version control
 - **pip** - Package management
 - **hatch** - Project management (installed automatically)

--- a/docs/documentation-review-report.md
+++ b/docs/documentation-review-report.md
@@ -49,7 +49,7 @@
 
 | Location | Claim | Issue |
 |----------|-------|-------|
-| installation.md:52-56 | "Python 3.9+ recommended, 3.8 limited" | Conflicts with README "3.8+" |
+| ~~installation.md:52-56~~ | ~~"Python 3.9+ recommended, 3.8 limited"~~ | ✅ **RESOLVED** - See [ADR-001](architecture/decisions/001-drop-python-3.9-support.md) |
 | api-reference/plugins/index.md | Sinks table | Lists 3 of 10 actual sinks |
 | api-reference/plugins/enrichers.md | Enrichers list | Missing KubernetesEnricher |
 
@@ -91,7 +91,7 @@
 
 ### P1 (Confusing/Incomplete)
 
-1. Python version messaging inconsistent between README and installation docs
+1. ~~Python version messaging inconsistent between README and installation docs~~ ✅ **RESOLVED**
 2. Sinks documentation scattered across multiple locations
 3. No clear distinction between stable and experimental features
 
@@ -115,7 +115,7 @@
 
 ### Next Sprint (P1)
 
-1. Align Python version messaging
+1. ~~Align Python version messaging~~ ✅ **RESOLVED**
 2. Add CloudWatch/Loki/Postgres to sinks API reference
 3. Create builder API reference
 4. Add troubleshooting section
@@ -124,7 +124,7 @@
 
 1. Consolidate sink routing docs
 2. Add migration guide from stdlib logging
-3. Add architectural decision records
+3. ~~Add architectural decision records~~ ✅ **RESOLVED** - See `docs/architecture/decisions/`
 
 ---
 
@@ -159,7 +159,7 @@
 | `docs/api-reference/plugins/index.md` | Update tables | P0 |
 | `docs/api-reference/plugins/enrichers.md` | Add k8s enricher | P0 |
 | `docs/api-reference/plugins/sinks.md` | Add all sinks | P1 |
-| `docs/getting-started/installation.md` | Align Python version | P1 |
+| ~~`docs/getting-started/installation.md`~~ | ~~Align Python version~~ | ✅ **RESOLVED** |
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -49,11 +49,12 @@ pip install -e .
 
 ## Python Version Support
 
-| Python Version | Status             | Notes                      |
-| -------------- | ------------------ | -------------------------- |
-| 3.9+           | ✅ Full Support    | Recommended minimum        |
-| 3.8            | ⚠️ Limited Support | Some features may not work |
-| 3.7            | ❌ Not Supported   | End of life                |
+| Python Version | Status           | Notes                                |
+| -------------- | ---------------- | ------------------------------------ |
+| 3.12           | ✅ Full Support  | Latest stable                        |
+| 3.11           | ✅ Full Support  | Recommended                          |
+| 3.10           | ✅ Full Support  | Minimum supported                    |
+| 3.9 and below  | ❌ Not Supported | See [ADR-001](../architecture/decisions/001-drop-python-3.9-support.md) |
 
 ## Dependencies
 

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -96,7 +96,7 @@ Ensure correctness, concurrency safety, and multi-version support.
 - [ ] Concurrency stress tests (e.g., `asyncio.gather`)
 - [ ] Pre-commit hooks: `ruff`, `black`, `mypy`, `pytest`
 - [ ] GitHub Actions workflow for CI
-- [ ] Python version matrix (3.8 to 3.12+)
+- [ ] Python version matrix (3.10 to 3.12+)
 - [ ] GitHub badge for test coverage
 
 **Estimated Duration:** 1 week

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -30,7 +29,7 @@ classifiers = [
     "Framework :: FastAPI",
     "Typing :: Typed",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     # Pydantic v2
     "pydantic>=2.11.0",

--- a/tests/plugin_examples/fapilog-sample-plugin/pyproject.toml
+++ b/tests/plugin_examples/fapilog-sample-plugin/pyproject.toml
@@ -7,7 +7,7 @@ name = "fapilog-sample-plugin"
 version = "0.1.0"
 description = "Sample plugin skeleton for fapilog CI smoke tests"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [{name = "Fapilog", email = "dev@fapilog.dev"}]
 license = {text = "Apache-2.0"}
 dependencies = [


### PR DESCRIPTION
## Summary

Drop Python 3.9 support following nightly CI failures due to type annotation syntax incompatibility. Python 3.9 reached end-of-life in October 2025.

## Changes

- `pyproject.toml` (modified) - Set `requires-python = ">=3.10"`, removed 3.9 classifier
- `.github/workflows/nightly.yml` (modified) - Removed 3.9 from matrix, added `issues: write` permission
- `docs/architecture/decisions/001-drop-python-3.9-support.md` (new) - ADR documenting decision
- `docs/getting-started/installation.md` (modified) - Updated version table
- `docs/contributing.md` (modified) - Updated prerequisites
- `docs/README.md` (modified) - Updated prerequisites and build matrix
- `docs/milestones.md` (modified) - Updated version matrix reference
- `docs/documentation-review-report.md` (modified) - Marked version issues as resolved
- `tests/plugin_examples/fapilog-sample-plugin/pyproject.toml` (modified) - Updated to 3.10+

## Acceptance Criteria

- [x] Minimum Python version is 3.10
- [x] All documentation aligned on version requirements
- [x] Decision documented in ADR
- [x] CI matrix updated
- [x] Workflow permissions fixed for failure notifications

## Test Plan

- [x] Pre-commit hooks pass
- [x] No remaining Python 3.9 support claims in active documentation