### PR TITLE
docs(changelog): add missing 0.3.4 and 0.3.5 release entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,36 @@ All notable changes to this project will be documented in this file. This change
 - Added default log-level selection based on TTY/CI when no preset or explicit log level is set.
 - Added stderr fallback for sink write failures with optional diagnostics warnings.
 
+## [0.3.5] - 2026-01-01
+
+### Added
+
+- Hash-chain integrity for AuditTrail.
+
+### Changed
+
+- `unbind()` now returns self for method chaining.
+
+### Fixed
+
+- GitHub release workflow now handles existing releases.
+
+## [0.3.4] - 2025-12-30
+
+### Added
+
+- Enterprise key management for tamper-evident plugin (Story 4.18).
+- Verification API and CLI for tamper-evident plugin (Story 4.17).
+- Enterprise tamper-evident plugin stories and package scaffold.
+- Configurable worker count for logging pipeline.
+
+### Fixed
+
+- PYTHONPATH passing to subprocess in CLI test.
+- fapilog-tamper tests now skip gracefully if package not available.
+- Loop stall tolerance increased for CI runners.
+- Prometheus fallback typing for mypy.
+
 ## [0.3.3] - 2025-12-22
 
 - Project status upgraded from Alpha to Beta classification.

--- a/docs/stories/10.10.changelog-release-traceability.md
+++ b/docs/stories/10.10.changelog-release-traceability.md
@@ -1,6 +1,6 @@
 # Story 10.10: Changelog Release Traceability
 
-**Status:** Ready
+**Status:** Complete
 **Priority:** High
 **Depends on:** None
 


### PR DESCRIPTION
## Summary

The GPT-5.2 audit identified that CHANGELOG.md is missing entries for versions 0.3.4 and 0.3.5, despite git tags and GitHub releases existing for both versions. This PR adds the missing changelog sections reconstructed from git history.

## Changes

- `CHANGELOG.md` (modified) - Added [0.3.4] and [0.3.5] sections with categorized changes
- `docs/stories/10.10.changelog-release-traceability.md` (modified) - Status updated to Complete

## Acceptance Criteria

- [x] AC1: Changelog contains 0.3.4 entry with date and changes
- [x] AC2: Changelog contains 0.3.5 entry with date and changes
- [x] AC3: Changes accurately reflect git history between tags
- [x] AC4: Release workflow validates changelog (already implemented)

## Test Plan

- [x] Verified changelog entries match git log between tags
- [x] Verified dates match tag creation dates
- [x] Verified formatting follows Keep-a-Changelog format

## Story

[10.10 - Changelog Release Traceability](docs/stories/10.10.changelog-release-traceability.md)