### PR TITLE
fix(scripts): align benchmark key references in derive_verdicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,3 +195,24 @@ jobs:
       - name: Run tox
         if: steps.should-run.outputs.run == 'true'
         run: tox -q
+
+  benchmark-smoke:
+    name: Benchmark Smoke Test
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || needs.detect-docs-only.outputs.docs-only != 'true'
+    needs: [detect-docs-only]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Hatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+
+      - name: Run benchmark smoke test
+        run: hatch run python scripts/benchmarking.py --iterations 100 --latency-iterations 50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+- **Fixed**: Benchmark script key alignment in `derive_verdicts()` to match actual output keys from `benchmark()` (Story 10.11).
+- Added CI smoke test for benchmark script to catch future regressions.
 - **Fixed**: Strict mode serialization drops now correctly increment the `dropped` counter and record metrics; previously these drops were silently unaccounted (Story 1.24).
 - Fixed extras documentation accuracy: removed non-existent extras (enterprise, loki, cloud, siem), documented all real extras with descriptions.
 - **Security**: Bumped orjson minimum version to 3.9.15 (CVE-2024-27454 fix).

--- a/docs/stories/10.11.benchmark-script-key-alignment.md
+++ b/docs/stories/10.11.benchmark-script-key-alignment.md
@@ -1,6 +1,6 @@
 # Story 10.11: Benchmark Script Key Alignment
 
-**Status:** Ready
+**Status:** Complete
 **Priority:** Medium
 **Depends on:** None
 

--- a/scripts/benchmarking.py
+++ b/scripts/benchmarking.py
@@ -346,9 +346,10 @@ def derive_verdicts(results: dict[str, object]) -> None:
     latency = results["latency_us"]  # type: ignore[assignment]
     memory = results["memory_peak_bytes"]  # type: ignore[assignment]
 
-    speedup = float(throughput["speedup_factor"])  # type: ignore[index]
-    lat_red = float(latency["reduction_pct_avg"])  # type: ignore[index]
-    mem_red = float(memory["reduction_pct"])  # type: ignore[index]
+    # Use _on variant (optimized path with serialize_in_flush=True)
+    speedup = float(throughput["speedup_factor_on"])  # type: ignore[index]
+    lat_red = float(latency["reduction_pct_avg_on"])  # type: ignore[index]
+    mem_red = float(memory["reduction_pct_on"])  # type: ignore[index]
 
     # Claims to evaluate
     claims = [
@@ -359,7 +360,7 @@ def derive_verdicts(results: dict[str, object]) -> None:
             "High",
             "Remove unsubstantiated performance claims",
             speedup >= 50.0,
-            f"fapilog {throughput['fapilog_logs_per_sec']:.1f} logs/s vs stdlib {throughput['stdlib_logs_per_sec']:.1f} logs/s; speedup {speedup:.2f}x",
+            f"fapilog {throughput['fapilog_on_logs_per_sec']:.1f} logs/s vs stdlib {throughput['stdlib_logs_per_sec']:.1f} logs/s; speedup {speedup:.2f}x",
         ),
         (
             "D002",
@@ -368,7 +369,7 @@ def derive_verdicts(results: dict[str, object]) -> None:
             "High",
             "Remove unsubstantiated performance claims",
             lat_red >= 90.0,
-            f"avg latency reduction {latency['reduction_pct_avg']:.2f}% (median {latency['reduction_pct_median']:.2f}%, p95 {latency['reduction_pct_p95']:.2f}%)",
+            f"avg latency reduction {latency['reduction_pct_avg_on']:.2f}% (median {latency['reduction_pct_median_on']:.2f}%, p95 {latency['reduction_pct_p95_on']:.2f}%)",
         ),
         (
             "D003",
@@ -377,7 +378,7 @@ def derive_verdicts(results: dict[str, object]) -> None:
             "High",
             "Remove unsubstantiated performance claims",
             mem_red >= 80.0,
-            f"peak memory reduction {memory['reduction_pct']:.2f}% (stdlib {memory['stdlib']} B → fapilog {memory['fapilog']} B)",
+            f"peak memory reduction {memory['reduction_pct_on']:.2f}% (stdlib {memory['stdlib']} B → fapilog {memory['fapilog_on']} B)",
         ),
     ]
 


### PR DESCRIPTION
## Summary

Fix key references in `derive_verdicts()` to match actual output keys from `benchmark()`. The GPT-5.2 audit identified inconsistent key references that caused KeyError when running the benchmark script.

## Changes

- `scripts/benchmarking.py` (modified) - Fix key references to use `_on` variant keys
- `.github/workflows/ci.yml` (modified) - Add benchmark smoke test job
- `CHANGELOG.md` (modified) - Document fix and CI addition
- `docs/stories/10.11.benchmark-script-key-alignment.md` (modified) - Update status

## Acceptance Criteria

- [x] Script runs without KeyError (`--iterations 100 --latency-iterations 50`)
- [x] Verdicts use `_on` variant keys (optimized path)
- [x] Evaluation table references correct metrics
- [x] CI smoke test added

## Test Plan

- [x] Local smoke test passes (exit code 0)
- [x] ruff check passes
- [x] Pre-commit hooks pass

## Story

[10.11 - Benchmark Script Key Alignment](docs/stories/10.11.benchmark-script-key-alignment.md)