### PR TITLE
docs(stories): add audit findings stories and fix CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,6 @@
 
 Thank you for your interest in contributing to fapilog! This document provides guidelines and instructions for contributors to help ensure a smooth development process.
 
-> **Project Naming**: This project is developed in the `fastapi-logger` repository but published to PyPI as `fapilog`. The repository name is descriptive of the project's purpose, while the package name is concise and memorable.
-
 ## Table of Contents
 
 - [Project Setup](#project-setup)

--- a/docs/stories/1.25.eliminate-settings-hot-path-calls.md
+++ b/docs/stories/1.25.eliminate-settings-hot-path-calls.md
@@ -1,0 +1,335 @@
+# Story 1.25: Eliminate Remaining Settings() Hot Path Calls
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** Story 1.23 (Settings hot path caching - completed)
+
+---
+
+## Context / Background
+
+Story 1.23 addressed `Settings()` instantiation in `_prepare_payload()` by caching sampling/dedupe settings at logger init. However, an audit found several remaining places where `Settings()` is still called on hot paths, causing:
+
+- Unnecessary CPU overhead (Pydantic parsing on every call)
+- Inconsistent behavior (env changes mid-request)
+- Harder-to-reason-about code (implicit global state reads)
+
+### Remaining Hot Path Calls
+
+**1. Diagnostics enablement** (`src/fapilog/core/diagnostics.py:69-73`):
+```python
+def _is_enabled() -> bool:
+    try:
+        from .settings import Settings
+        return bool(Settings().core.internal_logging_enabled)  # Every diagnostic emit!
+    except Exception:
+        return False
+```
+
+**2. Strict envelope mode check** (`src/fapilog/core/worker.py:27-32`):
+```python
+def strict_envelope_mode_enabled() -> bool:
+    try:
+        from . import settings as _settings
+        return bool(_settings.Settings().core.strict_envelope_mode)  # Worker processing!
+    except Exception:
+        return False
+```
+
+**3. Sink write paths** (`src/fapilog/plugins/sinks/rotating_file.py:143`, `stdout_json.py:47`):
+```python
+strict = bool(_settings.Settings().core.strict_envelope_mode)  # Every log write!
+```
+
+**4. Shutdown timeout** (`src/fapilog/core/lifecycle.py:33`):
+```python
+to = float(Settings().core.shutdown_timeout_seconds)  # Shutdown path
+```
+
+### Impact
+
+- At 10k logs/sec, sink calls alone create 10k Settings() objects per second
+- Diagnostics in error paths add more overhead when debugging
+- Behavior can change mid-request if environment changes
+- Memory churn from temporary Pydantic model instances
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Pass configuration values into components at creation time
+- Add configuration fields to `LoggerWorker` for strict_envelope_mode
+- Add module-level caching for diagnostics enablement
+- Pass shutdown_timeout to lifecycle functions
+- Remove all `Settings()` calls from write/emit paths
+
+### Out of Scope
+
+- Dynamic settings reloading (use explicit hot-reload mechanism if needed)
+- Refactoring Settings class itself
+- Adding configuration validation beyond what exists
+
+---
+
+## Acceptance Criteria
+
+### AC1: No Settings() in Diagnostic Emit Path
+
+**Description:** `diagnostics.warn()` and `diagnostics.debug()` do not instantiate Settings() on every call.
+
+**Validation:**
+```python
+# diagnostics._is_enabled() should use cached/configured value
+# Not re-read Settings() on every call
+
+import fapilog.core.diagnostics as diag
+
+# After init, this should not create Settings() objects
+for _ in range(1000):
+    diag.warn("test", "message")
+
+# Verify no Settings() instantiation in hot path
+```
+
+### AC2: No Settings() in Worker/Sink Write Paths
+
+**Description:** `strict_envelope_mode_enabled()` and sink writes use configuration passed at creation time.
+
+**Validation:**
+```python
+# LoggerWorker should receive strict_envelope_mode at __init__
+# Sinks should receive it via config, not re-query Settings()
+
+# After worker creation, processing should not call Settings()
+worker = LoggerWorker(strict_envelope_mode=True, ...)
+
+# grep should find no Settings() in write() methods
+grep -n "Settings()" src/fapilog/plugins/sinks/*.py
+# Should return empty or only in __init__ / class-level
+```
+
+### AC3: Configuration Passed at Creation Time
+
+**Description:** Components receive configuration values as constructor arguments, not via global lookups.
+
+**Validation:**
+```python
+# LoggerWorker signature should include:
+class LoggerWorker:
+    def __init__(
+        self,
+        ...,
+        strict_envelope_mode: bool = False,
+        internal_logging_enabled: bool = False,
+    ): ...
+
+# Sinks receive strict_envelope_mode via config dict
+class RotatingFileSink:
+    def __init__(self, config: RotatingFileSinkConfig, ...):
+        self._strict_mode = config.strict_envelope_mode  # Not Settings()
+```
+
+### AC4: Explicit Refresh Mechanism for Dynamic Toggles
+
+**Description:** If dynamic configuration changes are needed, use an explicit mechanism rather than silent per-call reads.
+
+**Validation:**
+```python
+# If hot-reload is needed, it should be explicit:
+from fapilog.core.hot_reload import refresh_diagnostics_config
+
+# Not implicit via Settings() on every call
+refresh_diagnostics_config()  # Explicit, auditable
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/diagnostics.py (MODIFIED - module-level caching)
+src/fapilog/core/worker.py (MODIFIED - accept config at init)
+src/fapilog/core/lifecycle.py (MODIFIED - accept timeout as parameter)
+src/fapilog/plugins/sinks/rotating_file.py (MODIFIED - use config)
+src/fapilog/plugins/sinks/stdout_json.py (MODIFIED - use config)
+src/fapilog/core/logger.py (MODIFIED - pass config to worker)
+tests/unit/test_settings_hot_path.py (NEW - verify no Settings() in hot path)
+```
+
+### Diagnostics Caching Pattern
+
+```python
+# src/fapilog/core/diagnostics.py
+
+# Module-level cache, set once at import or first use
+_internal_logging_enabled: bool | None = None
+
+def _is_enabled() -> bool:
+    global _internal_logging_enabled
+    if _internal_logging_enabled is None:
+        try:
+            from .settings import Settings
+            _internal_logging_enabled = bool(Settings().core.internal_logging_enabled)
+        except Exception:
+            _internal_logging_enabled = False
+    return _internal_logging_enabled
+
+def configure_diagnostics(enabled: bool) -> None:
+    """Explicitly configure diagnostics enablement."""
+    global _internal_logging_enabled
+    _internal_logging_enabled = enabled
+```
+
+### Worker Configuration Pattern
+
+```python
+# src/fapilog/core/worker.py
+
+class LoggerWorker:
+    def __init__(
+        self,
+        queue: asyncio.Queue,
+        sinks: list[BaseSink],
+        *,
+        strict_envelope_mode: bool = False,
+        # ... other config
+    ):
+        self._strict_envelope_mode = strict_envelope_mode
+
+    async def _process_batch(self, batch: list[dict]) -> None:
+        # Use self._strict_envelope_mode, not Settings()
+        if self._strict_envelope_mode:
+            ...
+```
+
+### Sink Configuration Pattern
+
+```python
+# src/fapilog/plugins/sinks/rotating_file.py
+
+class RotatingFileSinkConfig(BaseModel):
+    # ... existing fields
+    strict_envelope_mode: bool = Field(
+        default=False,
+        description="Use strict envelope serialization mode",
+    )
+
+class RotatingFileSink:
+    def __init__(self, config: RotatingFileSinkConfig, ...):
+        self._strict_mode = config.strict_envelope_mode
+
+    async def write(self, entry: dict) -> None:
+        # Use self._strict_mode, not Settings()
+```
+
+---
+
+## Tasks
+
+### Phase 1: Diagnostics Module
+
+- [ ] Add module-level caching to `diagnostics.py`
+- [ ] Add `configure_diagnostics()` function for explicit setup
+- [ ] Initialize cache from Settings() once at module load or first use
+- [ ] Update tests to verify no per-call Settings() instantiation
+
+### Phase 2: Worker and Lifecycle
+
+- [ ] Add `strict_envelope_mode` parameter to `LoggerWorker.__init__`
+- [ ] Pass config from logger creation to worker
+- [ ] Update `lifecycle.py` to accept timeout as parameter
+- [ ] Remove `strict_envelope_mode_enabled()` global function
+
+### Phase 3: Sinks
+
+- [ ] Add `strict_envelope_mode` to sink config models
+- [ ] Update `RotatingFileSink` to use config value
+- [ ] Update `StdoutJsonSink` to use config value
+- [ ] Pass config from logger/settings at sink instantiation
+
+### Phase 4: Testing and Documentation
+
+- [ ] Add `tests/unit/test_settings_hot_path.py`
+- [ ] Verify no Settings() calls in write/emit paths
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_settings_hot_path.py`
+  - `test_diagnostics_warn_no_settings_instantiation`
+  - `test_worker_process_no_settings_instantiation`
+  - `test_sink_write_no_settings_instantiation`
+  - `test_configure_diagnostics_overrides_settings`
+
+### Performance Tests
+
+- Benchmark log throughput before/after
+- Verify no Settings() allocation in hot path (can use mock/spy)
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] No `Settings()` calls in diagnostic emit path
+- [ ] No `Settings()` calls in worker process path
+- [ ] No `Settings()` calls in sink write paths
+- [ ] Configuration passed at creation time
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+- [ ] Performance benchmark shows improvement
+
+### Documentation
+
+- [ ] Code comments explain caching strategy
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Cached config doesn't reflect runtime env changes
+   - **Mitigation:** Document that config is read at init; provide explicit refresh mechanism
+
+2. **Risk:** Breaking change for code relying on dynamic Settings() reads
+   - **Mitigation:** Internal APIs only; no public API change
+
+3. **Risk:** Initialization order issues with module-level caching
+   - **Mitigation:** Use lazy initialization pattern (None check)
+
+### Rollback Plan
+
+If issues occur:
+1. Revert to `Settings()` calls with deprecation warning
+2. Configuration injection is additive; can coexist with fallback
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 1.23 - Settings hot path caching (initial work)
+- **Related:** Story 1.24 - Strict mode drop accounting (uses strict_envelope_mode)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-18 | Initial draft from audit findings | Claude |

--- a/docs/stories/10.15.documentation-correctness-ci-enforcement.md
+++ b/docs/stories/10.15.documentation-correctness-ci-enforcement.md
@@ -1,0 +1,213 @@
+# Story 10.15: Documentation Correctness and CI Enforcement
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** None
+
+---
+
+## Context / Background
+
+An external audit identified documentation accuracy as the highest-ROI improvement for the project. Three specific issues were found:
+
+1. **Environment variable mismatch**: `docs/user-guide/configuration.md:146` documents `FAPILOG_FILE__DIRECTORY` and `FAPILOG_FILE__MAX_BYTES`, but the actual env vars are `FAPILOG_SINK_CONFIG__ROTATING_FILE__DIRECTORY` etc. No short aliases exist for the rotating file sink.
+
+2. **Architecture docs drift**: `docs/architecture/high-level-architecture.md` describes a source tree that doesn't match reality:
+   - Doc shows `src/fapilog/integrations/fastapi/` but actual is `src/fapilog/fastapi/`
+   - Doc shows `src/fapilog/runtime/{loader,compatibility,extras}.py` but actual is `src/fapilog/plugins/loader.py` with no `compatibility.py` or `extras.py`
+   - Doc references `CompatibilityManager` and `ExtrasResolver` components that don't exist
+
+3. **No CI protection**: `.readthedocs.yml:19` sets `fail_on_warning: false`, allowing documentation drift to go unnoticed.
+
+These issues break onboarding and damage trust. Documentation quality (weight 14) and DX (weight 16) are large score factors in the audit.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Fix env var names in `docs/user-guide/configuration.md`
+- Update architecture docs to match actual source tree
+- Enable `fail_on_warning: true` in ReadTheDocs
+- Add CI step to validate docs build without warnings
+- Add short env aliases for rotating file sink (optional, if straightforward)
+
+### Out of Scope
+
+- Comprehensive documentation rewrite (future story)
+- Automated doc generation from code (future story)
+- Documentation testing framework (future story)
+
+---
+
+## Acceptance Criteria
+
+### AC1: Env Var Documentation Matches Reality
+
+**Description:** All environment variable names in user-facing docs must match the actual env vars supported by the codebase.
+
+**Validation:**
+```bash
+# Extract documented env vars and verify against generated matrix
+grep -E "FAPILOG_[A-Z_]+" docs/user-guide/configuration.md | \
+  while read var; do
+    grep -q "$var" docs/env-vars.md || echo "MISMATCH: $var"
+  done
+# Should output nothing (no mismatches)
+```
+
+### AC2: Architecture Docs Match Source Tree
+
+**Description:** The source tree diagram in `docs/architecture/high-level-architecture.md` accurately reflects `src/fapilog/` structure.
+
+**Validation:**
+```bash
+# Key paths mentioned in docs should exist
+test -d src/fapilog/fastapi && echo "OK: fastapi dir exists"
+test -f src/fapilog/plugins/loader.py && echo "OK: loader.py exists"
+# Paths that shouldn't be referenced
+test ! -d src/fapilog/integrations && echo "OK: no integrations dir"
+test ! -d src/fapilog/runtime && echo "OK: no runtime dir"
+```
+
+### AC3: ReadTheDocs Fails on Warnings
+
+**Description:** Documentation builds must fail when Sphinx emits warnings, preventing drift.
+
+**Validation:**
+```yaml
+# .readthedocs.yml should contain:
+sphinx:
+  fail_on_warning: true
+```
+
+### AC4: CI Validates Docs Build
+
+**Description:** CI pipeline includes a step that builds docs and fails on warnings.
+
+**Validation:**
+```bash
+# This command should be in CI and exit non-zero on warnings
+sphinx-build -W -b html docs/ docs/_build/html
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+docs/user-guide/configuration.md (MODIFIED - fix env var names)
+docs/architecture/high-level-architecture.md (MODIFIED - update source tree)
+.readthedocs.yml (MODIFIED - enable fail_on_warning)
+.github/workflows/ci.yml (MODIFIED - add docs validation step)
+```
+
+### Env Var Fixes
+
+Replace in `docs/user-guide/configuration.md`:
+```bash
+# Before
+export FAPILOG_FILE__DIRECTORY=/var/log/myapp
+export FAPILOG_FILE__MAX_BYTES="10 MB"
+export FAPILOG_FILE__INTERVAL_SECONDS="daily"
+
+# After
+export FAPILOG_SINK_CONFIG__ROTATING_FILE__DIRECTORY=/var/log/myapp
+export FAPILOG_SINK_CONFIG__ROTATING_FILE__MAX_BYTES="10 MB"
+export FAPILOG_SINK_CONFIG__ROTATING_FILE__INTERVAL_SECONDS="daily"
+```
+
+---
+
+## Tasks
+
+### Phase 1: Fix Documentation
+
+- [ ] Update env var names in `docs/user-guide/configuration.md`
+- [ ] Update source tree diagram in `docs/architecture/high-level-architecture.md`
+- [ ] Remove references to non-existent components (CompatibilityManager, ExtrasResolver)
+- [ ] Update FastAPI integration paths in architecture docs
+
+### Phase 2: Enable CI Protection
+
+- [ ] Set `fail_on_warning: true` in `.readthedocs.yml`
+- [ ] Add docs build step to CI workflow
+- [ ] Fix any existing Sphinx warnings that surface
+
+### Phase 3: Verification
+
+- [ ] Run local docs build with `-W` flag
+- [ ] Verify ReadTheDocs build passes
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Manual Verification
+
+- Build docs locally: `sphinx-build -W -b html docs/ docs/_build/html`
+- Verify no warnings are emitted
+- Check ReadTheDocs build status after merge
+
+### CI Integration
+
+- CI should fail if docs build produces warnings
+- CI should pass after fixes are applied
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All env var references corrected
+- [ ] Architecture docs match source tree
+- [ ] No references to non-existent components
+
+### Quality Assurance
+
+- [ ] `sphinx-build -W` passes locally
+- [ ] ReadTheDocs build passes with `fail_on_warning: true`
+- [ ] CI docs step passes
+
+### Documentation
+
+- [ ] CHANGELOG updated with documentation fixes
+- [ ] No new Sphinx warnings introduced
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Enabling `fail_on_warning` reveals many existing warnings
+   - **Mitigation:** Fix warnings incrementally; can use warning suppression for known issues while fixing
+
+2. **Risk:** Short env var aliases may require code changes
+   - **Mitigation:** Document full paths first; aliases are optional enhancement
+
+### Rollback Plan
+
+If issues occur:
+1. Revert `fail_on_warning` to `false` if blocking releases
+2. Documentation fixes are low-risk and don't affect runtime
+
+---
+
+## Related Stories
+
+- **Related:** Story 10.14 - Extras documentation accuracy (similar area)
+- **Related:** Story 10.9 - DX documentation migration guide
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-18 | Initial draft from audit findings | Claude |

--- a/docs/stories/3.6.fapilog-audit-ecosystem-fixes.md
+++ b/docs/stories/3.6.fapilog-audit-ecosystem-fixes.md
@@ -1,0 +1,321 @@
+# Story 3.6: fapilog-audit Ecosystem Fixes
+
+**Status:** Ready
+**Priority:** Critical
+**Depends on:** Story 3.5 (Plugin allowlist secure default - completed)
+
+---
+
+## Context / Background
+
+An external audit identified two blocking issues with the fapilog-audit add-on package that prevent it from being installed or used:
+
+1. **Version constraint mismatch**: `packages/fapilog-audit/pyproject.toml:29` requires `fapilog>=0.3.6`:
+   ```toml
+   dependencies = [
+       "fapilog>=0.3.6",
+   ]
+   ```
+   But `CHANGELOG.md` shows the latest released version is **0.3.5**. This means `pip install fapilog-audit` fails immediately because the dependency cannot be satisfied.
+
+2. **Auto-discovery claim is misleading**: `packages/fapilog-audit/README.md:16-17` claims:
+   ```python
+   # Use with fapilog pipeline (auto-discovered via entry point)
+   # Just install fapilog-audit and configure in settings
+   ```
+   But Story 3.5 changed the default to block external plugins. `src/fapilog/core/settings.py:1011-1013`:
+   ```python
+   allow_external: bool = Field(
+       default=False,
+       description="Allow loading plugins from entry points (security risk)",
+   )
+   ```
+   Users who follow the README will get a `PluginNotFoundError` because external plugins are blocked by default.
+
+These issues mean the advertised ecosystem doesn't work out of the box, damaging Capability Maturity (weight 20), DX, and Maintenance/Health scores.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Fix version constraint to `fapilog>=0.3.5` (current release)
+- Update fapilog-audit README with explicit plugin allowlist instructions
+- Add working example showing correct configuration
+- Add CI check to prevent version constraint drift
+
+### Out of Scope
+
+- Releasing fapilog 0.3.6 to satisfy current constraint (requires release process)
+- Changing default plugin security policy (already decided in Story 3.5)
+- Auto-detection of installed packages to suggest allowlist entries (future enhancement)
+
+---
+
+## Acceptance Criteria
+
+### AC1: Version Constraint Allows Installation
+
+**Description:** fapilog-audit can be installed against the current fapilog release.
+
+**Validation:**
+```bash
+# Create fresh venv
+python -m venv test-venv && source test-venv/bin/activate
+
+# Install current fapilog release
+pip install fapilog==0.3.5
+
+# Install fapilog-audit (should succeed)
+pip install packages/fapilog-audit/
+echo $?  # Should be 0
+```
+
+### AC2: README Documents Plugin Allowlist
+
+**Description:** The fapilog-audit README clearly explains how to enable the plugin.
+
+**Validation:**
+```markdown
+# README.md should include:
+## Configuration
+
+fapilog-audit is an external plugin. To use it, add it to your plugin allowlist:
+
+```python
+from fapilog import Settings, get_logger
+
+settings = Settings(
+    plugins={"allowlist": ["audit"]},
+    core={"sinks": ["audit"]},
+)
+logger = get_logger(settings=settings)
+```
+
+Or via environment variables:
+```bash
+export FAPILOG_PLUGINS__ALLOWLIST='["audit"]'
+export FAPILOG_CORE__SINKS='["audit"]'
+```
+```
+
+### AC3: Working Example in README
+
+**Description:** README includes a complete, working example that users can copy-paste.
+
+**Validation:**
+```python
+# Example from README should work when executed
+from fapilog import Settings, get_logger
+from fapilog_audit import AuditTrail, CompliancePolicy, ComplianceLevel
+
+settings = Settings(
+    plugins={"allowlist": ["audit"]},
+    core={"sinks": ["audit"]},
+)
+logger = get_logger(settings=settings)
+logger.info("Audit logging configured")
+# No errors raised
+```
+
+### AC4: CI Prevents Version Drift
+
+**Description:** CI checks that fapilog-audit's version constraint is satisfiable.
+
+**Validation:**
+```yaml
+# .github/workflows/ci.yml should include:
+- name: Validate fapilog-audit constraints
+  run: |
+    CORE_VERSION=$(grep 'version =' pyproject.toml | head -1 | cut -d'"' -f2)
+    AUDIT_MIN=$(grep 'fapilog>=' packages/fapilog-audit/pyproject.toml | grep -oP '\d+\.\d+\.\d+')
+    python -c "from packaging.version import Version; assert Version('$CORE_VERSION') >= Version('$AUDIT_MIN')"
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+packages/fapilog-audit/pyproject.toml (MODIFIED - fix version constraint)
+packages/fapilog-audit/README.md (MODIFIED - add allowlist docs)
+.github/workflows/ci.yml (MODIFIED - add constraint validation)
+```
+
+### Version Constraint Fix
+
+```toml
+# Before
+dependencies = [
+    "fapilog>=0.3.6",
+]
+
+# After
+dependencies = [
+    "fapilog>=0.3.5",
+]
+```
+
+### README Update
+
+```markdown
+# fapilog-audit
+
+Enterprise compliance audit trail add-on for fapilog.
+
+## Installation
+
+```bash
+pip install fapilog-audit
+```
+
+## Configuration
+
+**Important:** fapilog-audit is an external plugin. External plugins are disabled by default for security. You must explicitly allow it:
+
+### Option 1: Plugin Allowlist (Recommended)
+
+```python
+from fapilog import Settings, get_logger
+
+settings = Settings(
+    plugins={"allowlist": ["audit"]},
+    core={"sinks": ["audit"]},
+)
+logger = get_logger(settings=settings)
+```
+
+### Option 2: Environment Variables
+
+```bash
+export FAPILOG_PLUGINS__ALLOWLIST='["audit"]'
+export FAPILOG_CORE__SINKS='["audit"]'
+```
+
+### Option 3: Allow All External Plugins (Less Secure)
+
+```python
+settings = Settings(
+    plugins={"allow_external": True},
+    core={"sinks": ["audit"]},
+)
+```
+
+## Direct Usage
+
+You can also use AuditTrail directly without the plugin system:
+
+```python
+from fapilog_audit import AuditTrail, CompliancePolicy, ComplianceLevel
+
+trail = AuditTrail(policy=CompliancePolicy(level=ComplianceLevel.HIPAA))
+await trail.start()
+await trail.log_security_event(...)
+await trail.stop()
+```
+```
+
+---
+
+## Tasks
+
+### Phase 1: Fix Blocking Issues
+
+- [ ] Update version constraint in `packages/fapilog-audit/pyproject.toml`
+- [ ] Rewrite README with allowlist documentation
+- [ ] Add complete working example to README
+
+### Phase 2: CI Protection
+
+- [ ] Add version constraint validation to CI
+- [ ] Test installation in clean environment
+
+### Phase 3: Verification
+
+- [ ] Test full workflow: install fapilog, install fapilog-audit, run example
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Manual Verification
+
+```bash
+# Full installation test
+python -m venv test-env
+source test-env/bin/activate
+pip install fapilog
+pip install packages/fapilog-audit/
+
+# Test import and basic usage
+python -c "
+from fapilog import Settings, get_logger
+from fapilog_audit import AuditSink
+
+settings = Settings(plugins={'allowlist': ['audit']})
+print('fapilog-audit installed and importable')
+"
+```
+
+### CI Integration
+
+- Version constraint check prevents future drift
+- Installation smoke test in CI
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] Version constraint allows installation with current release
+- [ ] README documents plugin allowlist requirement
+- [ ] Working example provided
+
+### Quality Assurance
+
+- [ ] Manual installation test passes
+- [ ] CI constraint validation passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] README fully updated
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Lowering version constraint may expose incompatibilities
+   - **Mitigation:** 0.3.5 to 0.3.6 is minor; API should be stable
+
+2. **Risk:** Users may not read updated README
+   - **Mitigation:** Error message from PluginNotFoundError already suggests allowlist; can improve message
+
+### Rollback Plan
+
+If issues occur:
+1. Version constraint change is trivial to revert
+2. README changes are documentation-only
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 3.5 - Plugin allowlist secure default (cause of breaking change)
+- **Related:** Story 4.44 - Extract audit to separate package (created the package)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-18 | Initial draft from audit findings | Claude |

--- a/docs/stories/4.45.webhook-secure-defaults.md
+++ b/docs/stories/4.45.webhook-secure-defaults.md
@@ -1,0 +1,248 @@
+# Story 4.45: Webhook Secure Defaults
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** Story 4.42 (Webhook HMAC signature - completed)
+
+---
+
+## Context / Background
+
+An external audit identified webhook security as a high-priority improvement. Two issues were found:
+
+1. **Default signature mode is deprecated**: `src/fapilog/plugins/sinks/webhook.py:42` defaults to `SignatureMode.HEADER` which sends secrets in plain headers. The more secure `HMAC` mode exists but isn't the default. Currently:
+   ```python
+   signature_mode: SignatureMode = Field(
+       default=SignatureMode.HEADER,  # Deprecated!
+       description="Authentication mode: 'header' (deprecated) or 'hmac' (recommended)",
+   )
+   ```
+
+2. **No replay protection**: The HMAC signature (`webhook.py:104-111`) only signs the JSON payload. An attacker who intercepts a signed request can replay it indefinitely. Industry best practice includes a timestamp and/or nonce in the signature.
+
+Story 4.42 added HMAC support with deprecation warnings for HEADER mode. This story completes the transition by making HMAC the default and adding replay protection.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Change `signature_mode` default from `HEADER` to `HMAC`
+- Add `X-Fapilog-Timestamp` header with Unix timestamp
+- Include timestamp in HMAC signature computation
+- Add optional `replay_tolerance_seconds` config (default: 300 seconds / 5 minutes)
+- Document signature verification for webhook consumers
+- Update migration guide for users relying on HEADER mode
+
+### Out of Scope
+
+- Nonce-based replay protection (stateful, requires server-side storage)
+- Webhook retry with idempotency keys (separate concern)
+- Mutual TLS authentication (enterprise feature)
+
+---
+
+## Acceptance Criteria
+
+### AC1: HMAC is Default Signature Mode
+
+**Description:** New webhook configurations default to HMAC signing, not header secrets.
+
+**Validation:**
+```python
+from fapilog.plugins.sinks.webhook import WebhookSinkConfig, SignatureMode
+
+config = WebhookSinkConfig(endpoint="https://example.com", secret="test")
+assert config.signature_mode == SignatureMode.HMAC
+```
+
+### AC2: Timestamp Included in Requests
+
+**Description:** All signed webhook requests include an `X-Fapilog-Timestamp` header with the current Unix timestamp.
+
+**Validation:**
+```python
+# When sending a webhook, headers should include:
+# X-Fapilog-Timestamp: 1737216000 (example Unix timestamp)
+# X-Fapilog-Signature-256: sha256=<hmac of timestamp + payload>
+```
+
+### AC3: Timestamp Included in Signature
+
+**Description:** The HMAC signature covers both timestamp and payload to prevent tampering.
+
+**Validation:**
+```python
+import hmac
+import hashlib
+
+# Signature computation should be:
+message = f"{timestamp}.{json_payload}".encode()
+signature = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+# Header: X-Fapilog-Signature-256: sha256={signature}
+```
+
+### AC4: Verification Documentation
+
+**Description:** Documentation explains how webhook consumers should verify signatures and reject stale requests.
+
+**Validation:**
+```python
+# docs/user-guide/webhooks.md should include:
+def verify_webhook(request, secret, tolerance_seconds=300):
+    timestamp = int(request.headers["X-Fapilog-Timestamp"])
+    if abs(time.time() - timestamp) > tolerance_seconds:
+        raise ValueError("Request too old or too new")
+
+    expected = hmac.new(
+        secret.encode(),
+        f"{timestamp}.{request.body}".encode(),
+        hashlib.sha256
+    ).hexdigest()
+
+    received = request.headers["X-Fapilog-Signature-256"].removeprefix("sha256=")
+    if not hmac.compare_digest(expected, received):
+        raise ValueError("Invalid signature")
+```
+
+### AC5: HEADER Mode Still Supported
+
+**Description:** Users can still opt into HEADER mode explicitly for backward compatibility.
+
+**Validation:**
+```python
+config = WebhookSinkConfig(
+    endpoint="https://example.com",
+    secret="test",
+    signature_mode=SignatureMode.HEADER,  # Explicit opt-in
+)
+# Should work but emit DeprecationWarning
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/plugins/sinks/webhook.py (MODIFIED - default + timestamp)
+src/fapilog/core/settings.py (MODIFIED - add replay_tolerance_seconds if needed)
+docs/user-guide/webhooks.md (NEW or MODIFIED - verification guide)
+tests/unit/sinks/test_webhook.py (MODIFIED - new test cases)
+```
+
+### Signature Format Change
+
+```python
+# Before (payload only):
+body = json.dumps(payload, separators=(",", ":")).encode()
+signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+# After (timestamp + payload):
+timestamp = int(time.time())
+message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'))}".encode()
+signature = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+headers["X-Fapilog-Timestamp"] = str(timestamp)
+headers["X-Fapilog-Signature-256"] = f"sha256={signature}"
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [ ] Change `signature_mode` default to `SignatureMode.HMAC`
+- [ ] Add `X-Fapilog-Timestamp` header generation
+- [ ] Update HMAC computation to include timestamp
+- [ ] Add `replay_tolerance_seconds` to config (for documentation purposes)
+
+### Phase 2: Testing
+
+- [ ] Update existing webhook tests for new default
+- [ ] Add tests for timestamp header presence
+- [ ] Add tests for signature computation with timestamp
+- [ ] Add tests for HEADER mode backward compatibility
+
+### Phase 3: Documentation
+
+- [ ] Create/update webhook verification guide
+- [ ] Add migration notes for HEADER → HMAC transition
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/sinks/test_webhook.py`
+  - `test_default_signature_mode_is_hmac`
+  - `test_timestamp_header_present`
+  - `test_signature_includes_timestamp`
+  - `test_header_mode_still_works_with_warning`
+  - `test_signature_verification_example`
+
+### Integration Tests
+
+- End-to-end webhook delivery with signature verification
+- Replay rejection test (old timestamp should fail verification)
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] Default signature mode is HMAC
+- [ ] Timestamp included in all signed requests
+- [ ] Signature computation includes timestamp
+- [ ] HEADER mode works with deprecation warning
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Webhook verification guide complete
+- [ ] Migration notes for HEADER users
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Breaking change for webhook consumers expecting old signature format
+   - **Mitigation:** Document the change clearly; old signature can be computed for comparison during transition
+
+2. **Risk:** Clock skew between sender and receiver
+   - **Mitigation:** Default 5-minute tolerance is generous; document NTP recommendation
+
+### Rollback Plan
+
+If issues occur:
+1. Users can set `signature_mode=SignatureMode.HEADER` to revert behavior
+2. Consider adding `signature_version` field for explicit format selection
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 4.42 - Webhook HMAC signature (foundation)
+- **Related:** Story 4.46 - Fallback sink PII protection (security theme)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-18 | Initial draft from audit findings | Claude |

--- a/docs/stories/4.46.fallback-sink-pii-protection.md
+++ b/docs/stories/4.46.fallback-sink-pii-protection.md
@@ -1,0 +1,271 @@
+# Story 4.46: Fallback Sink PII Protection
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** None
+
+---
+
+## Context / Background
+
+An external audit identified a security concern with the stderr fallback behavior:
+
+1. **Fallback writes unredacted payloads**: When a primary sink fails, `src/fapilog/plugins/sinks/fallback.py:42` writes the full payload to stderr:
+   ```python
+   def _write_to_stderr(payload: Any, *, serialized: bool) -> None:
+       text = _format_payload(payload, serialized=serialized)
+       sys.stderr.write(text)
+       sys.stderr.flush()
+   ```
+
+2. **Default redactors is empty**: `src/fapilog/core/settings.py:688` defaults `redactors` to an empty list:
+   ```python
+   redactors: list[str] = Field(
+       default_factory=list,
+       description=("Redactor plugins to use (by name); empty to disable"),
+   )
+   ```
+
+This creates a scenario where sensitive data (passwords, tokens, PII) can leak to stderr when:
+- A sink fails (network error, disk full, etc.)
+- The user hasn't configured redactors (common in development)
+- The fallback mechanism triggers
+
+Stderr often ends up in container logs, system journals, or monitoring systems that may not have the same access controls as the primary log destination.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Add diagnostic warning when fallback triggers with no redactors configured
+- Add `fallback_redact_mode` setting: `"inherit"` (use pipeline redactors), `"minimal"` (built-in sensitive field list), `"none"` (current behavior)
+- Default `fallback_redact_mode` to `"minimal"` for safe defaults
+- Add built-in minimal redaction for common sensitive fields (password, secret, token, api_key, authorization)
+- Document the security implications of fallback behavior
+
+### Out of Scope
+
+- Making redactors non-empty by default (breaking change, separate discussion)
+- Encrypting stderr output (impractical)
+- Fallback to encrypted file instead of stderr (enterprise feature)
+
+---
+
+## Acceptance Criteria
+
+### AC1: Warning When Fallback Triggers Without Redaction
+
+**Description:** When fallback writes to stderr and no redaction is configured, emit a diagnostic warning.
+
+**Validation:**
+```python
+# When fallback triggers with redactors=[] and fallback_redact_mode="none":
+# Diagnostic: "WARN [sink] fallback triggered without redaction configured"
+```
+
+### AC2: Minimal Redaction Mode
+
+**Description:** `fallback_redact_mode="minimal"` applies built-in field masking to fallback output.
+
+**Validation:**
+```python
+# Input payload with sensitive data:
+payload = {"user": "alice", "password": "secret123", "api_key": "sk-xxx"}
+
+# Output to stderr with fallback_redact_mode="minimal":
+# {"user": "alice", "password": "***", "api_key": "***"}
+```
+
+### AC3: Inherit Mode Uses Pipeline Redactors
+
+**Description:** `fallback_redact_mode="inherit"` applies the same redactors configured in the pipeline.
+
+**Validation:**
+```python
+settings = Settings(
+    core={"redactors": ["field-mask"]},
+    redactor_config={"field_mask": {"fields_to_mask": ["ssn"]}},
+)
+# Fallback output should also mask "ssn" field
+```
+
+### AC4: None Mode Preserves Current Behavior
+
+**Description:** `fallback_redact_mode="none"` writes unredacted payload (opt-in to current behavior).
+
+**Validation:**
+```python
+settings = Settings(core={"fallback_redact_mode": "none"})
+# Fallback writes full payload to stderr (current behavior)
+# Diagnostic warning still emitted
+```
+
+### AC5: Default is Minimal
+
+**Description:** Without explicit configuration, fallback uses minimal built-in redaction.
+
+**Validation:**
+```python
+settings = Settings()
+assert settings.core.fallback_redact_mode == "minimal"
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/plugins/sinks/fallback.py (MODIFIED - add redaction)
+src/fapilog/core/settings.py (MODIFIED - add fallback_redact_mode)
+src/fapilog/core/defaults.py (MODIFIED - add SENSITIVE_FIELD_DEFAULTS)
+tests/unit/sinks/test_fallback.py (MODIFIED - new test cases)
+docs/user-guide/security.md (MODIFIED - document fallback behavior)
+```
+
+### Minimal Sensitive Fields List
+
+```python
+# src/fapilog/core/defaults.py
+FALLBACK_SENSITIVE_FIELDS = frozenset({
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "api_secret",
+    "apisecret",
+    "authorization",
+    "auth",
+    "credential",
+    "credentials",
+    "private_key",
+    "privatekey",
+    "access_token",
+    "refresh_token",
+})
+```
+
+### Fallback Redaction Logic
+
+```python
+def _minimal_redact(payload: dict[str, Any]) -> dict[str, Any]:
+    """Apply minimal redaction for fallback safety."""
+    result = {}
+    for key, value in payload.items():
+        if key.lower() in FALLBACK_SENSITIVE_FIELDS:
+            result[key] = "***"
+        elif isinstance(value, dict):
+            result[key] = _minimal_redact(value)
+        else:
+            result[key] = value
+    return result
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [ ] Add `fallback_redact_mode` to `CoreSettings`
+- [ ] Add `FALLBACK_SENSITIVE_FIELDS` constant
+- [ ] Implement `_minimal_redact()` function
+- [ ] Update `_write_to_stderr()` to apply redaction based on mode
+- [ ] Add diagnostic warning for unredacted fallback
+
+### Phase 2: Integration
+
+- [ ] Pass redactor context to fallback handler
+- [ ] Implement "inherit" mode using pipeline redactors
+- [ ] Handle edge cases (redactor failures, nested objects)
+
+### Phase 3: Testing & Documentation
+
+- [ ] Add unit tests for all redaction modes
+- [ ] Add integration test for fallback with redaction
+- [ ] Document fallback security implications
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/sinks/test_fallback.py`
+  - `test_minimal_redact_masks_sensitive_fields`
+  - `test_minimal_redact_handles_nested_dicts`
+  - `test_fallback_default_mode_is_minimal`
+  - `test_fallback_none_mode_no_redaction`
+  - `test_fallback_inherit_mode_uses_pipeline`
+  - `test_diagnostic_warning_on_unredacted_fallback`
+
+### Integration Tests
+
+- `tests/integration/test_fallback_redaction.py`
+  - End-to-end test with sink failure triggering redacted fallback
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] `fallback_redact_mode` setting implemented
+- [ ] Minimal redaction applied by default
+- [ ] All three modes working correctly
+- [ ] Diagnostic warning on unredacted fallback
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Security implications documented
+- [ ] Configuration options documented
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Performance impact from redaction on every fallback
+   - **Mitigation:** Minimal redaction is simple dict traversal; fallback is rare path
+
+2. **Risk:** False negatives (sensitive fields not in default list)
+   - **Mitigation:** Document that minimal is a safety net, not comprehensive; recommend proper redactor config
+
+3. **Risk:** Breaking change for users parsing stderr output
+   - **Mitigation:** Add `fallback_redact_mode="none"` for opt-out
+
+### Rollback Plan
+
+If issues occur:
+1. Users can set `fallback_redact_mode="none"` to restore current behavior
+2. Minimal redaction is additive; doesn't affect primary pipeline
+
+---
+
+## Related Stories
+
+- **Related:** Story 4.45 - Webhook secure defaults (security theme)
+- **Related:** Story 3.5 - Plugin allowlist secure default (security defaults theme)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-18 | Initial draft from audit findings | Claude |

--- a/docs/stories/4.47.redaction-defaults-alignment.md
+++ b/docs/stories/4.47.redaction-defaults-alignment.md
@@ -1,0 +1,365 @@
+# Story 4.47: Redaction Defaults Alignment
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** None
+
+---
+
+## Context / Background
+
+An external audit found that users cannot reliably answer "am I protected by default?" because docs, presets, and settings don't align on redaction behavior. This creates a dangerous situation where users may deploy believing secrets are masked when they aren't.
+
+### Evidence of Mismatch
+
+**1. Docs claim broad regex-based secret matching** (`docs/user-guide/reliability-defaults.md:24-25`):
+```markdown
+- Order: `field-mask` → `regex-mask` → `url-credentials`
+- Patterns: regex-mask uses a broad secret matcher (password/pass/secret/api key/token/authorization/set-cookie/ssn/email).
+```
+
+**2. Production preset enables only field_mask + url_credentials** (`src/fapilog/core/presets.py:32`):
+```python
+"redactors": ["field_mask", "url_credentials"],  # NO regex_mask!
+```
+And field_mask only masks specific `metadata.*` paths, not a broad pattern:
+```python
+"fields_to_mask": [
+    "metadata.password",
+    "metadata.api_key",
+    # ... only metadata.* fields
+],
+```
+
+**3. Core settings defaults redactors to empty** (`src/fapilog/core/settings.py:688-690`):
+```python
+redactors: list[str] = Field(
+    default_factory=list,  # Empty! Redaction effectively off
+    description=("Redactor plugins to use (by name); empty to disable"),
+)
+```
+
+The `redactors_order` field (`settings.py:669`) includes `regex-mask`, but that only defines *order* when redactors are active—it doesn't enable them.
+
+### Impact
+
+- Users reading docs believe regex-based secret masking is active by default
+- Users using `preset="production"` get only field_mask + url_credentials (no regex)
+- Users with no preset and no explicit config get NO redaction at all
+- Secrets may leak to logs in production deployments
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Decide on the canonical redaction behavior (Option A or B below)
+- Align docs, presets, and settings to match the decision
+- Create a "Redaction Guarantee" reference page documenting exactly what's redacted
+- Add CI snapshot test to prevent future drift between defaults and docs
+
+### Out of Scope
+
+- Adding new redactor plugins
+- Changing the redactor plugin architecture
+- Backward-compatible shims for existing deployments (breaking change is acceptable with migration guide)
+
+---
+
+## API Design Decision
+
+### Option A: Make Production Preset Include regex_mask (Recommended)
+
+Add `regex_mask` to production preset with documented default patterns:
+
+```python
+"production": {
+    "core": {
+        "redactors": ["field_mask", "regex_mask", "url_credentials"],
+    },
+    "redactor_config": {
+        "field_mask": {
+            "fields_to_mask": [
+                "password", "api_key", "token", "secret",
+                "authorization", "api_secret", "private_key",
+                "ssn", "credit_card",
+            ],
+        },
+        "regex_mask": {
+            "patterns": [
+                r"(?i)(password|passwd|pwd)\s*[:=]\s*\S+",
+                r"(?i)(api[_-]?key|apikey)\s*[:=]\s*\S+",
+                r"(?i)(secret|token)\s*[:=]\s*\S+",
+                r"(?i)bearer\s+[a-zA-Z0-9\-._~+/]+=*",
+            ],
+        },
+        "url_credentials": {},
+    },
+}
+```
+
+**Pros:**
+- Matches documentation claims
+- More secure by default
+- Users get protection without extra config
+
+**Cons:**
+- Slightly more processing overhead
+- May mask false positives in log messages
+
+### Option B: Rewrite Docs to Match Current Behavior
+
+Update `reliability-defaults.md` to accurately describe what's actually enabled:
+
+```markdown
+## Redaction defaults
+
+- **With no preset**: Redaction is **disabled** by default. Set `core.redactors` to enable.
+- **With `preset="production"`**: Enables `field_mask` and `url_credentials` only.
+  - `field_mask` masks these fields: password, api_key, token, secret, authorization, api_secret, private_key, ssn, credit_card
+  - `url_credentials` strips userinfo from URLs
+  - `regex_mask` is **not enabled** by default (add to `core.redactors` if needed)
+```
+
+**Pros:**
+- No behavior change
+- Accurate documentation
+
+**Cons:**
+- Less secure by default
+- Users must opt-in to regex protection
+
+---
+
+## Acceptance Criteria
+
+### AC1: Docs Match Actual Behavior
+
+**Description:** `docs/user-guide/reliability-defaults.md` accurately describes what redaction is enabled by default and per preset.
+
+**Validation:**
+```python
+from fapilog import Settings
+from fapilog.core.presets import get_preset
+
+# What docs claim should match what code does
+settings = Settings()
+assert settings.core.redactors == []  # Docs should say "empty by default"
+
+prod = get_preset("production")
+assert prod["core"]["redactors"] == ["field_mask", "url_credentials"]  # Or include regex_mask if Option A
+```
+
+### AC2: Redaction Guarantee Page Exists
+
+**Description:** A dedicated page documents exactly what's redacted under each configuration.
+
+**Validation:**
+```markdown
+# docs/user-guide/redaction-guarantee.md should include:
+
+## What's Redacted by Preset
+
+| Preset | field_mask | regex_mask | url_credentials | Effective Protection |
+|--------|------------|------------|-----------------|---------------------|
+| None (default) | ❌ | ❌ | ❌ | None |
+| `dev` | ❌ | ❌ | ❌ | None |
+| `production` | ✅ | ✅/❌ | ✅ | Standard fields + URLs |
+| `fastapi` | ❌ | ❌ | ❌ | None |
+| `minimal` | ❌ | ❌ | ❌ | None |
+
+## Fields Masked by field_mask (production)
+- password, api_key, token, secret, authorization, api_secret, private_key, ssn, credit_card
+```
+
+### AC3: CI Prevents Drift
+
+**Description:** A snapshot test validates that Settings() defaults and preset behavior match documentation claims.
+
+**Validation:**
+```python
+# tests/unit/test_redaction_defaults.py
+def test_default_redactors_match_docs():
+    """Ensure Settings() defaults match reliability-defaults.md claims."""
+    settings = Settings()
+    # If docs say "empty by default", this should pass
+    assert settings.core.redactors == []
+    # If docs say regex-mask is included, this should fail until fixed
+
+def test_production_preset_redactors_match_docs():
+    """Ensure production preset matches documentation claims."""
+    prod = get_preset("production")
+    # Should match what docs/user-guide/redaction-guarantee.md says
+    assert "field_mask" in prod["core"]["redactors"]
+    assert "url_credentials" in prod["core"]["redactors"]
+    # Add or remove regex_mask assertion based on Option A/B decision
+```
+
+### AC4: No Conflicting Claims
+
+**Description:** No documentation page claims redaction behavior that contradicts another page or actual code.
+
+**Validation:**
+- `reliability-defaults.md` consistent with `redaction-guarantee.md`
+- `configuration.md` examples consistent with actual defaults
+- README preset comparison table accurate
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+docs/user-guide/reliability-defaults.md (MODIFIED - fix claims)
+docs/user-guide/redaction-guarantee.md (NEW - comprehensive reference)
+src/fapilog/core/presets.py (MODIFIED if Option A - add regex_mask)
+tests/unit/test_redaction_defaults.py (NEW - snapshot test)
+docs/user-guide/configuration.md (MODIFIED - update preset table if needed)
+```
+
+### Redaction Guarantee Page Structure
+
+```markdown
+# Redaction Guarantee
+
+This page documents exactly what fapilog redacts under each configuration.
+
+## Quick Reference
+
+| Configuration | Secrets Protected? | URL Credentials? | Regex Patterns? |
+|--------------|-------------------|------------------|-----------------|
+| `Settings()` (no preset) | ❌ No | ❌ No | ❌ No |
+| `preset="dev"` | ❌ No | ❌ No | ❌ No |
+| `preset="production"` | ✅ Yes | ✅ Yes | ✅/❌ See below |
+| `preset="fastapi"` | ❌ No | ❌ No | ❌ No |
+
+## Production Preset Details
+
+### field_mask Redactor
+Masks these field names (case-insensitive, any nesting level):
+- `password`, `api_key`, `token`, `secret`
+- `authorization`, `api_secret`, `private_key`
+- `ssn`, `credit_card`
+
+### url_credentials Redactor
+Strips userinfo from URLs:
+- `https://user:pass@example.com` → `https://***:***@example.com`
+
+### regex_mask Redactor
+[Document patterns if Option A, or state "not enabled by default" if Option B]
+
+## Enabling Additional Protection
+
+```python
+settings = Settings(
+    core={"redactors": ["field_mask", "regex_mask", "url_credentials"]},
+    redactor_config={
+        "regex_mask": {
+            "patterns": [r"(?i)secret[:=]\s*\S+"]
+        }
+    }
+)
+```
+```
+
+---
+
+## Tasks
+
+### Phase 1: Decision and Alignment
+
+- [ ] Decide Option A (add regex_mask to production) or Option B (fix docs only)
+- [ ] Update `docs/user-guide/reliability-defaults.md` to match decision
+- [ ] If Option A: Update `src/fapilog/core/presets.py` to include regex_mask
+
+### Phase 2: Documentation
+
+- [ ] Create `docs/user-guide/redaction-guarantee.md`
+- [ ] Update preset comparison table in `docs/user-guide/configuration.md`
+- [ ] Review and fix any other redaction claims in docs
+
+### Phase 3: CI Protection
+
+- [ ] Add `tests/unit/test_redaction_defaults.py` snapshot test
+- [ ] Ensure test fails if docs/code drift apart
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_redaction_defaults.py`
+  - `test_default_settings_redactors_empty`
+  - `test_production_preset_redactors_match_docs`
+  - `test_dev_preset_has_no_redactors`
+  - `test_fastapi_preset_has_no_redactors`
+  - `test_field_mask_fields_match_docs`
+
+### Documentation Tests
+
+- Validate that claims in `reliability-defaults.md` match code behavior
+- Validate `redaction-guarantee.md` table matches presets
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] Docs accurately describe redaction defaults
+- [ ] Redaction guarantee page exists
+- [ ] CI test prevents future drift
+- [ ] Presets match documentation (or vice versa)
+
+### Quality Assurance
+
+- [ ] Snapshot tests passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] Documentation builds without warnings
+
+### Documentation
+
+- [ ] `reliability-defaults.md` accurate
+- [ ] `redaction-guarantee.md` complete
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk (Option A):** Adding regex_mask to production may cause false positives
+   - **Mitigation:** Use conservative patterns; document how to disable
+
+2. **Risk (Option B):** Users may be surprised their secrets aren't masked
+   - **Mitigation:** Clear documentation and migration guide
+
+3. **Risk:** Breaking change for users relying on current behavior
+   - **Mitigation:** Document in CHANGELOG; provide opt-out
+
+### Rollback Plan
+
+If issues occur:
+1. Option A: Users can remove `regex_mask` from their redactors list
+2. Option B: No code change to rollback, only docs
+
+---
+
+## Related Stories
+
+- **Related:** Story 4.46 - Fallback sink PII protection (redaction theme)
+- **Related:** Story 10.15 - Documentation correctness (docs accuracy theme)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-18 | Initial draft from audit findings | Claude |


### PR DESCRIPTION
## Summary

Add 6 new stories based on follow-up audit findings covering documentation accuracy, security defaults, and performance improvements. Also fixes an outdated project naming note in CONTRIBUTING.md.

## Changes

- `CONTRIBUTING.md` (modified) - Remove outdated "fastapi-logger" repository naming note
- `docs/stories/3.6.fapilog-audit-ecosystem-fixes.md` (new) - Critical: fix version constraint and README
- `docs/stories/10.15.documentation-correctness-ci-enforcement.md` (new) - Fix env var docs, architecture drift
- `docs/stories/4.45.webhook-secure-defaults.md` (new) - HMAC default + replay protection
- `docs/stories/4.46.fallback-sink-pii-protection.md` (new) - Redact fallback stderr output
- `docs/stories/4.47.redaction-defaults-alignment.md` (new) - Align docs/presets/settings
- `docs/stories/1.25.eliminate-settings-hot-path-calls.md` (new) - Remove Settings() from hot paths

## Acceptance Criteria

- [x] All stories follow template format
- [x] Stories have accurate code references (verified against codebase)
- [x] Dependencies reference existing stories with correct status
- [x] All stories set to Ready status after review

## Test Plan

- [x] Stories reviewed and validated against codebase
- [x] Line number references verified
- [x] Dependency stories confirmed to exist and be Complete

## Stories

| Priority | Story | Issue |
|----------|-------|-------|
| Critical | 3.6 | fapilog-audit uninstallable (version >=0.3.6, latest is 0.3.5) |
| High | 10.15 | Env vars and architecture docs don't match code |
| High | 4.47 | Redaction docs/presets/settings misaligned |
| High | 4.45 | Webhook defaults to deprecated HEADER mode |
| High | 4.46 | Fallback sink can leak PII to stderr |
| High | 1.25 | Settings() called on every log write in sinks |