### PR TITLE
fix(core): audit encryption config accuracy

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -116,7 +116,7 @@
 | `FAPILOG_SECURITY__ENCRYPTION__MIN_TLS_VERSION` | Literal | 1.2 | Minimum TLS version for transport |
 | `FAPILOG_SECURITY__ENCRYPTION__ROTATE_INTERVAL_DAYS` | int | 90 | Recommended key rotation interval |
 | `FAPILOG_SINK_CONFIG__AUDIT__COMPLIANCE_LEVEL` | str | basic | Compliance level for audit trail |
-| `FAPILOG_SINK_CONFIG__AUDIT__ENCRYPT_LOGS` | bool | True | Encrypt audit log files when supported |
+| `FAPILOG_SINK_CONFIG__AUDIT__ENCRYPT_LOGS` | bool | False | Encrypt audit log files (not yet implemented) |
 | `FAPILOG_SINK_CONFIG__AUDIT__REAL_TIME_ALERTS` | bool | False | Emit real-time compliance alerts |
 | `FAPILOG_SINK_CONFIG__AUDIT__REQUIRE_INTEGRITY` | bool | True | Enable hash chain integrity checks |
 | `FAPILOG_SINK_CONFIG__AUDIT__RETENTION_DAYS` | int | 365 | Retention window for audit logs (days) |

--- a/docs/stories/4.29.audit-encryption-config-accuracy.md
+++ b/docs/stories/4.29.audit-encryption-config-accuracy.md
@@ -1,6 +1,6 @@
 # Story 4.29: Audit Encryption Configuration Accuracy
 
-**Status:** Ready
+**Status:** Complete
 **Priority:** High
 **Depends on:** None
 
@@ -200,19 +200,19 @@ def __init__(
 
 ### Code Complete
 
-- [ ] Default changed to False
-- [ ] Warning emitted when True
-- [ ] Both core and sink configs updated
+- [x] Default changed to False
+- [x] Warning emitted when True
+- [x] Both core and sink configs updated
 
 ### Quality Assurance
 
-- [ ] All tests pass
-- [ ] `ruff check` passes
-- [ ] `mypy` passes
+- [x] All tests pass
+- [x] `ruff check` passes
+- [x] `mypy` passes
 
 ### Documentation
 
-- [ ] User docs updated
+- [x] User docs updated
 - [ ] CHANGELOG updated
 - [ ] Roadmap for encryption documented
 

--- a/docs/user-guide/environment-variables.md
+++ b/docs/user-guide/environment-variables.md
@@ -156,7 +156,7 @@ When `FAPILOG_FILE__DIRECTORY` is set, the rotating file sink is auto-enabled wi
 | `FAPILOG_SINK_CONFIG__AUDIT__COMPLIANCE_LEVEL` | string | `basic` | Compliance level (`basic`, `sox`, `hipaa`, etc.) |
 | `FAPILOG_SINK_CONFIG__AUDIT__STORAGE_PATH` | string | `audit_logs` | Directory for audit JSONL files |
 | `FAPILOG_SINK_CONFIG__AUDIT__RETENTION_DAYS` | int | `365` | Retention window |
-| `FAPILOG_SINK_CONFIG__AUDIT__ENCRYPT_LOGS` | bool | `true` | Enable encryption when supported |
+| `FAPILOG_SINK_CONFIG__AUDIT__ENCRYPT_LOGS` | bool | `false` | Encrypt audit logs (not yet implemented) |
 | `FAPILOG_SINK_CONFIG__AUDIT__REQUIRE_INTEGRITY` | bool | `true` | Hash-chain integrity |
 | `FAPILOG_SINK_CONFIG__AUDIT__REAL_TIME_ALERTS` | bool | `false` | Compliance alerts |
 

--- a/src/fapilog/core/audit.py
+++ b/src/fapilog/core/audit.py
@@ -99,7 +99,7 @@ class CompliancePolicy:
     archive_after_days: int = 90  # When to archive logs
 
     # Security settings
-    encrypt_audit_logs: bool = True  # Encrypt audit log files
+    encrypt_audit_logs: bool = False  # Encryption not yet implemented
     require_integrity_check: bool = True  # Verify log integrity
 
     # Access control
@@ -207,6 +207,18 @@ class AuditTrail:
         """
         self.policy = policy or CompliancePolicy()
         self.storage_path = storage_path or Path("audit_logs")
+
+        # Warn if encryption requested but not implemented
+        if self.policy.encrypt_audit_logs:
+            import warnings
+
+            warnings.warn(
+                "encrypt_audit_logs=True requested but encryption is not yet "
+                "implemented. Audit logs will be written as plaintext JSONL with "
+                "hash-chain integrity. See docs for encryption roadmap.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         # Event queue for async processing
         self._event_queue: asyncio.Queue[AuditEvent] = asyncio.Queue()

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -321,7 +321,7 @@ class AuditSinkSettings(BaseModel):
         default=365, ge=1, description="Retention window for audit logs (days)"
     )
     encrypt_logs: bool = Field(
-        default=True, description="Encrypt audit log files when supported"
+        default=False, description="Encrypt audit log files (not yet implemented)"
     )
     require_integrity: bool = Field(
         default=True, description="Enable hash chain integrity checks"

--- a/src/fapilog/plugins/sinks/audit.py
+++ b/src/fapilog/plugins/sinks/audit.py
@@ -21,7 +21,7 @@ class AuditSinkConfig:
     compliance_level: str = "basic"
     storage_path: str = "audit_logs"
     retention_days: int = 365
-    encrypt_logs: bool = True
+    encrypt_logs: bool = False
     require_integrity: bool = True
     real_time_alerts: bool = False
 

--- a/tests/unit/test_audit_encryption_warning.py
+++ b/tests/unit/test_audit_encryption_warning.py
@@ -1,0 +1,112 @@
+"""Tests for audit encryption configuration accuracy (Story 4.29)."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from fapilog.core.audit import AuditTrail, CompliancePolicy
+from fapilog.plugins.sinks.audit import AuditSink, AuditSinkConfig
+
+
+class TestCompliancePolicyDefault:
+    """Tests for CompliancePolicy.encrypt_audit_logs default value."""
+
+    def test_default_encrypt_audit_logs_is_false(self) -> None:
+        """Default should be False since encryption is not implemented."""
+        policy = CompliancePolicy()
+        assert policy.encrypt_audit_logs is False
+
+    def test_explicit_false_is_allowed(self) -> None:
+        """Explicitly setting False should work without issue."""
+        policy = CompliancePolicy(encrypt_audit_logs=False)
+        assert policy.encrypt_audit_logs is False
+
+
+class TestAuditTrailEncryptionWarning:
+    """Tests for warning when encrypt_audit_logs=True."""
+
+    def test_warning_when_encrypt_audit_logs_true(self, tmp_path: Path) -> None:
+        """Should emit warning when encrypt_audit_logs=True."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            policy = CompliancePolicy(encrypt_audit_logs=True)
+            _ = AuditTrail(policy=policy, storage_path=tmp_path)
+
+            assert len(w) == 1
+            assert issubclass(w[0].category, UserWarning)
+            assert "not yet implemented" in str(w[0].message).lower()
+
+    def test_no_warning_when_encrypt_audit_logs_false(self, tmp_path: Path) -> None:
+        """Should not emit warning when encrypt_audit_logs=False."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            policy = CompliancePolicy(encrypt_audit_logs=False)
+            _ = AuditTrail(policy=policy, storage_path=tmp_path)
+
+            # Filter for UserWarning only (ignore any other warnings)
+            user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+            assert len(user_warnings) == 0
+
+    def test_no_warning_with_default_policy(self, tmp_path: Path) -> None:
+        """Should not emit warning with default policy (which defaults to False)."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = AuditTrail(storage_path=tmp_path)
+
+            user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+            assert len(user_warnings) == 0
+
+
+class TestAuditSinkConfigDefault:
+    """Tests for AuditSinkConfig.encrypt_logs default value."""
+
+    def test_default_encrypt_logs_is_false(self) -> None:
+        """Default should be False since encryption is not implemented."""
+        config = AuditSinkConfig()
+        assert config.encrypt_logs is False
+
+    def test_explicit_false_is_allowed(self) -> None:
+        """Explicitly setting False should work without issue."""
+        config = AuditSinkConfig(encrypt_logs=False)
+        assert config.encrypt_logs is False
+
+
+class TestAuditSinkEncryptionWarning:
+    """Tests for warning when AuditSink encrypt_logs=True."""
+
+    @pytest.mark.asyncio
+    async def test_warning_when_encrypt_logs_true(self, tmp_path: Path) -> None:
+        """Should emit warning when encrypt_logs=True on sink start."""
+        config = AuditSinkConfig(encrypt_logs=True, storage_path=str(tmp_path))
+        sink = AuditSink(config=config)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            await sink.start()
+            await sink.stop()
+
+            # Exactly one encryption warning should be emitted
+            encryption_warnings = [
+                x
+                for x in w
+                if issubclass(x.category, UserWarning)
+                and "not yet implemented" in str(x.message).lower()
+            ]
+            assert len(encryption_warnings) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_encrypt_logs_false(self, tmp_path: Path) -> None:
+        """Should not emit warning when encrypt_logs=False."""
+        config = AuditSinkConfig(encrypt_logs=False, storage_path=str(tmp_path))
+        sink = AuditSink(config=config)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            await sink.start()
+            await sink.stop()
+
+            user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+            assert len(user_warnings) == 0

--- a/tests/unit/test_error_audit_basic.py
+++ b/tests/unit/test_error_audit_basic.py
@@ -204,7 +204,7 @@ class TestAuditTrailsBasic:
         assert policy.enabled is True
         assert policy.retention_days == 365
         assert policy.archive_after_days == 90
-        assert policy.encrypt_audit_logs is True
+        assert policy.encrypt_audit_logs is False  # Not yet implemented
         assert policy.require_integrity_check is True
         assert policy.real_time_alerts is True
         assert policy.alert_on_critical_errors is True


### PR DESCRIPTION
## Summary

The `CompliancePolicy.encrypt_audit_logs` setting defaulted to `True`, but encryption was never implemented—audit logs are written as plaintext JSONL. This created a compliance risk where users may have relied on assumed encryption for HIPAA/SOX compliance.

This PR changes the default to `False` and emits a `UserWarning` when users explicitly set `True`, making the current capability honest and explicit.

## Changes

- `src/fapilog/core/audit.py` (modified) - Default to False, add warning in `__init__`
- `src/fapilog/core/settings.py` (modified) - Update `AuditSinkSettings.encrypt_logs` default
- `src/fapilog/plugins/sinks/audit.py` (modified) - Update `AuditSinkConfig.encrypt_logs` default
- `docs/user-guide/environment-variables.md` (modified) - Clarify not implemented
- `docs/env-vars.md` (modified) - Auto-generated update
- `tests/unit/test_audit_encryption_warning.py` (new) - 9 tests for new behavior
- `tests/unit/test_error_audit_basic.py` (modified) - Update expected default

## Acceptance Criteria

- [x] `CompliancePolicy.encrypt_audit_logs` defaults to `False`
- [x] Warning emitted when `encrypt_audit_logs=True`
- [x] `AuditSinkConfig.encrypt_logs` defaults to `False`
- [x] Documentation updated to clarify encryption not implemented

## Test Plan

- [x] Unit tests pass
- [x] Coverage >= 90% on changed lines

## Story

[4.29 - Audit Encryption Config Accuracy](docs/stories/4.29.audit-encryption-config-accuracy.md)