### PR TITLE
docs(governance): address audit report findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+- **Security**: Bumped orjson minimum version to 3.9.15 (CVE-2024-27454 fix).
+- Added `SECURITY.md` with vulnerability reporting guidance.
+- Added `CODE_OF_CONDUCT.md` (Contributor Covenant).
+- Fixed Python version badge in README (3.8+ → 3.10+).
+- Added production tip callout in README for `preset="production"` guidance.
+- Updated plugin group documentation in architecture docs.
+- Added CloudWatch sink size limit documentation comment.
+- Updated `CONTRIBUTING.md` with correct Python version, repo name, and governance file references.
 - Added `SinkWriteError` for sinks to signal write failures to the core pipeline; core now catches these errors (and `False` returns) to trigger fallback and circuit breaker behavior (Story 4.41).
 - Updated built-in sinks (`stdout_json`, `stdout_pretty`, `rotating_file`, `audit`) to raise `SinkWriteError` instead of swallowing errors, enabling proper fallback handling.
 - Updated `BaseSink` protocol documentation to reflect the new error signaling contract.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+## Our Commitment
+
+We are committed to providing a welcoming and inclusive environment for all contributors, regardless of background or experience level.
+
+## Standards
+
+We expect all participants to:
+
+- Use welcoming and inclusive language
+- Be respectful of differing viewpoints and experiences
+- Accept constructive criticism gracefully
+- Focus on what is best for the community
+- Show empathy towards other community members
+
+## Enforcement
+
+Project maintainers are responsible for clarifying standards of acceptable behavior and will take appropriate action in response to unacceptable behavior.
+
+## Contact
+
+For conduct-related concerns, contact: **chris@haste.dev**
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thank you for your interest in contributing to fapilog! This document provides g
 
 ### Prerequisites
 
-- Python 3.8 or higher
+- Python 3.10 or higher
 - Git
 - pip (Python package installer)
 
@@ -26,8 +26,8 @@ Thank you for your interest in contributing to fapilog! This document provides g
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/chris-haste/fastapi-logger.git
-   cd fastapi-logger
+   git clone https://github.com/chris-haste/fapilog.git
+   cd fapilog
    ```
 
 2. **Create and activate a virtual environment**
@@ -263,6 +263,12 @@ When reporting bugs, please include:
 4. **Code example** - Minimal code that reproduces the issue
 5. **Error messages** - Full error traceback if applicable
 
+### Reporting Security Issues
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+Please see our [Security Policy](SECURITY.md) for instructions on responsibly reporting security concerns.
+
 ### Suggesting Features
 
 When suggesting new features:
@@ -274,7 +280,7 @@ When suggesting new features:
 
 ### Contributing Guidelines
 
-- **Be respectful** - Treat all contributors with respect
+- **Be respectful** - Follow our [Code of Conduct](CODE_OF_CONDUCT.md)
 - **Follow the process** - Use the established workflow and tools
 - **Test thoroughly** - Ensure your changes work correctly
 - **Document changes** - Update documentation as needed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-90%25-008080?style=flat-square)](docs/quality-signals.md)
 ![Pydantic v2](https://img.shields.io/badge/Pydantic-v2-008080?style=flat-square&logo=pydantic&logoColor=white)
 
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-008080?style=flat-square&logo=python&logoColor=white)](https://pypi.org/project/fapilog/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-008080?style=flat-square&logo=python&logoColor=white)](https://pypi.org/project/fapilog/)
 [![PyPI Version](https://img.shields.io/pypi/v/fapilog.svg?style=flat-square&color=008080&logo=pypi&logoColor=white)](https://pypi.org/project/fapilog/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-008080?style=flat-square&logo=apache&logoColor=white)](https://opensource.org/licenses/Apache-2.0)
 
@@ -74,6 +74,10 @@ Example output (TTY):
 ```
 2025-01-11 14:30:22 | INFO     | Application started environment=production
 ```
+
+> **Production Tip:** Use `preset="production"` for log durability - it sets
+> `drop_on_full=False` to prevent silent log drops under load. See
+> [reliability defaults](docs/user-guide/reliability-defaults.md) for details.
 
 ### Configuration Presets
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of fapilog are currently supported with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.3.x   | :white_check_mark: |
+| < 0.3   | :x:                |
+
+## Reporting a Vulnerability
+
+We take security vulnerabilities seriously. If you discover a security issue, please report it responsibly.
+
+### How to Report
+
+1. **Do not** open a public GitHub issue for security vulnerabilities.
+2. Email security concerns to: **chris@haste.dev**
+3. Include as much detail as possible:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+### What to Expect
+
+- **Acknowledgment**: We will acknowledge receipt of your report within 48 hours.
+- **Assessment**: We will investigate and assess the vulnerability within 7 days.
+- **Resolution**: We aim to release a fix within 30 days for critical vulnerabilities.
+- **Disclosure**: We follow a 90-day responsible disclosure timeline.
+
+### Disclosure Policy
+
+- We will work with you to understand and resolve the issue.
+- We will credit you in the security advisory (unless you prefer to remain anonymous).
+- We request that you do not publicly disclose the vulnerability until we have released a fix.
+
+## Security Best Practices
+
+When using fapilog in production:
+
+- Keep fapilog and its dependencies up to date.
+- Use the `production` preset which enables appropriate security defaults.
+- Configure redaction for sensitive fields (PII, credentials, etc.).
+- Review the [reliability defaults](docs/user-guide/reliability-defaults.md) for production deployments.
+
+## Known Security Considerations
+
+- **Log content**: Fapilog processes log data which may contain sensitive information. Use redactors to mask PII and credentials.
+- **Network sinks**: When using HTTP or cloud sinks, ensure TLS is enabled and credentials are properly secured.
+- **Plugin security**: Only install plugins from trusted sources. Third-party plugins are not reviewed by the fapilog maintainers.

--- a/docs/architecture/high-level-architecture.md
+++ b/docs/architecture/high-level-architecture.md
@@ -140,7 +140,13 @@ sequenceDiagram
 
 ### 4.3 PluginLoader
 
-- Discovers plugins via **entry points** (`group="fapilog.plugins"`).
+- Discovers plugins via **entry points** using type-specific groups:
+  - `fapilog.sinks` - Output destinations (file, HTTP, cloud)
+  - `fapilog.enrichers` - Context and metadata enrichment
+  - `fapilog.redactors` - PII and sensitive data masking
+  - `fapilog.processors` - Transform and routing logic
+  - `fapilog.filters` - Event filtering and sampling
+- Legacy group `fapilog.plugins` is deprecated but still supported for backward compatibility.
 - Imports and instantiates plugin classes with isolation and diagnostics.
 - Registers components with `AsyncLogger` if compatible.
 

--- a/docs/stories/5.33.address-audit-report-findings.md
+++ b/docs/stories/5.33.address-audit-report-findings.md
@@ -1,0 +1,307 @@
+# Story 5.33: Address Audit Report Findings
+
+**Status:** Complete
+**Priority:** High
+**Estimated Effort:** Small (1 day)
+**Depends on:** None
+
+---
+
+## Context / Background
+
+Deep audits of the fapilog library were conducted by multiple AI models (GPT-5.2, Claude Opus 4.5, Gemini-3-Flash, Grok) in January 2026. The reports identified several issues that, after manual verification against the codebase, have been confirmed as valid and actionable.
+
+This story consolidates all verified findings into a single implementation effort to improve security posture, documentation accuracy, and enterprise adoption readiness.
+
+**Audit Reports Location:** `docs/audits/`
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Security: Bump orjson minimum version to fix CVE-2024-27454
+- Security: Add SECURITY.md with vulnerability reporting guidance
+- Documentation: Fix Python version badge mismatch (3.8 vs 3.10)
+- Documentation: Clarify plugin entry point group naming in architecture docs
+- Documentation: Elevate existing `drop_on_full` guidance to be more prominent in README
+- Documentation: Update CloudWatch sink comments about conservative size limit
+- Governance: Add CODE_OF_CONDUCT.md
+- Documentation: Update CONTRIBUTING.md with correct Python version and new file references
+
+### Out of Scope
+
+- Marketplace implementation (tracked separately)
+- fapilog-tamper production readiness (already documented as placeholder)
+- Single maintainer risk (not addressable via code changes)
+
+---
+
+## Acceptance Criteria
+
+### AC1: orjson Version Bump (Security)
+
+**Description:** Raise orjson minimum version to address CVE-2024-27454.
+
+**Validation:**
+
+- [ ] `pyproject.toml` updated: `orjson>=3.9.15` (was `>=3.9.0`)
+- [ ] CI passes with new version constraint
+- [ ] No functionality regression
+
+**Evidence:** [CVE-2024-27454](https://nvd.nist.gov/vuln/detail/CVE-2024-27454) - recursion DoS fixed in 3.9.15.
+
+### AC2: SECURITY.md Added
+
+**Description:** Add security policy for vulnerability reporting.
+
+**Validation:**
+
+- [ ] `SECURITY.md` exists in repository root
+- [ ] Contains supported versions section
+- [ ] Contains vulnerability reporting instructions
+- [ ] References responsible disclosure timeline
+
+### AC3: Python Version Badge Fixed
+
+**Description:** README badge matches actual Python version requirement.
+
+**Validation:**
+
+- [ ] `README.md` badge updated from "Python 3.8+" to "Python 3.10+"
+- [ ] Badge URL points to correct version
+- [ ] Any other 3.8/3.9 references in README updated
+
+**Current State:**
+
+- `README.md:13`: Badge says "Python 3.8+"
+- `pyproject.toml:32`: `requires-python = ">=3.10"`
+
+### AC4: Plugin Group Documentation Clarified
+
+**Description:** Architecture docs clearly document the specific entry point groups.
+
+**Validation:**
+
+- [ ] `docs/architecture/high-level-architecture.md` updated
+- [ ] Remove/clarify the confusing `group="fapilog.plugins"` reference at line 143
+- [ ] Explicitly list all groups: `fapilog.sinks`, `fapilog.enrichers`, `fapilog.redactors`, `fapilog.processors`, `fapilog.filters`
+- [ ] Note that legacy `fapilog.plugins` is deprecated
+
+### AC5: Elevate Production Configuration Guidance
+
+**Description:** Make existing `drop_on_full` guidance more prominent in README.
+
+**Current State:**
+
+- `settings.py:628` defaults to `drop_on_full=True`
+- README line 299 has a "Reliability hint" buried in docs section
+- `docs/user-guide/reliability-defaults.md` has comprehensive guidance
+- `production` preset already sets `drop_on_full=False` (`presets.py:29`)
+
+**Validation:**
+
+- [ ] README.md has a prominent callout near Quick Start (not just buried at bottom)
+- [ ] Callout recommends using `preset="production"` for durability
+
+**Note:** Existing guidance is adequate; this AC elevates visibility only.
+
+### AC6: CloudWatch Sink Documentation
+
+**Description:** Document that CloudWatch size limit is intentionally conservative.
+
+**Validation:**
+
+- [ ] `src/fapilog/plugins/sinks/contrib/cloudwatch.py` has comment explaining 256KB limit
+- [ ] Comment notes AWS now supports 1MB but we use conservative limit for compatibility
+- [ ] Optional: Add configuration option to allow larger events
+
+### AC7: CODE_OF_CONDUCT.md Added
+
+**Description:** Add code of conduct for community governance.
+
+**Validation:**
+
+- [ ] `CODE_OF_CONDUCT.md` exists in repository root
+- [ ] Uses Contributor Covenant or similar standard
+- [ ] References enforcement contact
+
+### AC8: CONTRIBUTING.md Updated
+
+**Description:** Fix outdated information and add references to new governance files.
+
+**Current State:**
+
+- Line 20: Says "Python 3.8 or higher" (should be 3.10)
+- Line 29: References `fastapi-logger` repo name
+- No reference to SECURITY.md for vulnerability reporting
+- No reference to CODE_OF_CONDUCT.md
+
+**Validation:**
+
+- [ ] Python version updated to "3.10 or higher"
+- [ ] Repository name corrected to `fapilog`
+- [ ] "Reporting Security Issues" section added, referencing SECURITY.md
+- [ ] Reference to CODE_OF_CONDUCT.md added in guidelines section
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```text
+pyproject.toml                                  (MODIFIED - orjson version)
+README.md                                       (MODIFIED - Python badge, production tip callout)
+CONTRIBUTING.md                                 (MODIFIED - Python version, repo name, new file refs)
+SECURITY.md                                     (NEW)
+CODE_OF_CONDUCT.md                              (NEW)
+docs/architecture/high-level-architecture.md    (MODIFIED - plugin groups)
+src/fapilog/plugins/sinks/contrib/cloudwatch.py (MODIFIED - size limit comment)
+```
+
+### Key Changes
+
+**pyproject.toml (line 42):**
+
+```toml
+# Before
+"orjson>=3.9.0",
+
+# After
+"orjson>=3.9.15",  # CVE-2024-27454 fixed in 3.9.15
+```
+
+**README.md badge (line 13):**
+
+```markdown
+# Before
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-008080?...
+
+# After
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-008080?...
+```
+
+**README.md production callout (new callout after Quick Start, elevating existing guidance):**
+
+```markdown
+> **Production Tip:** Use `preset="production"` for log durability - it sets
+> `drop_on_full=False` to prevent silent log drops under load. See
+> [reliability defaults](docs/user-guide/reliability-defaults.md) for details.
+```
+
+**cloudwatch.py constant comment:**
+
+```python
+# CloudWatch historically had a 256 KB per-event limit. AWS increased this to
+# 1 MB in late 2024, but we keep the conservative limit for broad compatibility.
+# Users needing larger events can implement a custom sink with higher limits.
+MAX_EVENT_SIZE_BYTES = 256 * 1024  # 256 KB (conservative)
+```
+
+---
+
+## Tasks
+
+### Phase 1: Security Fixes
+
+- [ ] Update orjson version in `pyproject.toml` to `>=3.9.15`
+- [ ] Create `SECURITY.md` with vulnerability reporting process
+- [ ] Verify CI passes with new orjson constraint
+
+### Phase 2: Documentation Fixes
+
+- [ ] Update Python version badge in `README.md`
+- [ ] Add prominent production tip callout near Quick Start in `README.md`
+- [ ] Update `docs/architecture/high-level-architecture.md` plugin groups
+- [ ] Add comment to CloudWatch sink about conservative size limit
+- [ ] Update `CONTRIBUTING.md` Python version (3.8 → 3.10)
+- [ ] Update `CONTRIBUTING.md` repo name reference
+- [ ] Add security reporting and code of conduct references to `CONTRIBUTING.md`
+
+### Phase 3: Governance
+
+- [ ] Create `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
+
+### Phase 4: Verification
+
+- [ ] Run full test suite
+- [ ] Verify all new files render correctly
+- [ ] Check links in SECURITY.md and CODE_OF_CONDUCT.md
+
+---
+
+## Tests
+
+### Manual Verification
+
+- [ ] `pip install orjson>=3.9.15` succeeds
+- [ ] No import errors with new orjson version
+- [ ] README badge displays correctly on GitHub
+- [ ] SECURITY.md renders correctly on GitHub
+- [ ] CODE_OF_CONDUCT.md renders correctly on GitHub
+
+### CI Verification
+
+- [ ] All existing tests pass
+- [ ] Linting passes
+- [ ] Type checking passes
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria met
+- [ ] No linting errors
+- [ ] Type checking passes
+
+### Quality Assurance
+
+- [ ] Existing tests pass
+- [ ] Manual verification completed
+
+### Documentation
+
+- [ ] SECURITY.md created
+- [ ] CODE_OF_CONDUCT.md created
+- [ ] README updated (badge + production tip)
+- [ ] CONTRIBUTING.md updated (Python version, repo name, new file refs)
+- [ ] Architecture docs updated (plugin groups)
+- [ ] CloudWatch sink comment added
+- [ ] CHANGELOG.md updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** orjson version bump breaks environments with pinned old versions
+   - **Mitigation:** 3.9.15 is from early 2024; most environments already have newer
+
+2. **Risk:** Documentation changes create broken links
+   - **Mitigation:** Verify all links before merge
+
+### Rollback Plan
+
+- Revert commit (no data migration required)
+- All changes are additive or comment-only
+
+---
+
+## Related Documents
+
+- [Audit Reports](../audits/)
+- [CVE-2024-27454](https://nvd.nist.gov/vuln/detail/CVE-2024-27454)
+- [Contributor Covenant](https://www.contributor-covenant.org/)
+
+---
+
+## Change Log
+
+| Date       | Change                             | Author |
+|------------|------------------------------------|--------|
+| 2026-01-16 | Initial draft from audit analysis | Claude |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "httpx>=0.24.0",
     
     # JSON and serialization
-    "orjson>=3.9.0",
+    "orjson>=3.9.15",  # CVE-2024-27454 fixed in 3.9.15
     
     # Version parsing for plugin compatibility
     "packaging>=23.0",
@@ -205,7 +205,7 @@ dependencies = [
     "pydantic>=2.11.0",
     "pydantic-settings>=2.0.0",
     "httpx>=0.24.0",
-    "orjson>=3.9.0",
+    "orjson>=3.9.15",
     "packaging>=23.0",
     "prometheus-client>=0.17.0",
     "psutil>=5.9.0; sys_platform != 'win32'",
@@ -232,7 +232,7 @@ dependencies = [
     "pydantic>=2.11.0",
     "pydantic-settings>=2.0.0",
     "httpx>=0.24.0",
-    "orjson>=3.9.0",
+    "orjson>=3.9.15",
     "prometheus-client>=0.17.0",
     "psutil>=5.9.0; sys_platform != 'win32'",
 ]

--- a/src/fapilog/plugins/sinks/contrib/cloudwatch.py
+++ b/src/fapilog/plugins/sinks/contrib/cloudwatch.py
@@ -44,7 +44,10 @@ except Exception:  # pragma: no cover - optional import fallback
             self.operation_name = operation_name
 
 
-MAX_EVENT_SIZE_BYTES = 256 * 1024  # 256 KB
+# CloudWatch historically had a 256 KB per-event limit. AWS increased this to
+# 1 MB in late 2024, but we keep the conservative limit for broad compatibility.
+# Users needing larger events can implement a custom sink with higher limits.
+MAX_EVENT_SIZE_BYTES = 256 * 1024  # 256 KB (conservative)
 MAX_BATCH_SIZE = 10_000
 MAX_BATCH_BYTES = 1_048_576  # 1 MB
 


### PR DESCRIPTION
## Summary

Address verified findings from January 2026 AI audits (GPT-5.2, Claude Opus 4.5, Gemini-3-Flash, Grok) to improve security posture, documentation accuracy, and enterprise adoption readiness.

## Changes

- `pyproject.toml` (modified) - Bump orjson to >=3.9.15 (CVE-2024-27454)
- `SECURITY.md` (new) - Vulnerability reporting policy
- `CODE_OF_CONDUCT.md` (new) - Contributor Covenant
- `README.md` (modified) - Python 3.10+ badge, production tip callout
- `CONTRIBUTING.md` (modified) - Python version, repo name, governance refs
- `docs/architecture/high-level-architecture.md` (modified) - Plugin group documentation
- `src/fapilog/plugins/sinks/contrib/cloudwatch.py` (modified) - Size limit comment
- `CHANGELOG.md` (modified) - Document all changes
- `docs/stories/5.33.address-audit-report-findings.md` (new) - Story document

## Acceptance Criteria

- [x] AC1: orjson version bumped to >=3.9.15 (CVE fix)
- [x] AC2: SECURITY.md with supported versions, reporting, disclosure timeline
- [x] AC3: Python badge updated from 3.8+ to 3.10+
- [x] AC4: Plugin groups documented (5 specific groups, legacy deprecated)
- [x] AC5: Production tip callout added near Quick Start
- [x] AC6: CloudWatch sink size limit comment added
- [x] AC7: CODE_OF_CONDUCT.md with Contributor Covenant
- [x] AC8: CONTRIBUTING.md updated with all fixes

## Test Plan

- [x] Linting passes (ruff)
- [x] Type checking passes (mypy)
- [x] Existing tests pass (1961)

## Story

[5.33 - Address Audit Report Findings](docs/stories/5.33.address-audit-report-findings.md)