### PR TITLE
fix(core): fix strict mode drop accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+- **Fixed**: Strict mode serialization drops now correctly increment the `dropped` counter and record metrics; previously these drops were silently unaccounted (Story 1.24).
 - Fixed extras documentation accuracy: removed non-existent extras (enterprise, loki, cloud, siem), documented all real extras with descriptions.
 - **Security**: Bumped orjson minimum version to 3.9.15 (CVE-2024-27454 fix).
 - Added `SECURITY.md` with vulnerability reporting guidance.

--- a/docs/stories/1.24.strict-mode-drop-accounting.md
+++ b/docs/stories/1.24.strict-mode-drop-accounting.md
@@ -1,6 +1,6 @@
 # Story 1.24: Fix Strict Mode Drop Accounting
 
-**Status:** Ready
+**Status:** Complete
 **Priority:** High
 **Depends on:** None
 
@@ -189,11 +189,11 @@ Verify no regression in:
 
 ## Definition of Done
 
-- [ ] Drop counter incremented on strict mode failure
-- [ ] Metrics recorded
-- [ ] Test asserts dropped count
-- [ ] All tests pass
-- [ ] CHANGELOG updated
+- [x] Drop counter incremented on strict mode failure
+- [x] Metrics recorded
+- [x] Test asserts dropped count
+- [x] All tests pass
+- [x] CHANGELOG updated
 
 ---
 

--- a/src/fapilog/core/worker.py
+++ b/src/fapilog/core/worker.py
@@ -273,6 +273,9 @@ class LoggerWorker:
                 if self._serialize_in_flush and self._sink_write_serialized is not None:
                     view, drop_entry = await self._try_serialize(entry)
                     if drop_entry:
+                        self._counters["dropped"] += 1
+                        if self._metrics is not None:
+                            await self._metrics.record_events_dropped(1)
                         continue
                     if view is not None:
                         # Stage 4: PROCESSORS - transform serialized bytes


### PR DESCRIPTION
## Summary

Fix bug where events dropped in strict serialization mode were not counted in the `dropped` counter, making drop accounting inaccurate. When `strict_envelope_mode=True` and serialization fails, the event was silently dropped without incrementing the counter or recording metrics.

## Changes

- `src/fapilog/core/worker.py` (modified)
- `tests/unit/test_pipeline_processing.py` (modified)
- `CHANGELOG.md` (modified)
- `docs/stories/1.24.strict-mode-drop-accounting.md` (modified)

## Acceptance Criteria

- [x] Dropped counter incremented when strict mode drops an event
- [x] Metrics recorded via `record_events_dropped()` when collector present
- [x] Test verifies dropped counter reflects strict mode failures

## Test Plan

- [x] Unit tests pass
- [x] Coverage >= 90% on changed lines (100%)
- [x] No regressions in worker/pipeline tests (38 passed)

## Story

[1.24 - Fix Strict Mode Drop Accounting](docs/stories/1.24.strict-mode-drop-accounting.md)