### PR TITLE
chore(docs): add GPT-5.2 audit stories and contract test guidelines

### DIFF
--- a/.claude/skills/story-creation/SKILL.md
+++ b/.claude/skills/story-creation/SKILL.md
@@ -80,6 +80,33 @@ Use the template in `references/template.md` as the starting point.
 - Include code snippets where helpful
 - Number them (AC1, AC2...) for reference
 
+### Contract Test Consideration
+
+For stories that change function signatures, data schemas, or interfaces:
+
+1. **Identify producer/consumer pairs** - What functions produce output that other functions consume?
+2. **Add contract test AC** - Include an acceptance criterion that tests `consumer(producer(...))` works
+3. **Check for manual test data** - If existing tests hand-craft data instead of using real function output, flag for update
+
+**Example AC for schema changes:**
+```markdown
+### AC: Contract Test for Schema Compatibility
+
+**Description:** Producer output is valid consumer input.
+
+**Validation:**
+```python
+# Must not raise - if it does, schemas have drifted
+output = producer_function(...)
+consumer_function(output)
+```
+```
+
+**Warning signs to look for in existing code:**
+- Tests with hand-crafted dicts that add fields to satisfy validation
+- Comments like "will fail because missing X"
+- Try/except patterns treating validation errors as expected
+
 ### Scope Boundaries
 
 - "In Scope" - What this story WILL do
@@ -106,6 +133,8 @@ Before creating the story file:
 2. Verify dependencies reference real stories
 3. Ensure acceptance criteria are testable
 4. Confirm scope boundaries are clear
+5. **For schema/interface changes:** Verify contract test AC is included (see "Contract Test Consideration")
+6. **Check for test debt:** Search for existing tests that hand-craft data for the affected interfaces
 
 ## Output
 

--- a/docs/stories/1.26.canonical-log-schema-v1.1.md
+++ b/docs/stories/1.26.canonical-log-schema-v1.1.md
@@ -1,0 +1,396 @@
+# Story 1.26: Canonical Log Schema v1.1 Definition
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** None (foundational)
+
+---
+
+## Context / Background
+
+An external audit identified a critical schema inconsistency in the fapilog logging pipeline:
+
+**Current State:**
+- `build_envelope()` (envelope.py:84-91) produces: `{timestamp, level, message, logger, correlation_id, metadata}`
+- `serialize_envelope()` (serialization.py:221-226) requires: `{timestamp, level, message, context, diagnostics}`
+- These schemas are **incompatible**
+
+**Impact:**
+- Every log event triggers `TypeError: context must be a mapping` in `serialize_envelope()`
+- Sinks catch this exception and fall back to `serialize_mapping_to_json_bytes()` (stdout_json.py:44-62, rotating_file.py:140-154)
+- The v1.0 envelope format from Story 1.17 is **never actually produced**
+- `strict_envelope_mode=True` drops ALL events because validation always fails
+- Performance penalty from exceptions on every log event
+
+**Evidence from tests:**
+- `test_serialization_recovery.py:17`: *"serialize_envelope() - requires context/diagnostics fields (fails for LogEvent)"*
+- `test_worker_lifecycle.py:481`: *"All events will fail serialize_envelope (missing context/diagnostics)"*
+
+This story defines a unified canonical schema and implements it in `build_envelope()`.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Define canonical log schema v1.1 with semantic field groupings
+- Update `build_envelope()` to produce the canonical schema
+- Update `jsonschema/log_envelope_v1.json` to v1.1
+- Add schema migration documentation
+- Update inline documentation and docstrings
+
+### Out of Scope
+
+- Enricher changes (Story 1.27)
+- LogEvent model changes (Story 1.27)
+- Serialization cleanup (Story 1.28)
+- Sink fallback removal (Story 1.28)
+
+---
+
+## Acceptance Criteria
+
+### AC1: Canonical Schema Definition
+
+**Description:** Define a unified schema with clear semantic groupings that serves both internal pipeline and external serialization needs.
+
+**Schema v1.1:**
+```python
+{
+    "timestamp": str,        # RFC3339 UTC with Z suffix (e.g., "2024-01-15T10:30:00.123Z")
+    "level": str,            # DEBUG, INFO, WARNING, ERROR, CRITICAL
+    "message": str,          # Human-readable log message
+    "logger": str | None,    # Logger name (optional)
+
+    # Semantic groupings:
+    "context": {             # Request/trace context - identifies WHO and WHAT request
+        "correlation_id": str | None,
+        "request_id": str | None,
+        "user_id": str | None,
+        "tenant_id": str | None,
+        "trace_id": str | None,
+        "span_id": str | None,
+        # Extensible: enrichers may add more
+    },
+    "diagnostics": {         # Runtime/operational context - identifies WHERE and system state
+        "service": str | None,
+        "env": str | None,
+        "host": str | None,
+        "pid": int | None,
+        "python": str | None,
+        # Exception info when present:
+        "exception": {...} | None,
+        # Extensible: enrichers may add k8s_*, etc.
+    },
+    "data": {                # User-provided structured data (replaces "metadata")
+        # Arbitrary key-value pairs from log call extra args
+    }
+}
+```
+
+**Validation:**
+```python
+from fapilog.core.envelope import build_envelope
+
+envelope = build_envelope(
+    level="INFO",
+    message="Test message",
+    extra={"user_action": "login"},
+    correlation_id="corr-123",
+)
+
+# All semantic groups present
+assert "context" in envelope
+assert "diagnostics" in envelope
+assert "data" in envelope
+
+# Context contains correlation_id
+assert envelope["context"]["correlation_id"] == "corr-123"
+
+# User data in data field
+assert envelope["data"]["user_action"] == "login"
+
+# Timestamp is RFC3339 UTC
+assert envelope["timestamp"].endswith("Z")
+```
+
+### AC2: build_envelope() Produces Canonical Schema
+
+**Description:** Update `build_envelope()` to output the v1.1 canonical schema structure.
+
+**Validation:**
+```python
+from fapilog.core.envelope import build_envelope
+
+# Basic envelope
+envelope = build_envelope(
+    level="ERROR",
+    message="Something failed",
+    logger_name="myapp.service",
+)
+
+assert envelope["level"] == "ERROR"
+assert envelope["message"] == "Something failed"
+assert envelope["logger"] == "myapp.service"
+assert isinstance(envelope["context"], dict)
+assert isinstance(envelope["diagnostics"], dict)
+assert isinstance(envelope["data"], dict)
+
+# With exception
+try:
+    raise ValueError("test error")
+except ValueError:
+    envelope = build_envelope(
+        level="ERROR",
+        message="Caught error",
+        exc_info=True,
+    )
+    # Exception data now in diagnostics
+    assert "exception" in envelope["diagnostics"]
+```
+
+### AC3: JSON Schema Updated to v1.1
+
+**Description:** Update `jsonschema/log_envelope_v1.json` to validate the new schema structure.
+
+**Validation:**
+```python
+import json
+import jsonschema
+from fapilog.core.envelope import build_envelope
+from fapilog.core.serialization import serialize_envelope
+
+# Load schema
+with open("jsonschema/log_envelope_v1.json") as f:
+    schema = json.load(f)
+
+# Build and serialize envelope
+envelope = build_envelope(level="INFO", message="test")
+serialized = serialize_envelope(envelope)
+parsed = json.loads(serialized.data)
+
+# Should validate without errors
+jsonschema.validate(parsed, schema)
+```
+
+### AC4: Migration Documentation
+
+**Description:** Document schema changes from v1.0 to v1.1 for downstream consumers upgrading to the new release.
+
+**Validation:**
+- `docs/schema-migration-v1.0-to-v1.1.md` exists
+- Documents breaking changes:
+  - `metadata` field removed → use `data`
+  - `correlation_id` (top-level) removed → use `context.correlation_id`
+- Documents new semantic groupings (`context`, `diagnostics`, `data`)
+- Includes example transformations for consumers updating their log parsers
+
+### AC5: Code Documentation Updated
+
+**Description:** All modified functions have updated docstrings reflecting the new schema.
+
+**Validation:**
+- `build_envelope()` docstring documents output schema structure
+- `serialize_envelope()` docstring references v1.1 schema
+- Module-level docstrings updated in `envelope.py` and `serialization.py`
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/envelope.py (MODIFIED - restructure output schema)
+src/fapilog/core/serialization.py (MODIFIED - update validation for v1.1)
+jsonschema/log_envelope_v1.json (MODIFIED - update to v1.1)
+docs/schema-migration-v1.0-to-v1.1.md (NEW)
+tests/unit/envelope/test_envelope_schema.py (MODIFIED)
+tests/unit/envelope/test_envelope_v1_1.py (NEW)
+tests/property/test_serialization_properties.py (MODIFIED)
+```
+
+### Key Implementation
+
+**build_envelope() structure:**
+```python
+def build_envelope(
+    level: str,
+    message: str,
+    *,
+    extra: dict[str, Any] | None = None,
+    bound_context: dict[str, Any] | None = None,
+    exc: BaseException | None = None,
+    exc_info: ...,
+    exceptions_enabled: bool = True,
+    exceptions_max_frames: int = 50,
+    exceptions_max_stack_chars: int = 20000,
+    logger_name: str = "root",
+    correlation_id: str | None = None,
+) -> dict[str, Any]:
+    # Build context dict (request/trace identifiers)
+    context: dict[str, Any] = {}
+    corr_id = correlation_id if correlation_id is not None else str(uuid4())
+    context["correlation_id"] = corr_id
+
+    # Extract trace context from bound_context if present
+    for key in ("request_id", "user_id", "tenant_id", "trace_id", "span_id"):
+        if bound_context and key in bound_context:
+            context[key] = bound_context[key]
+
+    # Build diagnostics dict (runtime/operational)
+    diagnostics: dict[str, Any] = {}
+    if exceptions_enabled:
+        exc_data = _serialize_exception(...)
+        if exc_data:
+            diagnostics["exception"] = exc_data
+
+    # Build data dict (user-provided structured data)
+    data: dict[str, Any] = {}
+    if bound_context:
+        # Non-context fields go to data
+        for k, v in bound_context.items():
+            if k not in ("request_id", "user_id", "tenant_id", "trace_id", "span_id"):
+                data[k] = v
+    if extra:
+        data.update(extra)
+
+    # RFC3339 timestamp
+    ts = datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+    return {
+        "timestamp": ts,
+        "level": level,
+        "message": message,
+        "logger": logger_name,
+        "context": context,
+        "diagnostics": diagnostics,
+        "data": data,
+    }
+```
+
+---
+
+## Tasks
+
+### Phase 1: Schema Definition
+
+- [ ] Document canonical schema v1.1 in code comments
+- [ ] Update `jsonschema/log_envelope_v1.json` with v1.1 structure
+- [ ] Create `docs/schema-migration-v1.0-to-v1.1.md`
+
+### Phase 2: Implementation
+
+- [ ] Update `build_envelope()` to produce v1.1 schema
+- [ ] Move `correlation_id` into `context` dict
+- [ ] Move exception data into `diagnostics` dict
+- [ ] Rename internal `metadata` handling to `data`
+- [ ] Update timestamp to RFC3339 string format
+
+### Phase 3: Serialization Alignment
+
+- [ ] Update `serialize_envelope()` validation for v1.1 (accept `data` field)
+- [ ] Ensure `serialize_envelope(build_envelope(...))` works without exception
+- [ ] Update property-based test strategies
+
+### Phase 4: Documentation
+
+- [ ] Update `build_envelope()` docstring
+- [ ] Update `serialize_envelope()` docstring
+- [ ] Update module docstrings
+- [ ] Add inline comments explaining semantic groupings
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/envelope/test_envelope_v1_1.py` (NEW)
+  - `test_build_envelope_produces_v1_1_schema`
+  - `test_context_contains_correlation_id`
+  - `test_diagnostics_contains_exception_data`
+  - `test_data_contains_user_provided_fields`
+  - `test_timestamp_is_rfc3339_utc`
+  - `test_bound_context_fields_routed_correctly`
+
+- `tests/unit/envelope/test_envelope_schema.py` (MODIFIED)
+  - Update existing tests for new schema structure
+
+### Property Tests
+
+- `tests/property/test_serialization_properties.py` (MODIFIED)
+  - Update `envelope_logs` strategy for v1.1 schema
+  - Add property: `serialize_envelope(build_envelope(...))` never raises
+
+### Integration Tests
+
+- `tests/integration/test_envelope_serialization_roundtrip.py` (NEW)
+  - `test_build_serialize_roundtrip_produces_valid_json`
+  - `test_json_schema_validation_passes`
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] `serialize_envelope(build_envelope(...))` works without exception
+- [ ] JSON schema validates serialized output
+- [ ] Code follows project patterns
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] Property tests updated and passing
+- [ ] Integration tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Schema migration guide created
+- [ ] Code docstrings updated
+- [ ] CHANGELOG updated with v1.1 schema changes
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Downstream consumers depend on v1.0 schema structure
+   - **Mitigation:** This is a breaking release; migration guide documents all changes
+
+2. **Risk:** Breaking change to `build_envelope()` return type affects internal code
+   - **Mitigation:** Update all callers in same PR; comprehensive test coverage
+
+3. **Risk:** Performance regression from timestamp string formatting
+   - **Mitigation:** Benchmark before/after; string formatting is fast
+
+### Rollback Plan
+
+If critical issues occur post-release:
+1. Revert the PR in a patch release
+2. Users can pin to previous version until fix available
+
+---
+
+## Related Stories
+
+- **Depends on:** None (foundational)
+- **Enables:** Story 1.27 - Enricher and Pipeline Schema Alignment
+- **Enables:** Story 1.28 - Serialization Path Cleanup
+- **Supersedes:** Story 1.17 - Schema Versioned Log Envelope v1 (this fixes its incomplete implementation)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-01-19 | Initial draft based on audit findings | Claude |
+| 2025-01-19 | Simplified for breaking release - removed backward compat considerations | Claude |

--- a/docs/stories/1.27.enricher-pipeline-schema-alignment.md
+++ b/docs/stories/1.27.enricher-pipeline-schema-alignment.md
@@ -1,0 +1,436 @@
+# Story 1.27: Enricher and Pipeline Schema Alignment
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** Story 1.26 (Canonical Log Schema v1.1 Definition)
+
+---
+
+## Context / Background
+
+Story 1.26 defines the canonical log schema v1.1 with semantic groupings:
+- `context` - request/trace identifiers (correlation_id, request_id, trace_id, etc.)
+- `diagnostics` - runtime/operational data (host, pid, service, k8s info, exceptions)
+- `data` - user-provided structured data
+
+**Current enricher behavior:**
+Enrichers return flat dictionaries that are shallow-merged at the top level of the event:
+
+```python
+# RuntimeInfoEnricher returns:
+{"service": "myapp", "host": "server1", "pid": 12345}
+
+# ContextVarsEnricher returns:
+{"request_id": "req-123", "trace_id": "abc", "span_id": "def"}
+
+# KubernetesEnricher returns:
+{"k8s_pod": "app-xyz", "k8s_namespace": "prod"}
+```
+
+After enrichment, the event has these fields scattered at the top level, not in their semantic groups.
+
+**Required change:**
+Enrichers must target the appropriate semantic group, and the merge logic must support deep-merging into nested dictionaries.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Update `RuntimeInfoEnricher` to return data targeting `diagnostics`
+- Update `ContextVarsEnricher` to return data targeting `context`
+- Update `KubernetesEnricher` to return data targeting `diagnostics`
+- Update `enrich_parallel()` to support deep-merge into nested dicts
+- Update `LogEvent` Pydantic model to match v1.1 schema
+- Update enricher protocol/documentation
+- Update enricher tests
+
+### Out of Scope
+
+- New enrichers (future stories)
+- Serialization path cleanup (Story 1.28)
+- Sink modifications (Story 1.28)
+
+---
+
+## Acceptance Criteria
+
+### AC1: Enricher Return Format Updated
+
+**Description:** Enrichers return data structured to target semantic groups.
+
+**New enricher return format:**
+```python
+# Option A: Nested dict (enricher specifies target group)
+{"diagnostics": {"host": "server1", "pid": 12345}}
+
+# Option B: Flat dict with __target__ hint
+{"host": "server1", "pid": 12345, "__target__": "diagnostics"}
+```
+
+**Validation (using Option A - nested dict):**
+```python
+from fapilog.plugins.enrichers import RuntimeInfoEnricher
+
+enricher = RuntimeInfoEnricher()
+await enricher.start()
+result = await enricher.enrich({"level": "INFO", "message": "test"})
+
+# Returns nested structure targeting diagnostics
+assert "diagnostics" in result
+assert "host" in result["diagnostics"]
+assert "pid" in result["diagnostics"]
+```
+
+### AC2: RuntimeInfoEnricher Targets Diagnostics
+
+**Description:** Runtime info (service, env, host, pid, python) goes into `diagnostics`.
+
+**Validation:**
+```python
+from fapilog.plugins.enrichers import RuntimeInfoEnricher
+
+enricher = RuntimeInfoEnricher()
+await enricher.start()
+result = await enricher.enrich({})
+
+assert "diagnostics" in result
+diag = result["diagnostics"]
+assert "host" in diag
+assert "pid" in diag
+assert "python" in diag
+# service and env only present if env vars set
+```
+
+### AC3: ContextVarsEnricher Targets Context
+
+**Description:** Request/trace identifiers (request_id, user_id, trace_id, span_id) go into `context`.
+
+**Validation:**
+```python
+from fapilog.plugins.enrichers import ContextVarsEnricher
+from fapilog.core.errors import request_id_var, user_id_var
+
+request_id_var.set("req-abc")
+user_id_var.set("user-123")
+
+enricher = ContextVarsEnricher()
+result = await enricher.enrich({})
+
+assert "context" in result
+ctx = result["context"]
+assert ctx["request_id"] == "req-abc"
+assert ctx["user_id"] == "user-123"
+```
+
+### AC4: KubernetesEnricher Targets Diagnostics
+
+**Description:** Kubernetes metadata (pod, namespace, node, cluster) goes into `diagnostics`.
+
+**Validation:**
+```python
+import os
+from fapilog.plugins.enrichers import KubernetesEnricher
+
+os.environ["POD_NAME"] = "myapp-abc123-xyz"
+os.environ["POD_NAMESPACE"] = "production"
+
+enricher = KubernetesEnricher()
+await enricher.start()
+result = await enricher.enrich({})
+
+assert "diagnostics" in result
+diag = result["diagnostics"]
+assert "k8s_pod" in diag
+assert "k8s_namespace" in diag
+```
+
+### AC5: Deep-Merge in enrich_parallel()
+
+**Description:** The `enrich_parallel()` function deep-merges enricher results into nested dicts.
+
+**Validation:**
+```python
+from fapilog.plugins.enrichers import enrich_parallel, RuntimeInfoEnricher, ContextVarsEnricher
+
+event = {
+    "timestamp": "2024-01-15T10:00:00.000Z",
+    "level": "INFO",
+    "message": "test",
+    "context": {"correlation_id": "corr-123"},
+    "diagnostics": {},
+    "data": {},
+}
+
+enrichers = [RuntimeInfoEnricher(), ContextVarsEnricher()]
+result = await enrich_parallel(event, enrichers)
+
+# Original context preserved and enriched
+assert result["context"]["correlation_id"] == "corr-123"
+# Enricher additions merged in
+assert "host" in result["diagnostics"]
+assert "pid" in result["diagnostics"]
+```
+
+### AC6: LogEvent Model Updated
+
+**Description:** The `LogEvent` Pydantic model reflects the v1.1 canonical schema.
+
+**Validation:**
+```python
+from fapilog.core.events import LogEvent
+
+event = LogEvent(
+    timestamp=1705312800.0,
+    level="INFO",
+    message="test",
+    logger="myapp",
+    context={"correlation_id": "abc"},
+    diagnostics={"host": "server1"},
+    data={"user_action": "login"},
+)
+
+mapping = event.to_mapping()
+assert "context" in mapping
+assert "diagnostics" in mapping
+assert "data" in mapping
+assert mapping["context"]["correlation_id"] == "abc"
+```
+
+### AC7: Enricher Protocol Documentation Updated
+
+**Description:** The `BaseEnricher` protocol docstring documents the expected return format.
+
+**Validation:**
+- `BaseEnricher.enrich()` docstring explains:
+  - Return dict should contain semantic group keys (`context`, `diagnostics`, or `data`)
+  - Deep-merge behavior for nested dicts
+  - Examples of correct return format
+- Plugin authoring docs updated with enricher examples
+
+### AC8: Documentation Alignment
+
+**Description:** Documentation reflects the new enricher behavior and schema.
+
+**Validation:**
+- README enricher examples show new return format
+- Inline docstrings in all three enrichers updated
+- CHANGELOG documents the breaking change
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/plugins/enrichers/__init__.py (MODIFIED - deep-merge logic)
+src/fapilog/plugins/enrichers/runtime_info.py (MODIFIED - target diagnostics)
+src/fapilog/plugins/enrichers/context_vars.py (MODIFIED - target context)
+src/fapilog/plugins/enrichers/kubernetes.py (MODIFIED - target diagnostics)
+src/fapilog/core/events.py (MODIFIED - update LogEvent model)
+tests/unit/test_runtime_info_enricher.py (NEW - runtime info doesn't have dedicated tests)
+tests/unit/test_context_vars_enricher.py (MODIFIED)
+tests/unit/test_kubernetes_enricher.py (MODIFIED)
+tests/unit/test_enrichers_parallel.py (MODIFIED)
+tests/unit/test_log_event_v1_1.py (NEW)
+```
+
+### Deep-Merge Implementation
+
+```python
+def _deep_merge(base: dict, updates: dict) -> dict:
+    """Deep-merge updates into base dict.
+
+    For nested dicts (context, diagnostics, data), merge contents.
+    For other keys, updates overwrite base.
+    """
+    result = dict(base)
+    for key, value in updates.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+async def enrich_parallel(event: dict, enrichers: Iterable[BaseEnricher], ...) -> dict:
+    # ... existing parallel execution ...
+
+    merged = dict(event)
+    for res in results:
+        if isinstance(res, BaseException):
+            continue
+        merged = _deep_merge(merged, res)
+    return merged
+```
+
+### Updated Enricher Example
+
+```python
+class RuntimeInfoEnricher:
+    async def enrich(self, event: dict[str, Any]) -> dict[str, Any]:
+        info = {
+            "service": os.getenv("FAPILOG_SERVICE", "fapilog"),
+            "env": os.getenv("FAPILOG_ENV", os.getenv("ENV", "dev")),
+            "host": socket.gethostname(),
+            "pid": os.getpid(),
+            "python": platform.python_version(),
+        }
+        # Remove None values
+        compact = {k: v for k, v in info.items() if v is not None}
+
+        # Return targeting diagnostics group
+        return {"diagnostics": compact}
+```
+
+### Updated LogEvent Model
+
+```python
+class LogEvent(BaseModel):
+    timestamp: float = Field(...)
+    level: str = Field(...)
+    message: str = Field(...)
+    logger: str | None = Field(default=None)
+
+    # Semantic groupings (v1.1)
+    context: dict[str, Any] = Field(default_factory=dict)
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+    data: dict[str, Any] = Field(default_factory=dict)
+
+    # Removed in v1.1 (breaking change):
+    # - metadata: dict[str, Any] → use data instead
+    # - correlation_id: str → use context["correlation_id"]
+    # - component: str → use context or data
+```
+
+---
+
+## Tasks
+
+### Phase 1: Deep-Merge Infrastructure
+
+- [ ] Implement `_deep_merge()` helper function
+- [ ] Update `enrich_parallel()` to use deep-merge
+- [ ] Add unit tests for deep-merge behavior
+
+### Phase 2: Enricher Updates
+
+- [ ] Update `RuntimeInfoEnricher.enrich()` to return `{"diagnostics": {...}}`
+- [ ] Update `ContextVarsEnricher.enrich()` to return `{"context": {...}}`
+- [ ] Update `KubernetesEnricher.enrich()` to return `{"diagnostics": {...}}`
+- [ ] Update enricher docstrings
+
+### Phase 3: LogEvent Model
+
+- [ ] Add `context`, `diagnostics`, `data` fields to LogEvent
+- [ ] Remove `metadata`, `correlation_id`, `component` fields (breaking change)
+- [ ] Update `to_mapping()` method
+- [ ] Update model docstring
+
+### Phase 4: Protocol and Documentation
+
+- [ ] Update `BaseEnricher` protocol docstring
+- [ ] Update enricher inline documentation
+- [ ] Update README enricher examples
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_runtime_info_enricher.py` (NEW)
+  - `test_returns_diagnostics_structure`
+  - `test_diagnostics_contains_host_pid_python`
+
+- `tests/unit/test_context_vars_enricher.py` (MODIFIED)
+  - `test_returns_context_structure`
+  - `test_context_contains_request_id_user_id`
+  - `test_context_contains_trace_span_ids`
+
+- `tests/unit/test_kubernetes_enricher.py` (MODIFIED)
+  - `test_returns_diagnostics_structure`
+  - `test_diagnostics_contains_k8s_fields`
+
+- `tests/unit/test_enrichers_parallel.py` (MODIFIED)
+  - `test_deep_merge_preserves_existing_context`
+  - `test_deep_merge_combines_multiple_enrichers`
+  - `test_deep_merge_handles_empty_dicts`
+
+- `tests/unit/test_log_event_v1_1.py` (NEW)
+  - `test_log_event_v1_1_schema`
+  - `test_log_event_to_mapping_includes_semantic_groups`
+
+### Integration Tests
+
+- `tests/integration/test_enricher_pipeline.py`
+  - `test_full_pipeline_produces_v1_1_schema`
+  - `test_enrichers_populate_correct_semantic_groups`
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] All three enrichers return nested structure
+- [ ] Deep-merge works correctly
+- [ ] LogEvent model updated
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] Integration tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] BaseEnricher protocol docstring updated
+- [ ] All enricher docstrings updated
+- [ ] README enricher section updated
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Custom enrichers in user code return flat dicts
+   - **Mitigation:** Deep-merge handles both nested and flat formats for flexibility
+   - **Mitigation:** Document new return format in CHANGELOG and migration guide
+
+2. **Risk:** LogEvent model change breaks serialization
+   - **Mitigation:** Ensure `to_mapping()` produces v1.1 schema output
+
+3. **Risk:** Deep-merge performance overhead
+   - **Mitigation:** Benchmark; dict operations are fast; only 3 levels deep
+
+### Rollback Plan
+
+If critical issues occur post-release:
+1. Revert the PR in a patch release
+2. Users can pin to previous version until fix available
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 1.26 - Canonical Log Schema v1.1 Definition
+- **Enables:** Story 1.28 - Serialization Path Cleanup
+- **Related:** Story 1.15 - Formal Plugin Contracts (enricher protocol)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-01-19 | Initial draft | Claude |
+| 2025-01-19 | Simplified for breaking release - removed deprecated field framing | Claude |

--- a/docs/stories/1.28.serialization-path-cleanup.md
+++ b/docs/stories/1.28.serialization-path-cleanup.md
@@ -1,0 +1,458 @@
+# Story 1.28: Serialization Path Cleanup
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** Story 1.26 (Canonical Log Schema v1.1), Story 1.27 (Enricher Pipeline Alignment)
+
+---
+
+## Context / Background
+
+After Stories 1.26 and 1.27, the pipeline produces log events in the v1.1 canonical schema:
+- `build_envelope()` outputs `{timestamp, level, message, logger, context, diagnostics, data}`
+- Enrichers deep-merge into `context` and `diagnostics`
+- `serialize_envelope()` expects this exact structure
+
+**Current problematic code patterns:**
+
+1. **Sinks try/except fallback** (stdout_json.py:44-62, rotating_file.py:140-154):
+   ```python
+   try:
+       view = serialize_envelope(entry)
+   except Exception as e:
+       # Fallback - THIS WAS THE NORMAL PATH!
+       view = serialize_mapping_to_json_bytes(entry)
+   ```
+
+2. **Worker try/except fallback** (worker.py:421-447):
+   ```python
+   async def _try_serialize(self, entry):
+       try:
+           return serialize_envelope(entry), False
+       except Exception:
+           # Fallback to raw serialization
+           return serialize_mapping_to_json_bytes(entry), False
+   ```
+
+**After 1.26 + 1.27:** These exceptions should never occur in normal operation. The fallback becomes a true safety net for edge cases (non-serializable objects, corruption), not the default path.
+
+This story cleans up the serialization path to:
+1. Remove exception as the expected flow
+2. Simplify `serialize_envelope()` validation
+3. Add metrics/logging for actual failures (which are now exceptional)
+4. Update tests that explicitly relied on the failure path
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Simplify `serialize_envelope()` to trust input schema
+- Update sink serialization code (remove try/except as normal flow)
+- Update worker `_try_serialize()` method
+- Add metrics for actual serialization failures
+- Update tests that expected schema mismatch
+- Verify `strict_envelope_mode` now works correctly
+- Performance validation (no more exceptions in hot path)
+- Update serialization documentation
+
+### Out of Scope
+
+- New serialization formats (future)
+- Compression/encryption processors (existing)
+- New sink types (future)
+
+---
+
+## Acceptance Criteria
+
+### AC1: serialize_envelope() Trusts Input Schema
+
+**Description:** `serialize_envelope()` performs minimal validation since input is now guaranteed to be v1.1 compliant from `build_envelope()` + enrichers.
+
+**Validation:**
+```python
+from fapilog.core.envelope import build_envelope
+from fapilog.core.serialization import serialize_envelope
+import json
+
+# Normal flow - no exception
+envelope = build_envelope(level="INFO", message="test")
+view = serialize_envelope(envelope)  # No exception!
+
+parsed = json.loads(view.data)
+assert parsed["schema_version"] == "1.0"  # or "1.1"
+assert "log" in parsed
+assert parsed["log"]["context"] is not None
+assert parsed["log"]["diagnostics"] is not None
+```
+
+### AC2: Sinks Use Direct Serialization
+
+**Description:** Sinks call `serialize_envelope()` directly without defensive try/except for schema errors. The fallback is retained only for truly exceptional cases (non-JSON-serializable objects).
+
+**Validation:**
+```python
+# In StdoutJsonSink.write():
+# - serialize_envelope() succeeds for all valid log entries
+# - Fallback only triggers for non-serializable data (rare)
+# - Diagnostics warn only logged for actual failures
+
+# Test: Normal log entries serialize without fallback
+from fapilog.plugins.sinks.stdout_json import StdoutJsonSink
+from fapilog.core.envelope import build_envelope
+import io, sys
+
+sink = StdoutJsonSink()
+await sink.start()
+
+# Capture output
+envelope = build_envelope(level="INFO", message="test")
+# This should NOT trigger diagnostics.warn() for schema errors
+await sink.write(envelope)
+```
+
+### AC3: Worker _try_serialize() Simplified
+
+**Description:** The worker's `_try_serialize()` method is simplified. Schema validation errors no longer expected.
+
+**Validation:**
+```python
+# In LoggerWorker._try_serialize():
+# - serialize_envelope() expected to succeed
+# - Exception path is for edge cases only
+# - Metrics recorded for actual failures
+
+from fapilog.core.worker import LoggerWorker
+# Worker processes events without schema-related exceptions
+```
+
+### AC4: strict_envelope_mode Works Correctly
+
+**Description:** With schema alignment, `strict_envelope_mode=True` now works as intended - only dropping events with actual serialization issues (non-JSON-serializable data), not ALL events.
+
+**Validation:**
+```python
+from fapilog.core.logger import AsyncLoggerFacade
+
+# With strict mode, normal events are NOT dropped
+logger = AsyncLoggerFacade(
+    name="test",
+    strict_envelope_mode=True,  # Was broken, now works
+    ...
+)
+logger.start()
+
+await logger.info("normal event")  # NOT dropped
+await logger.info("bad event", obj=NonSerializable())  # Dropped (correct)
+
+result = await logger.stop_and_drain()
+assert result.processed >= 1  # Normal events processed
+assert result.dropped >= 1    # Only bad events dropped
+```
+
+### AC5: Serialization Failure Metrics
+
+**Description:** Actual serialization failures (now rare) are tracked via metrics.
+
+**Validation:**
+```python
+# When a serialization failure occurs (non-JSON-serializable object):
+# - metrics.record_serialization_error() called
+# - diagnostics.warn() emitted with details
+# - Event falls back or drops based on strict_mode
+
+# Verify metrics are recorded for actual failures only
+```
+
+### AC6: Test Updates for Schema Alignment
+
+**Description:** Tests that explicitly expected schema mismatch or manually worked around it are updated.
+
+**Files requiring updates (comments acknowledging mismatch):**
+- `tests/integration/test_serialization_recovery.py:17` - comment: "fails for LogEvent"
+- `tests/integration/test_worker_lifecycle.py:481,496` - comments about missing context/diagnostics
+- `tests/unit/test_stdout_json_sink_strict.py` - may test fallback behavior
+
+**Files requiring updates (manual `"context": {}` workarounds):**
+- `tests/unit/test_core_log_level_wiring.py:79,82` - manually adds context/diagnostics to test data
+- `tests/unit/envelope/test_envelope_modes.py:34,49` - manually adds context/diagnostics
+- `tests/unit/envelope/test_envelope_properties.py:25` - manually adds context/diagnostics
+
+**Validation:**
+- All tests pass with new schema-aligned behavior
+- Test comments updated to reflect new behavior (schema now aligned)
+- Tests use `build_envelope()` to generate test data instead of manual dicts where appropriate
+- Tests verify actual error cases (non-serializable data), not schema mismatch
+
+### AC7: Performance Validation
+
+**Description:** Serialization path no longer incurs exception overhead on every event.
+
+**Validation:**
+```python
+# Benchmark: serialize 10,000 events
+# Before: Exception on every event (~X ms)
+# After: No exceptions (~Y ms, Y < X)
+
+# Run: pytest tests/benchmark/test_perf_benchmarks.py -v
+# Verify serialization benchmarks show improvement
+```
+
+### AC8: Documentation Updated
+
+**Description:** Serialization documentation reflects the cleaned-up behavior.
+
+**Validation:**
+- `serialization.py` module docstring updated
+- `serialize_envelope()` docstring updated
+- Developer docs explain when fallback triggers
+- CHANGELOG documents the behavioral change
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/serialization.py (MODIFIED - simplify validation)
+src/fapilog/core/worker.py (MODIFIED - simplify _try_serialize)
+src/fapilog/plugins/sinks/stdout_json.py (MODIFIED - remove defensive try/except)
+src/fapilog/plugins/sinks/rotating_file.py (MODIFIED - remove defensive try/except)
+tests/integration/test_serialization_recovery.py (MODIFIED - update comments, use build_envelope())
+tests/integration/test_worker_lifecycle.py (MODIFIED - update comments)
+tests/unit/test_stdout_json_sink_strict.py (MODIFIED)
+tests/unit/test_core_log_level_wiring.py (MODIFIED - use build_envelope() instead of manual dicts)
+tests/unit/envelope/test_envelope_modes.py (MODIFIED - use build_envelope())
+tests/unit/envelope/test_envelope_properties.py (MODIFIED - use build_envelope())
+tests/benchmark/test_perf_benchmarks.py (MODIFIED - add serialization benchmark)
+```
+
+### Simplified serialize_envelope()
+
+```python
+def serialize_envelope(log: Mapping[str, Any]) -> SerializedView:
+    """Build a schema-versioned envelope {"schema_version":"1.1","log":{...}}.
+
+    Expects input from build_envelope() + enrichers pipeline, which guarantees
+    the v1.1 schema structure. Validation is minimal since schema compliance
+    is enforced upstream.
+
+    Raises FapilogError only for truly unserializable data (edge cases).
+    """
+    # Minimal validation - trust upstream schema compliance
+    if "timestamp" not in log or "level" not in log or "message" not in log:
+        raise ValueError("missing required fields in log payload")
+
+    # Normalize timestamp if needed
+    ts = ensure_rfc3339_utc(log["timestamp"])
+
+    # Build envelope - context/diagnostics/data already present from pipeline
+    norm_log: dict[str, Any] = {
+        "timestamp": ts,
+        "level": str(log["level"]),
+        "message": str(log["message"]),
+        "context": dict(log.get("context", {})),
+        "diagnostics": dict(log.get("diagnostics", {})),
+        "data": dict(log.get("data", {})),
+    }
+
+    # Copy optional fields
+    if "logger" in log:
+        norm_log["logger"] = log["logger"]
+
+    envelope = {"schema_version": "1.1", "log": norm_log}
+    return serialize_mapping_to_json_bytes(envelope)
+```
+
+### Simplified Sink Write
+
+```python
+# In StdoutJsonSink.write():
+async def write(self, entry: dict[str, Any]) -> None:
+    try:
+        view = serialize_envelope(entry)
+    except Exception as e:
+        # This is now an actual error (non-serializable data), not expected
+        diagnostics.warn(
+            "sink",
+            "serialization error (non-serializable data)",
+            reason=type(e).__name__,
+            detail=str(e),
+        )
+        if self._strict_envelope_mode:
+            return None  # Drop event
+        # Best-effort fallback for edge cases
+        view = serialize_mapping_to_json_bytes(entry)
+
+    # Continue with write...
+```
+
+### Simplified _try_serialize()
+
+```python
+async def _try_serialize(
+    self, entry: dict[str, Any]
+) -> tuple[SerializedView | None, bool]:
+    """Serialize entry to envelope format.
+
+    With v1.1 schema alignment, this should succeed for all valid log entries.
+    Failures indicate actual issues (non-serializable objects) not schema mismatch.
+    """
+    try:
+        return serialize_envelope(entry), False
+    except Exception as exc:
+        # This is now exceptional - log and handle
+        strict_mode = self._strict_envelope_mode_provider()
+
+        warn(
+            "sink",
+            "serialization error",
+            mode="strict" if strict_mode else "best-effort",
+            reason=type(exc).__name__,
+            detail=str(exc),
+        )
+
+        if strict_mode:
+            return None, True  # Drop event
+
+        # Best-effort fallback for edge cases
+        try:
+            return serialize_mapping_to_json_bytes(entry), False
+        except Exception:
+            return None, False  # Give up, let dict path handle it
+```
+
+---
+
+## Tasks
+
+### Phase 1: Serialization Simplification
+
+- [ ] Update `serialize_envelope()` to expect v1.1 schema input
+- [ ] Remove strict `context`/`diagnostics` mapping validation (trust upstream)
+- [ ] Add `data` field handling
+- [ ] Update schema version to "1.1"
+
+### Phase 2: Sink Cleanup
+
+- [ ] Simplify `StdoutJsonSink.write()` exception handling
+- [ ] Simplify `RotatingFileSink.write()` exception handling
+- [ ] Update diagnostic messages to indicate actual errors
+
+### Phase 3: Worker Cleanup
+
+- [ ] Simplify `LoggerWorker._try_serialize()`
+- [ ] Update comments to reflect new behavior
+- [ ] Add metrics for actual serialization failures
+
+### Phase 4: Test Updates
+
+- [ ] Update `test_serialization_recovery.py` comments and assertions
+- [ ] Update `test_worker_lifecycle.py` comments
+- [ ] Update `test_stdout_json_sink_strict.py` for new behavior
+- [ ] Update `test_core_log_level_wiring.py` to use `build_envelope()` instead of manual dicts
+- [ ] Update `test_envelope_modes.py` to use `build_envelope()`
+- [ ] Update `test_envelope_properties.py` to use `build_envelope()`
+- [ ] Add benchmark test for serialization performance
+
+### Phase 5: Documentation
+
+- [ ] Update `serialization.py` module docstring
+- [ ] Update `serialize_envelope()` docstring
+- [ ] Update sink docstrings
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_serialization_cleanup.py` (NEW)
+  - `test_serialize_envelope_accepts_v1_1_schema`
+  - `test_serialize_envelope_rejects_non_serializable`
+  - `test_fallback_only_for_edge_cases`
+
+### Integration Tests
+
+- `tests/integration/test_serialization_recovery.py` (MODIFIED)
+  - Update to test actual error cases (non-serializable objects)
+  - Remove references to schema mismatch as expected behavior
+
+- `tests/integration/test_strict_mode_behavior.py` (NEW)
+  - `test_strict_mode_processes_normal_events`
+  - `test_strict_mode_drops_only_bad_events`
+
+### Benchmark Tests
+
+- `tests/benchmark/test_perf_benchmarks.py` (MODIFIED)
+  - `test_serialization_throughput_no_exceptions`
+  - Compare before/after exception elimination
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] Exception path is truly exceptional
+- [ ] strict_envelope_mode works correctly
+- [ ] Code follows project patterns
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] Integration tests updated and passing
+- [ ] Benchmark shows performance improvement
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Module docstrings updated
+- [ ] Function docstrings updated
+- [ ] CHANGELOG updated with behavioral change
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Some code path still produces old schema format
+   - **Mitigation:** Comprehensive test coverage; CI catches regressions
+
+2. **Risk:** Third-party code relies on fallback behavior
+   - **Mitigation:** Fallback still exists for actual errors; document change
+
+3. **Risk:** Performance benchmark shows no improvement
+   - **Mitigation:** Profile to identify bottleneck; exception elimination is proven optimization
+
+### Rollback Plan
+
+If critical issues occur post-release:
+1. Revert the PR in a patch release
+2. Users can pin to previous version until fix available
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 1.26 - Canonical Log Schema v1.1 Definition
+- **Depends on:** Story 1.27 - Enricher Pipeline Schema Alignment
+- **Completes:** Epic - Schema Unification (all three stories together)
+- **Fixes:** Issue identified in audit - exception-driven hot path
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-01-19 | Initial draft | Claude |
+| 2025-01-19 | Simplified for breaking release - updated rollback plan | Claude |

--- a/docs/stories/1.29.backpressure-startup-validation.md
+++ b/docs/stories/1.29.backpressure-startup-validation.md
@@ -1,0 +1,257 @@
+# Story 1.29: Backpressure Configuration Startup Validation
+
+**Status:** Ready
+**Priority:** Medium
+**Depends on:** Story 1.19 (Consistent Backpressure Semantics) - Complete
+
+---
+
+## Context / Background
+
+Story 1.19 addressed the GPT-5.2 audit finding about surprising same-thread backpressure behavior by adding documentation and runtime diagnostic warnings. However, users still only discover the limitation when a drop actually occurs at runtime.
+
+**Current state after Story 1.19:**
+
+1. **Documentation exists** - `docs/user-guide/reliability-defaults.md` explains same-thread behavior
+2. **Runtime warning exists** - When same-thread drop occurs with `drop_on_full=False`, a diagnostic is emitted
+3. **Recommendation exists** - Use `AsyncLoggerFacade` in async contexts
+
+**Remaining gap:**
+
+Users who configure `drop_on_full=False` expect waiting/blocking behavior. They only discover the limitation when:
+1. They're running in production
+2. The queue fills up
+3. A same-thread log call drops
+4. They notice the diagnostic (if internal logging is enabled)
+
+This is late and potentially surprising. A startup-time warning would help users discover this earlier.
+
+**Audit finding:**
+> "same-thread backpressure drops immediately regardless of drop_on_full... surprising drops/behavior under certain concurrency contexts"
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Add one-time startup warning when `drop_on_full=False` is configured
+- Warning explains that same-thread calls will still drop
+- Warning recommends using `AsyncLoggerFacade` in async contexts
+- Warning is rate-limited (once per logger instance)
+
+### Out of Scope
+
+- Changing the fundamental same-thread behavior (covered by 1.19 rationale)
+- Adding new configuration options for same-thread policy
+- Detecting at startup whether same-thread calls will actually occur
+
+---
+
+## Acceptance Criteria
+
+### AC1: Startup Warning When drop_on_full=False
+
+**Description:** When a `SyncLoggerFacade` is created with `drop_on_full=False`, emit a one-time diagnostic warning.
+
+**Validation:**
+```python
+# When SyncLoggerFacade is instantiated with drop_on_full=False:
+logger = SyncLoggerFacade(
+    name="test",
+    queue_capacity=100,
+    batch_max_size=10,
+    batch_timeout_seconds=0.1,
+    backpressure_wait_ms=50,
+    drop_on_full=False,  # <-- Triggers warning
+    sink_write=mock_sink,
+)
+logger.start()
+
+# Diagnostic emitted:
+# {"category": "backpressure", "message": "drop_on_full=False configured - note: same-thread calls will still drop immediately to prevent deadlock. Consider AsyncLoggerFacade for async contexts."}
+```
+
+### AC2: Warning Only Emitted Once Per Logger
+
+**Description:** The warning is emitted once when `start()` is called, not on every log call.
+
+**Validation:**
+```python
+logger = SyncLoggerFacade(..., drop_on_full=False, ...)
+logger.start()  # Warning emitted here
+
+# Subsequent calls do not emit the startup warning
+logger.info("test1")  # No startup warning
+logger.info("test2")  # No startup warning
+```
+
+### AC3: No Warning When drop_on_full=True
+
+**Description:** The default `drop_on_full=True` configuration does not trigger the warning.
+
+**Validation:**
+```python
+logger = SyncLoggerFacade(..., drop_on_full=True, ...)
+logger.start()  # No startup warning
+```
+
+### AC4: Warning Includes Actionable Recommendation
+
+**Description:** The warning message includes a recommendation to use `AsyncLoggerFacade`.
+
+**Validation:**
+```python
+# Warning message contains:
+# - Explanation of the limitation
+# - Reference to same-thread context
+# - Recommendation for AsyncLoggerFacade
+```
+
+### AC5: AsyncLoggerFacade Does Not Emit Warning
+
+**Description:** `AsyncLoggerFacade` does not emit this warning (same-thread issue doesn't apply).
+
+**Validation:**
+```python
+logger = AsyncLoggerFacade(..., drop_on_full=False, ...)
+await logger.start_async()  # No startup warning
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/logger.py (MODIFIED - override start() in SyncLoggerFacade)
+tests/unit/core/test_logger_startup.py (NEW - startup warning tests)
+```
+
+### Architecture Note
+
+The `start()` method is defined in `_LoggerMixin` (line 163) and inherited by both `SyncLoggerFacade` and `AsyncLoggerFacade`. To emit the warning only for `SyncLoggerFacade`, we need to override `start()` in that class and call the parent implementation.
+
+### Key Code Change
+
+```python
+# src/fapilog/core/logger.py - add start() override in SyncLoggerFacade
+
+class SyncLoggerFacade(_LoggerMixin):
+    # ... existing __init__ and other methods ...
+
+    def start(self) -> None:
+        """Start the background worker with startup validation.
+
+        Emits a one-time warning if drop_on_full=False is configured,
+        since same-thread calls will still drop to prevent deadlock.
+        """
+        # Emit one-time warning for drop_on_full=False configuration
+        if not self._drop_on_full and self._worker_loop is None:
+            try:
+                from .diagnostics import warn
+                warn(
+                    "backpressure",
+                    "drop_on_full=False configured - note: same-thread calls "
+                    "will still drop immediately to prevent deadlock. "
+                    "Consider AsyncLoggerFacade for async contexts.",
+                    _rate_limit_key="startup-drop-on-full-warning",
+                    setting="drop_on_full=False",
+                    recommendation="Use AsyncLoggerFacade in async contexts",
+                )
+            except Exception:
+                pass
+
+        # Call parent implementation
+        super().start()
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [ ] Override `start()` in `SyncLoggerFacade` (call `super().start()`)
+- [ ] Add startup warning before calling parent `start()`
+- [ ] Ensure warning only emits once (check `_worker_loop is None`)
+- [ ] Verify `AsyncLoggerFacade` does not emit warning (inherits unmodified `_LoggerMixin.start()`)
+
+### Phase 2: Testing
+
+- [ ] Add unit test for startup warning emission
+- [ ] Add test for warning not emitted when `drop_on_full=True`
+- [ ] Add test for warning rate limiting
+
+### Phase 3: Documentation
+
+- [ ] Update reliability-defaults.md to mention startup warning
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/core/test_logger_startup.py`
+  - `test_sync_facade_warns_on_drop_on_full_false`
+  - `test_sync_facade_no_warn_on_drop_on_full_true`
+  - `test_async_facade_no_startup_warning`
+  - `test_startup_warning_emitted_once_per_logger`
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] Startup warning implemented for `drop_on_full=False`
+- [ ] Warning is rate-limited
+- [ ] `AsyncLoggerFacade` does not emit warning
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] reliability-defaults.md updated
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Warning noise for users who understand the limitation
+   - **Mitigation:** Warning is one-time per logger instance; rate-limited
+
+2. **Risk:** Users may over-rotate to AsyncLoggerFacade unnecessarily
+   - **Mitigation:** Warning explains this is only for same-thread context
+
+### Rollback Plan
+
+If issues occur:
+1. Remove the startup warning code
+2. Existing runtime warnings (from 1.19) still provide feedback
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 1.19 - Consistent Backpressure Semantics (provides runtime warning)
+- **Related:** Story 7.10 - Worker lifecycle coverage (tests backpressure behavior)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-19 | Initial draft from GPT-5.2 audit follow-up | Claude |

--- a/docs/stories/10.17.schema-contract-test-infrastructure.md
+++ b/docs/stories/10.17.schema-contract-test-infrastructure.md
@@ -1,0 +1,439 @@
+# Story 10.17: Schema Contract Test Infrastructure
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** Story 1.26 (Canonical Log Schema v1.1 Definition)
+
+---
+
+## Context / Background
+
+The schema inconsistency between `build_envelope()` and `serialize_envelope()` (addressed in Stories 1.26-1.28) went undetected despite extensive test coverage. Root cause analysis reveals structural gaps in the test strategy:
+
+**Why Tests Didn't Catch It:**
+
+1. **Isolation testing** - `build_envelope()` and `serialize_envelope()` tested separately, never together
+2. **Synthetic test data** - Property tests generate valid input matching `serialize_envelope()` expectations (tests/property/test_serialization_properties.py:36-37), not actual `build_envelope()` output
+3. **Fallback as feature** - Tests treated the exception-driven fallback as expected behavior, not a failure signal
+4. **No schema validation** - No tests validate output against `jsonschema/log_envelope_v1.json`
+
+**Evidence:**
+```python
+# Property test generates synthetic data with context/diagnostics
+envelope_logs = st.fixed_dictionaries({
+    "context": st.dictionaries(...),      # Manually added - not from build_envelope()
+    "diagnostics": st.dictionaries(...),  # Manually added - not from build_envelope()
+})
+
+# No test exists that does this:
+serialize_envelope(build_envelope(...))  # Would have caught the mismatch
+```
+
+This story adds contract tests and schema validation to catch schema drift early.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Contract tests verifying producer/consumer schema compatibility
+- JSON schema validation at key pipeline boundaries
+- Shared type definitions for schema enforcement
+- CI enforcement of contract tests
+- Test fixture to fail-fast on fallback path
+- Documentation of contract testing patterns
+
+### Out of Scope
+
+- Fixing the schema mismatch (Stories 1.26-1.28)
+- Performance testing infrastructure
+- New test frameworks or tools
+
+---
+
+## Acceptance Criteria
+
+### AC1: Contract Test for Envelope Roundtrip
+
+**Description:** A contract test verifies that `build_envelope()` output is valid input for `serialize_envelope()`.
+
+**Validation:**
+```python
+# tests/contract/test_envelope_contract.py
+
+import pytest
+from fapilog.core.envelope import build_envelope
+from fapilog.core.serialization import serialize_envelope
+
+class TestEnvelopeContract:
+    """Contract tests ensuring schema compatibility between pipeline stages."""
+
+    def test_build_envelope_output_is_serializable(self):
+        """build_envelope() output must be valid serialize_envelope() input."""
+        envelope = build_envelope(level="INFO", message="test message")
+
+        # This should NOT raise - if it does, schemas have drifted
+        view = serialize_envelope(envelope)
+        assert view is not None
+        assert len(view.data) > 0
+
+    def test_build_envelope_with_all_options_is_serializable(self):
+        """Full-featured envelope must serialize without exception."""
+        envelope = build_envelope(
+            level="ERROR",
+            message="error occurred",
+            extra={"user_id": "u-123", "action": "login"},
+            correlation_id="corr-abc",
+            logger_name="myapp.auth",
+            exc_info=False,
+        )
+
+        view = serialize_envelope(envelope)
+        assert view is not None
+```
+
+### AC2: JSON Schema Validation Tests
+
+**Description:** Tests validate pipeline output against the canonical JSON schema.
+
+**Validation:**
+```python
+# tests/contract/test_schema_validation.py
+
+import json
+import jsonschema
+import pytest
+from fapilog.core.envelope import build_envelope
+from fapilog.core.serialization import serialize_envelope
+
+@pytest.fixture
+def envelope_schema():
+    with open("jsonschema/log_envelope_v1.json") as f:
+        return json.load(f)
+
+def test_serialized_output_validates_against_schema(envelope_schema):
+    """Serialized envelope must conform to published JSON schema."""
+    envelope = build_envelope(level="INFO", message="test")
+    view = serialize_envelope(envelope)
+    parsed = json.loads(view.data)
+
+    # Should not raise ValidationError
+    jsonschema.validate(parsed, envelope_schema)
+
+def test_enriched_envelope_validates_against_schema(envelope_schema):
+    """Envelope after enrichment must still conform to schema."""
+    # Test with enrichers applied
+    ...
+```
+
+### AC3: Shared Type Definition
+
+**Description:** A shared TypedDict or Protocol defines the canonical schema, used by both `build_envelope()` and `serialize_envelope()`.
+
+**Validation:**
+```python
+# src/fapilog/core/schema.py
+
+from typing import Any, TypedDict
+
+class LogContext(TypedDict, total=False):
+    correlation_id: str | None
+    request_id: str | None
+    user_id: str | None
+    tenant_id: str | None
+    trace_id: str | None
+    span_id: str | None
+
+class LogDiagnostics(TypedDict, total=False):
+    service: str | None
+    env: str | None
+    host: str | None
+    pid: int | None
+    exception: dict[str, Any] | None
+
+class LogEnvelopeV1(TypedDict):
+    timestamp: str
+    level: str
+    message: str
+    logger: str | None
+    context: LogContext
+    diagnostics: LogDiagnostics
+    data: dict[str, Any]
+
+# Used in function signatures:
+def build_envelope(...) -> LogEnvelopeV1: ...
+def serialize_envelope(log: LogEnvelopeV1) -> SerializedView: ...
+```
+
+**Validation:**
+- `mypy` catches type mismatches at lint time
+- IDE provides autocomplete for schema fields
+- Refactoring updates all usages
+
+### AC4: Fail-Fast Test Fixture for Fallback Path
+
+**Description:** A pytest fixture makes the fallback path fail loudly, catching unintended schema drift in any test.
+
+**Validation:**
+```python
+# conftest.py (project root)
+
+import pytest
+
+@pytest.fixture
+def strict_serialization(monkeypatch):
+    """Fail if fallback serialization is triggered.
+
+    Use this fixture in tests where the happy path should always work.
+    If fallback triggers, it indicates schema drift.
+    """
+    def _fail_on_fallback(*args, **kwargs):
+        pytest.fail(
+            "Fallback serialization triggered! "
+            "This indicates schema mismatch between build_envelope() and serialize_envelope(). "
+            "See Story 10.17 for context."
+        )
+
+    monkeypatch.setattr(
+        "fapilog.core.worker.serialize_mapping_to_json_bytes",
+        _fail_on_fallback
+    )
+    yield
+
+# Usage in tests:
+def test_normal_logging_uses_envelope_path(strict_serialization, logger):
+    """Normal logging should never trigger fallback."""
+    logger.info("test message")
+    # If fallback is triggered, test fails with clear message
+```
+
+### AC5: Property Test Uses Real build_envelope()
+
+**Description:** Update property tests to use actual `build_envelope()` output, not synthetic data.
+
+**Validation:**
+```python
+# tests/property/test_serialization_properties.py
+
+from hypothesis import given
+from hypothesis import strategies as st
+from fapilog.core.envelope import build_envelope
+from fapilog.core.serialization import serialize_envelope
+
+@given(
+    level=st.sampled_from(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+    message=st.text(min_size=1, max_size=200),
+    extra=st.dictionaries(st.text(min_size=1, max_size=20), st.text(), max_size=5),
+)
+def test_build_then_serialize_never_raises(level, message, extra):
+    """Property: serialize_envelope(build_envelope(...)) never raises."""
+    envelope = build_envelope(level=level, message=message, extra=extra)
+
+    # Must not raise for any valid input combination
+    view = serialize_envelope(envelope)
+    assert view is not None
+```
+
+### AC6: CI Enforces Contract Tests
+
+**Description:** Contract tests run in CI and block PRs if they fail.
+
+**Validation:**
+- Contract tests in `tests/contract/` directory
+- CI runs `pytest tests/contract/ -v` as separate step
+- Contract test failures are clearly labeled in CI output
+- PR cannot merge if contract tests fail
+
+### AC7: Contract Testing Documentation
+
+**Description:** Document the contract testing pattern for contributors.
+
+**Validation:**
+- `docs/contributing/contract-tests.md` explains:
+  - What contract tests are and why they exist
+  - How to write new contract tests
+  - When to use `strict_serialization` fixture
+  - How schema drift is detected
+- CONTRIBUTING.md references the contract test docs
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/schema.py (NEW - shared type definitions)
+tests/contract/__init__.py (NEW)
+tests/contract/test_envelope_contract.py (NEW)
+tests/contract/test_schema_validation.py (NEW)
+tests/contract/test_pipeline_contract.py (NEW)
+conftest.py (root) (MODIFIED - add strict_serialization fixture)
+tests/property/test_serialization_properties.py (MODIFIED - use build_envelope())
+.github/workflows/ci.yml (MODIFIED - add contract test step)
+docs/contributing/contract-tests.md (NEW)
+CONTRIBUTING.md (MODIFIED - reference contract tests)
+```
+
+### Contract Test Categories
+
+| Category | Purpose | Example |
+|----------|---------|---------|
+| **Roundtrip** | Producer output → Consumer input | `serialize_envelope(build_envelope(...))` |
+| **Schema** | Output validates against JSON schema | `jsonschema.validate(output, schema)` |
+| **Pipeline** | Full pipeline produces valid output | Logger → Worker → Sink with real components |
+| **Enricher** | Enriched events still conform | Event + enrichment → valid schema |
+
+### Directory Structure
+
+```
+/
+├── conftest.py                  # Root conftest - add strict_serialization fixture here
+└── tests/
+    ├── contract/                # Contract tests (schema compatibility) - NEW
+    │   ├── __init__.py
+    │   ├── test_envelope_contract.py
+    │   ├── test_schema_validation.py
+    │   └── test_pipeline_contract.py
+    ├── unit/                    # Unit tests (isolated components)
+    ├── integration/             # Integration tests (component interaction)
+    └── property/                # Property-based tests (invariants)
+```
+
+---
+
+## Tasks
+
+### Phase 1: Contract Test Infrastructure
+
+- [ ] Create `tests/contract/` directory structure
+- [ ] Implement `test_envelope_contract.py` with roundtrip tests
+- [ ] Implement `test_schema_validation.py` with JSON schema validation
+- [ ] Add `strict_serialization` fixture to root `conftest.py`
+
+### Phase 2: Type Definitions
+
+- [ ] Create `src/fapilog/core/schema.py` with TypedDict definitions
+- [ ] Update `build_envelope()` return type annotation
+- [ ] Update `serialize_envelope()` parameter type annotation
+- [ ] Verify `mypy` catches type mismatches
+
+### Phase 3: Property Test Updates
+
+- [ ] Update `test_serialization_properties.py` to use `build_envelope()`
+- [ ] Add property test for roundtrip invariant
+- [ ] Remove synthetic `envelope_logs` strategy (or keep for edge cases)
+
+### Phase 4: CI Integration
+
+- [ ] Add contract test step to CI workflow
+- [ ] Ensure contract test failures block PR merge
+- [ ] Add clear labeling for contract test results
+
+### Phase 5: Documentation
+
+- [ ] Create `docs/contributing/contract-tests.md`
+- [ ] Update CONTRIBUTING.md with contract test section
+- [ ] Add inline comments explaining contract test rationale
+
+---
+
+## Tests
+
+### Contract Tests (New)
+
+- `tests/contract/test_envelope_contract.py`
+  - `test_build_envelope_output_is_serializable`
+  - `test_build_envelope_with_all_options_is_serializable`
+  - `test_build_envelope_with_exception_is_serializable`
+  - `test_enriched_envelope_is_serializable`
+
+- `tests/contract/test_schema_validation.py`
+  - `test_serialized_output_validates_against_schema`
+  - `test_enriched_envelope_validates_against_schema`
+  - `test_full_pipeline_output_validates_against_schema`
+
+- `tests/contract/test_pipeline_contract.py`
+  - `test_logger_to_sink_produces_valid_output`
+  - `test_async_logger_to_sink_produces_valid_output`
+
+### Property Tests (Modified)
+
+- `tests/property/test_serialization_properties.py`
+  - `test_build_then_serialize_never_raises` (NEW)
+  - Update existing tests to use real `build_envelope()` where appropriate
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] Contract tests catch the original schema mismatch (verify by temporarily breaking schema)
+- [ ] Type definitions provide IDE support and mypy checking
+- [ ] `strict_serialization` fixture available for any test
+
+### Quality Assurance
+
+- [ ] Contract tests pass
+- [ ] Property tests updated and pass
+- [ ] `mypy` passes with new type annotations
+- [ ] CI runs contract tests and reports clearly
+- [ ] Existing tests unaffected
+
+### Documentation
+
+- [ ] Contract testing guide written
+- [ ] CONTRIBUTING.md updated
+- [ ] Code comments explain contract test purpose
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Type annotations too strict, break valid code
+   - **Mitigation:** Use `total=False` for optional fields; TypedDict is structural
+
+2. **Risk:** Contract tests too slow for CI
+   - **Mitigation:** Contract tests are fast (no I/O); separate CI step allows parallel execution
+
+3. **Risk:** False positives from `strict_serialization` fixture
+   - **Mitigation:** Fixture is opt-in; only use where fallback should never trigger
+
+### Rollback Plan
+
+If issues occur:
+1. Remove contract test CI step (tests still run locally)
+2. Make `strict_serialization` fixture no-op
+3. Type annotations can be loosened without breaking runtime
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 1.26 - Canonical Log Schema v1.1 (defines the schema to test against)
+- **Prevents:** Future schema drift issues like the one identified in audit
+- **Related:** Story 10.15 - Documentation Correctness CI Enforcement (similar CI pattern)
+
+---
+
+## Success Metrics
+
+After implementation, the following should be true:
+
+1. **Immediate detection:** If someone changes `build_envelope()` output or `serialize_envelope()` input requirements, contract tests fail immediately
+2. **Clear failure message:** Test failure explains *why* it failed and points to relevant documentation
+3. **Type safety:** `mypy` catches schema mismatches at lint time, before tests even run
+4. **No silent fallback:** Tests using `strict_serialization` fail loudly if fallback path is triggered
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-01-19 | Initial draft based on audit root cause analysis | Claude |

--- a/docs/stories/10.18.documentation-accuracy-redaction-envelope.md
+++ b/docs/stories/10.18.documentation-accuracy-redaction-envelope.md
@@ -1,0 +1,334 @@
+# Story 10.18: Documentation Accuracy - Redaction and Envelope
+
+**Status:** Ready
+**Priority:** Critical
+**Depends on:** None (immediate fix required)
+
+---
+
+## Context / Background
+
+An external audit identified material misrepresentations in fapilog documentation that could lead users to build integrations and compliance expectations on incorrect assumptions.
+
+**Finding 1: Redaction Guarantees Overstate Default Behavior**
+
+| Documentation Claim | Actual Behavior |
+|---------------------|-----------------|
+| `docs/redaction-guarantees.md:7`: "URL credentials are **always** scrubbed from string values" | Redaction is **disabled by default**. Only enabled with `preset="production"` or explicit configuration. |
+| `docs/stories/1.18.redaction-guarantees-and-validation.md:14-15`: "Always scrub URL credentials" | Same - not enabled by default |
+
+**Evidence:**
+- `docs/user-guide/reliability-defaults.md:24`: "With no preset: Redaction is **disabled** by default"
+- `src/fapilog/core/presets.py:32`: Only `production` preset includes `"redactors": ["field_mask", "regex_mask", "url_credentials"]`
+- `dev`, `fastapi`, `minimal` presets have NO redactors
+
+**Impact:** Users may believe their logs are automatically scrubbed and expose credentials in production.
+
+---
+
+**Finding 2: Envelope Documentation Misrepresents Format**
+
+| Documentation Claim | Actual Behavior |
+|---------------------|-----------------|
+| `docs/core-concepts/envelope.md`: `"timestamp": "2024-01-01T12:00:00.000Z"` (ISO 8601 string) | `build_envelope()` produces float seconds like `1704110400.123` |
+| `docs/core-concepts/envelope.md`: "timestamp: ISO 8601 with milliseconds in UTC" | Actual output uses POSIX float format |
+| `docs/core-concepts/envelope.md`: "metadata keys merged at top level" | No flattening - metadata stays nested under `"metadata"` key |
+
+**Technical Note:** The serialization module has `ensure_rfc3339_utc()` that would normalize timestamps to RFC3339 if `serialize_envelope()` succeeded. However, due to the schema mismatch between `build_envelope()` and `serialize_envelope()` (addressed in Stories 1.26-1.28), sinks fall back to `serialize_mapping_to_json_bytes()` which preserves the float format. The net result for users is float timestamps.
+
+**Note:** Story 1.26 will change timestamp to RFC3339 string as part of the unified schema fix.
+
+**Impact:** Users building log parsers, integrations, or compliance reports on documented format will fail.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Fix `docs/redaction-guarantees.md` to accurately describe default behavior
+- Fix `docs/core-concepts/envelope.md` to match actual output format
+- Add clear "Defaults" or "Warning" callouts to critical documentation
+- Update story 1.18 language if needed
+- Add CI check to prevent future doc/code drift for critical claims
+
+### Out of Scope
+
+- Changing default redaction behavior (Story 3.7)
+- Changing timestamp format (Story 1.26)
+- Adding metadata flattening feature
+
+---
+
+## Acceptance Criteria
+
+### AC1: Redaction Guarantees Document Accuracy
+
+**Description:** `docs/redaction-guarantees.md` accurately describes when redaction is active.
+
+**Before (misleading):**
+```markdown
+- URL credentials are always scrubbed from string values resembling `scheme://user:pass@host...` across all fields.
+```
+
+**After (accurate):**
+```markdown
+> **Important:** Redaction is disabled by default. To enable, use `preset="production"` or explicitly configure redactors.
+
+- URL credentials are scrubbed from string values resembling `scheme://user:pass@host...` across all fields **when the `url_credentials` redactor is enabled**.
+```
+
+**Validation:**
+- Document no longer uses "always" without qualification
+- Clear callout box at top explains default behavior
+- Links to preset documentation for enabling redaction
+
+### AC2: Envelope Document Timestamp Accuracy
+
+**Description:** `docs/core-concepts/envelope.md` accurately describes current timestamp format.
+
+**Before (misleading):**
+```markdown
+"timestamp": "2024-01-01T12:00:00.000Z",
+...
+- `timestamp`: ISO 8601 with milliseconds in UTC.
+```
+
+**After (accurate):**
+```markdown
+"timestamp": 1704110400.123,
+...
+- `timestamp`: POSIX timestamp as float seconds (UTC).
+  > **Note:** Story 1.26 will change this to RFC3339 string format (`"2024-01-01T12:00:00.000Z"`) in a future release.
+```
+
+**Validation:**
+- JSON example shows actual float format
+- Description matches code behavior
+- Note indicates planned change
+
+### AC3: Envelope Document Metadata Accuracy
+
+**Description:** Remove false claim about metadata flattening.
+
+**Before (false):**
+```markdown
+- Default stdout sink emits JSON lines with these fields flattened (metadata keys merged at top level).
+```
+
+**After (accurate):**
+```markdown
+- Default stdout sink emits JSON lines preserving the envelope structure. The `metadata` field remains nested.
+```
+
+**Validation:**
+- No claim of flattening (which doesn't exist)
+- Accurately describes nested structure
+
+### AC4: Reliability Defaults Cross-Reference
+
+**Description:** `docs/redaction-guarantees.md` prominently links to reliability defaults documentation.
+
+**Validation:**
+- First paragraph or callout box references `docs/user-guide/reliability-defaults.md`
+- Users can quickly understand what's enabled by default
+
+### AC5: Story 1.18 Language Updated
+
+**Description:** If story 1.18 is referenced as authoritative, update its language to match corrected guarantees.
+
+**Validation:**
+- `docs/stories/1.18.redaction-guarantees-and-validation.md:14-15` updated
+- "Always scrub" becomes "Scrub (when enabled)" or similar
+
+### AC6: Documentation Accuracy CI Check
+
+**Description:** Add a CI check that validates critical documentation claims against code behavior.
+
+**Validation:**
+```yaml
+# In CI workflow
+- name: Validate doc claims
+  run: python scripts/check_doc_accuracy.py
+```
+
+Script checks:
+- Redaction guarantees doc mentions "disabled by default" or "when enabled"
+- Envelope doc timestamp example is float (until 1.26 merges)
+- No "always" claims without qualification for optional features
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+docs/redaction-guarantees.md (MODIFIED - add accuracy callouts)
+docs/user-guide/redaction-guarantee.md (MODIFIED - add accuracy callouts)
+docs/core-concepts/envelope.md (MODIFIED - fix timestamp and metadata claims)
+docs/user-guide/reliability-defaults.md (MODIFIED - add cross-reference if needed)
+docs/stories/1.18.redaction-guarantees-and-validation.md (MODIFIED - update language)
+scripts/check_doc_accuracy.py (NEW - CI validation script)
+.github/workflows/ci.yml (MODIFIED - add doc accuracy check)
+```
+
+### Callout Box Format
+
+Use consistent callout format for important caveats:
+
+```markdown
+> **Important:** [Key caveat about default behavior]
+```
+
+Or with admonition syntax if supported:
+
+```markdown
+!!! warning "Default Behavior"
+    Redaction is disabled by default. See [Reliability Defaults](../user-guide/reliability-defaults.md) for details.
+```
+
+---
+
+## Tasks
+
+### Phase 1: Redaction Documentation
+
+- [ ] Add "disabled by default" callout to `redaction-guarantees.md`
+- [ ] Change "always scrubbed" to "scrubbed when enabled"
+- [ ] Add link to reliability-defaults.md
+- [ ] Update story 1.18 language
+
+### Phase 2: Envelope Documentation
+
+- [ ] Change timestamp example from string to float
+- [ ] Update timestamp description with note about Story 1.26
+- [ ] Remove metadata flattening claim
+- [ ] Describe actual nested structure
+
+### Phase 3: CI Enforcement
+
+- [ ] Create `scripts/check_doc_accuracy.py`
+- [ ] Add patterns to detect misleading language
+- [ ] Add CI workflow step
+- [ ] Document the check in CONTRIBUTING.md
+
+---
+
+## Tests
+
+### CI Validation Script
+
+`scripts/check_doc_accuracy.py`:
+```python
+"""Validate documentation accuracy for critical claims."""
+
+import re
+import sys
+from pathlib import Path
+
+CHECKS = [
+    {
+        "file": "docs/redaction-guarantees.md",
+        "must_contain": ["disabled by default", "when enabled", "preset"],
+        "must_not_contain": [r"always scrubbed(?! when)", r"always redact(?!ed when)"],
+    },
+    {
+        "file": "docs/user-guide/redaction-guarantee.md",
+        "must_contain": ["disabled by default", "when enabled"],
+        "must_not_contain": [r"always scrubbed(?! when)", r"always redact(?!ed when)"],
+    },
+    {
+        "file": "docs/core-concepts/envelope.md",
+        "must_not_contain": [r"flattened.*metadata", r"merged at top level"],
+    },
+]
+
+def check_file(check):
+    path = Path(check["file"])
+    if not path.exists():
+        print(f"SKIP: {path} not found")
+        return True
+
+    content = path.read_text()
+    errors = []
+
+    for pattern in check.get("must_contain", []):
+        if pattern.lower() not in content.lower():
+            errors.append(f"Missing required text: '{pattern}'")
+
+    for pattern in check.get("must_not_contain", []):
+        if re.search(pattern, content, re.IGNORECASE):
+            errors.append(f"Found prohibited pattern: '{pattern}'")
+
+    if errors:
+        print(f"FAIL: {path}")
+        for e in errors:
+            print(f"  - {e}")
+        return False
+
+    print(f"PASS: {path}")
+    return True
+
+if __name__ == "__main__":
+    results = [check_file(c) for c in CHECKS]
+    sys.exit(0 if all(results) else 1)
+```
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All misleading documentation corrected
+- [ ] Callout boxes added for critical caveats
+- [ ] Cross-references to defaults documentation
+- [ ] CI check implemented and passing
+
+### Quality Assurance
+
+- [ ] Documentation renders correctly
+- [ ] Links work
+- [ ] CI check catches the original issues (test by reverting temporarily)
+- [ ] No regression in doc build
+
+### Documentation
+
+- [ ] CHANGELOG notes documentation corrections
+- [ ] CONTRIBUTING.md mentions doc accuracy check
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Users relied on misleading docs and now feel misled
+   - **Mitigation:** Clear changelog entry explaining correction; Story 3.7 addresses secure defaults
+
+2. **Risk:** CI check too strict, blocks valid documentation
+   - **Mitigation:** Patterns are specific; easy to adjust
+
+### Rollback Plan
+
+Documentation changes are low-risk:
+1. Revert the commit if needed
+2. CI check can be disabled temporarily
+
+---
+
+## Related Stories
+
+- **Enables:** Story 3.7 - Secure Defaults Enhancement (users can understand current state before changes)
+- **Related:** Story 1.26 - Canonical Log Schema v1.1 (will fix timestamp format)
+- **Related:** Story 10.15 - Documentation Correctness CI Enforcement (similar pattern)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-01-19 | Initial draft based on audit findings | Claude |
+| 2025-01-19 | Added technical note on timestamp behavior; added docs/user-guide/redaction-guarantee.md to scope | Claude |

--- a/docs/stories/3.7.secure-defaults-url-credential-redaction.md
+++ b/docs/stories/3.7.secure-defaults-url-credential-redaction.md
@@ -1,0 +1,334 @@
+# Story 3.7: Secure Defaults - URL Credential Redaction
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** Story 10.18 (Documentation Accuracy - users must understand current state first)
+
+---
+
+## Context / Background
+
+An external audit identified that fapilog's documentation promises "URL credentials are always scrubbed" but this is only true when:
+1. Using `preset="production"`, OR
+2. Explicitly configuring the `url_credentials` redactor
+
+Users who don't use a preset (the default) have **no credential protection**.
+
+**Industry Analysis:**
+
+| Library | Default Credential Handling |
+|---------|----------------------------|
+| **Sentry** | Secure by default - automatic credential filtering always on |
+| **Django** | Secure in production - enabled when DEBUG=False |
+| **Structlog** | Opt-in via processors |
+| **Loguru** | Opt-in (diagnose=True can leak secrets) |
+
+**OWASP Guidance:** Credentials should not appear in logs by default.
+
+**Fapilog Position:** Best-in-class library should be secure by default where it doesn't break functionality. URL credential scrubbing is:
+- Low-risk operation (only affects output format)
+- Doesn't break functionality
+- Prevents accidental credential leakage
+- Aligns with Sentry's approach (industry leader)
+
+**Decision:** Enable `url_credentials` redactor by default immediately. A phased approach with deprecation warnings delays security protection and adds complexity. Users who need raw URLs can opt-out explicitly.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Enable `url_credentials` redactor by default (even without preset)
+- Update documentation to reflect new default
+- Provide opt-out mechanism for edge cases
+- Update changelog with security enhancement
+
+### Out of Scope
+
+- Enabling `field_mask` or `regex_mask` by default (requires user-specific configuration)
+- Changing other security defaults
+- Breaking existing preset behavior
+- Deprecation warnings (immediate enable, not phased)
+
+---
+
+## Acceptance Criteria
+
+### AC1: Default Enabled Immediately
+
+**Description:** The `url_credentials` redactor is enabled by default when no redactors are explicitly configured.
+
+**Validation:**
+```python
+import fapilog
+
+# With no preset, no explicit redactor config
+logger = fapilog.get_logger()
+logger.info("login", url="https://alice:secret@api.example.com/auth")
+
+# Output should have URL scrubbed:
+# {"message": "login", "metadata": {"url": "https://api.example.com/auth"}, ...}
+```
+
+### AC2: Opt-Out Mechanism
+
+**Description:** Users can explicitly disable URL credential redaction if needed.
+
+**Validation:**
+```python
+# Option 1: Empty redactors list
+fapilog.configure(redactors=[])  # Explicitly no redactors
+
+# Option 2: Environment variable
+# FAPILOG_CORE__REDACTORS=[]
+
+# Option 3: Config file
+# core:
+#   redactors: []
+
+# After opt-out, URLs are preserved:
+logger.info("debug", url="https://user:pass@example.com")
+# {"message": "debug", "metadata": {"url": "https://user:pass@example.com"}, ...}
+```
+
+### AC3: Preset Behavior Unchanged
+
+**Description:** Presets continue to work as documented - `production` has full redaction, others have their defined behavior.
+
+**Validation:**
+```python
+# Production preset still has all redactors
+fapilog.configure(preset="production")
+# redactors = ["field_mask", "regex_mask", "url_credentials"]
+
+# Dev preset explicitly opts out (documented choice)
+fapilog.configure(preset="dev")
+# redactors = []  # Explicit opt-out for development visibility
+
+# FastAPI preset explicitly opts out
+fapilog.configure(preset="fastapi")
+# redactors = []  # Explicit opt-out for API debugging
+
+# Minimal preset explicitly opts out
+fapilog.configure(preset="minimal")
+# redactors = []  # Explicit opt-out for minimal overhead
+```
+
+### AC4: Documentation Updated
+
+**Description:** Documentation reflects the new secure default behavior.
+
+**Validation:**
+- `docs/redaction-guarantees.md` updated: "URL credentials are scrubbed by default"
+- `docs/user-guide/redaction-guarantee.md` updated with new default
+- `docs/user-guide/reliability-defaults.md` updated with new default
+- Changelog documents the security enhancement
+- Migration guide for users who need to opt-out
+
+### AC5: Test Coverage
+
+**Description:** Tests verify the new default behavior and opt-out mechanism.
+
+**Validation:**
+- Test: default config has url_credentials enabled
+- Test: explicit empty redactors disables all redaction
+- Test: presets override default behavior
+- Test: URL scrubbing actually works with default config
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/settings.py (MODIFIED - add default url_credentials)
+src/fapilog/core/presets.py (MODIFIED - ensure presets override default)
+docs/redaction-guarantees.md (MODIFIED - update default behavior)
+docs/user-guide/redaction-guarantee.md (MODIFIED - update default behavior)
+docs/user-guide/reliability-defaults.md (MODIFIED - document new default)
+tests/unit/test_default_redaction.py (NEW)
+tests/integration/test_secure_defaults.py (NEW)
+```
+
+### Default Configuration Logic
+
+```python
+# In settings.py or configuration resolution
+
+def resolve_redactors(user_config: dict | None, preset: str | None) -> list[str]:
+    """Resolve redactor configuration with secure defaults.
+
+    Priority:
+    1. Explicit user configuration (including empty list)
+    2. Preset configuration
+    3. Secure default (url_credentials only)
+    """
+    if user_config is not None and "redactors" in user_config:
+        # User explicitly configured - respect their choice
+        return user_config["redactors"]
+
+    if preset:
+        # Preset overrides default
+        return get_preset(preset).get("core", {}).get("redactors", [])
+
+    # No explicit config, no preset - apply secure default
+    return ["url_credentials"]
+```
+
+### Preset Updates
+
+Presets that currently have no redactors should explicitly set `redactors: []` to indicate this is an intentional choice, not relying on (now changed) defaults:
+
+```python
+# In presets.py
+
+PRESETS = {
+    "dev": {
+        "core": {
+            "redactors": [],  # Explicit opt-out for development visibility
+            # ... other settings
+        }
+    },
+    "fastapi": {
+        "core": {
+            "redactors": [],  # Explicit opt-out for API debugging
+            # ... other settings
+        }
+    },
+    "minimal": {
+        "core": {
+            "redactors": [],  # Explicit opt-out for minimal overhead
+        }
+    },
+    "production": {
+        "core": {
+            "redactors": ["field_mask", "regex_mask", "url_credentials"],
+            # ... other settings
+        }
+    },
+}
+```
+
+---
+
+## Tasks
+
+- [ ] Update `resolve_redactors()` to include url_credentials by default
+- [ ] Ensure presets explicitly set `redactors: []` where they opt out
+- [ ] Update `docs/redaction-guarantees.md`
+- [ ] Update `docs/user-guide/reliability-defaults.md`
+- [ ] Add migration guide section for users who need to opt-out
+- [ ] Update changelog with security enhancement
+- [ ] Add unit tests for default behavior
+- [ ] Add integration tests for end-to-end URL scrubbing
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_default_redaction.py` (NEW)
+  - `test_default_config_enables_url_credentials`
+  - `test_explicit_empty_redactors_disables_all`
+  - `test_preset_overrides_default`
+  - `test_dev_preset_opts_out`
+  - `test_fastapi_preset_opts_out`
+  - `test_minimal_preset_opts_out`
+  - `test_production_preset_has_all_redactors`
+
+### Integration Tests
+
+- `tests/integration/test_secure_defaults.py` (NEW)
+  - `test_url_credentials_scrubbed_by_default`
+  - `test_opt_out_preserves_urls`
+  - `test_preset_redaction_behavior`
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] url_credentials enabled by default
+- [ ] Presets explicitly define redactor behavior
+- [ ] Opt-out mechanism works
+- [ ] All tests pass
+
+### Quality Assurance
+
+- [ ] `ruff check` passes
+- [ ] `ruff format --check` passes
+- [ ] `mypy` passes
+- [ ] Test coverage >= 90% on changed lines
+
+### Documentation
+
+- [ ] `redaction-guarantees.md` updated
+- [ ] `reliability-defaults.md` updated
+- [ ] Migration guide for opt-out
+- [ ] Changelog updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Breaking change for users with tests asserting on URL format
+   - **Mitigation:** Clear changelog; opt-out mechanism available; behavior aligns with industry expectations
+
+2. **Risk:** Performance impact from always running url_credentials
+   - **Mitigation:** Benchmark shows negligible impact; regex is efficient
+
+3. **Risk:** Users confused by behavior change
+   - **Mitigation:** Clear changelog; migration guide; consistent with industry (Sentry)
+
+### Rollback Plan
+
+If issues occur:
+1. Set `FAPILOG_CORE__REDACTORS=[]` as immediate workaround
+2. Release patch reverting default if widespread issues
+3. Default behavior can be toggled via configuration
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 10.18 - Documentation Accuracy (users must understand current state)
+- **Related:** Story 3.5 - Plugin Allowlist Secure Default (similar pattern)
+- **Related:** Story 4.47 - Redaction Defaults Alignment (production preset redaction)
+
+---
+
+## Security Considerations
+
+**Why this matters:**
+
+1. **Credential leakage is common** - Developers often log URLs without realizing they contain credentials
+2. **Low-risk mitigation** - URL scrubbing doesn't break functionality
+3. **Industry standard** - Sentry enables this by default
+4. **Compliance** - Helps meet PCI-DSS, GDPR requirements for credential handling
+
+**Example prevented:**
+```python
+# Developer accidentally logs URL with credentials
+logger.info("Connecting to database", url=db_url)
+
+# Without url_credentials: credentials in logs
+# {"url": "postgres://admin:secret123@db.example.com/mydb"}
+
+# With url_credentials: credentials scrubbed
+# {"url": "postgres://db.example.com/mydb"}
+```
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-01-19 | Initial draft based on audit findings and industry analysis | Claude |
+| 2025-01-19 | Revised to enable url_credentials immediately (not phased) | Claude |

--- a/docs/stories/4.48.fallback-redaction-list-recursion.md
+++ b/docs/stories/4.48.fallback-redaction-list-recursion.md
@@ -1,0 +1,330 @@
+# Story 4.48: Fallback Redaction List Recursion
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** Story 4.46 (Fallback Sink PII Protection) - Complete
+
+---
+
+## Context / Background
+
+The GPT-5.2 audit identified a security gap in the fallback minimal redaction implemented in Story 4.46:
+
+> "fallback 'minimal redaction' explicitly does not redact lists (`src/fapilog/plugins/sinks/fallback.py`) → secrets in arrays can leak to stderr during sink failures."
+
+**Current implementation in `src/fapilog/plugins/sinks/fallback.py:14-34`:**
+
+```python
+def minimal_redact(payload: dict[str, Any]) -> dict[str, Any]:
+    """Apply minimal redaction for fallback safety.
+
+    Masks values of keys that match FALLBACK_SENSITIVE_FIELDS (case-insensitive).
+    Recursively processes nested dictionaries but not lists.  # <-- THE GAP
+    ...
+    """
+    result: dict[str, Any] = {}
+    for key, value in payload.items():
+        if key.lower() in FALLBACK_SENSITIVE_FIELDS:
+            result[key] = "***"
+        elif isinstance(value, dict):
+            result[key] = minimal_redact(value)
+        else:
+            result[key] = value  # Lists pass through unredacted!
+    return result
+```
+
+**Problem:**
+
+A payload like:
+```python
+{"users": [{"password": "secret123", "name": "alice"}, {"token": "abc"}]}
+```
+
+Would have `password` and `token` **leak to stderr** because they're inside a list.
+
+**Why this matters:**
+
+- Secrets in arrays are common (user lists, batch API responses, audit logs)
+- The fallback path is specifically for failure scenarios
+- Leaking secrets during failures is worse than losing the log entry
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Extend `minimal_redact` to recurse into lists
+- Handle arbitrarily nested list/dict combinations
+- Add protection against infinite recursion (depth limit)
+- Add tests for list-based redaction scenarios
+
+### Out of Scope
+
+- Changing the sensitive field list (covered by 4.46)
+- Performance optimization (fallback is rare path)
+- Handling non-JSON-serializable types in lists
+
+---
+
+## Acceptance Criteria
+
+### AC1: List Contents Are Recursively Redacted
+
+**Description:** When a list contains dicts with sensitive fields, those fields are masked.
+
+**Validation:**
+```python
+payload = {"users": [{"password": "secret", "name": "alice"}]}
+result = minimal_redact(payload)
+assert result == {"users": [{"password": "***", "name": "alice"}]}
+```
+
+### AC2: Nested Lists Are Handled
+
+**Description:** Lists within lists containing dicts are also redacted.
+
+**Validation:**
+```python
+payload = {"matrix": [[{"token": "abc"}], [{"api_key": "xyz"}]]}
+result = minimal_redact(payload)
+assert result == {"matrix": [[{"token": "***"}], [{"api_key": "***"}]]}
+```
+
+### AC3: Mixed Nesting Works Correctly
+
+**Description:** Arbitrary combinations of dicts and lists are handled.
+
+**Validation:**
+```python
+payload = {
+    "data": {
+        "items": [
+            {"credentials": {"password": "secret", "username": "admin"}},
+            {"api_key": "sk-xxx", "public": True}
+        ]
+    }
+}
+result = minimal_redact(payload)
+assert result["data"]["items"][0]["credentials"]["password"] == "***"
+assert result["data"]["items"][1]["api_key"] == "***"
+assert result["data"]["items"][1]["public"] is True
+```
+
+### AC4: Non-Dict List Items Preserved
+
+**Description:** Lists containing primitives (strings, numbers) are preserved unchanged.
+
+**Validation:**
+```python
+payload = {"tags": ["prod", "critical"], "counts": [1, 2, 3]}
+result = minimal_redact(payload)
+assert result == {"tags": ["prod", "critical"], "counts": [1, 2, 3]}
+```
+
+### AC5: Depth Limit Prevents Stack Overflow
+
+**Description:** Extremely deep nesting doesn't cause stack overflow.
+
+**Validation:**
+```python
+# Create deeply nested structure (100+ levels)
+deep = {"password": "secret"}
+for _ in range(150):
+    deep = {"nested": [deep]}
+
+# Should not raise RecursionError, should redact up to limit
+result = minimal_redact(deep)
+# Redaction stops at depth limit, preserving structure
+```
+
+### AC6: Contract Test - Fallback Uses Updated Function
+
+**Description:** The fallback handler uses the updated `minimal_redact` function.
+
+**Validation:**
+```python
+# Integration test: sink failure with list-containing payload
+async def test_fallback_redacts_lists_in_payload(capsys):
+    payload = {"users": [{"password": "secret"}]}
+    await handle_sink_write_failure(
+        payload,
+        sink=mock_sink,
+        error=Exception("test"),
+        serialized=False,
+        redact_mode="minimal",
+    )
+    captured = capsys.readouterr()
+    assert '"password":"***"' in captured.err
+    assert "secret" not in captured.err
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/plugins/sinks/fallback.py (MODIFIED - extend minimal_redact)
+tests/unit/test_sink_fallback.py (MODIFIED - add list redaction tests)
+tests/integration/test_sink_fallback_signaling.py (MODIFIED - add list scenario)
+```
+
+### Key Code Change
+
+```python
+# src/fapilog/plugins/sinks/fallback.py
+
+_MAX_REDACT_DEPTH = 32  # Prevent stack overflow on pathological input
+
+
+def minimal_redact(
+    payload: dict[str, Any],
+    *,
+    _depth: int = 0,
+) -> dict[str, Any]:
+    """Apply minimal redaction for fallback safety.
+
+    Masks values of keys that match FALLBACK_SENSITIVE_FIELDS (case-insensitive).
+    Recursively processes nested dictionaries AND lists.
+
+    Args:
+        payload: The dictionary to redact.
+        _depth: Internal recursion depth counter (do not set manually).
+
+    Returns:
+        A new dictionary with sensitive fields masked as "***".
+    """
+    if _depth >= _MAX_REDACT_DEPTH:
+        return payload  # Stop recursion at depth limit
+
+    result: dict[str, Any] = {}
+    for key, value in payload.items():
+        if key.lower() in FALLBACK_SENSITIVE_FIELDS:
+            result[key] = "***"
+        elif isinstance(value, dict):
+            result[key] = minimal_redact(value, _depth=_depth + 1)
+        elif isinstance(value, list):
+            result[key] = _redact_list(value, _depth=_depth + 1)
+        else:
+            result[key] = value
+    return result
+
+
+def _redact_list(items: list[Any], *, _depth: int) -> list[Any]:
+    """Recursively redact sensitive fields within list items."""
+    if _depth >= _MAX_REDACT_DEPTH:
+        return items  # Stop recursion at depth limit
+
+    result: list[Any] = []
+    for item in items:
+        if isinstance(item, dict):
+            result.append(minimal_redact(item, _depth=_depth + 1))
+        elif isinstance(item, list):
+            result.append(_redact_list(item, _depth=_depth + 1))
+        else:
+            result.append(item)
+    return result
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [ ] Add `_MAX_REDACT_DEPTH` constant
+- [ ] Add `_depth` parameter to `minimal_redact`
+- [ ] Implement `_redact_list` helper function
+- [ ] Update `minimal_redact` to handle list values
+
+### Phase 2: Testing
+
+- [ ] Add unit tests for list redaction scenarios
+- [ ] Add test for nested list/dict combinations
+- [ ] Add test for depth limit protection
+- [ ] Add integration test for fallback with list payloads
+
+### Phase 3: Documentation
+
+- [ ] Update docstring to reflect list handling
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_sink_fallback.py`
+  - `test_minimal_redact_handles_list_of_dicts`
+  - `test_minimal_redact_handles_nested_lists`
+  - `test_minimal_redact_handles_mixed_nesting`
+  - `test_minimal_redact_preserves_primitive_lists`
+  - `test_minimal_redact_depth_limit_prevents_overflow`
+
+### Integration Tests
+
+- `tests/integration/test_sink_fallback_signaling.py`
+  - `test_fallback_redacts_sensitive_fields_in_lists`
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] `minimal_redact` recurses into lists
+- [ ] Depth limit protects against stack overflow
+- [ ] All acceptance criteria implemented
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] Integration tests passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Function docstring updated
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Performance impact from list recursion
+   - **Mitigation:** Fallback is rare path; depth limit bounds worst case
+
+2. **Risk:** Breaking existing behavior for edge cases
+   - **Mitigation:** Only adds functionality; existing dict-only redaction unchanged
+
+3. **Risk:** Memory usage on large list payloads
+   - **Mitigation:** Depth limit prevents unbounded recursion; fallback payloads typically small
+
+### Rollback Plan
+
+If issues occur:
+1. Revert the list handling changes
+2. Original dict-only redaction still functional
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 4.46 - Fallback Sink PII Protection (provides foundation)
+- **Related:** Story 4.45 - Webhook secure defaults (security theme)
+- **Related:** Story 3.5 - Plugin allowlist secure default (security defaults theme)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-19 | Initial draft from GPT-5.2 audit follow-up | Claude |


### PR DESCRIPTION
## Summary

Adds 8 new stories from the GPT-5.2 schema/security audit and updates development guidelines to prevent future schema drift issues.

## Changes

- `docs/stories/1.26.canonical-log-schema-v1.1.md` (new)
- `docs/stories/1.27.enricher-pipeline-schema-alignment.md` (new)
- `docs/stories/1.28.serialization-path-cleanup.md` (new)
- `docs/stories/1.29.backpressure-startup-validation.md` (new)
- `docs/stories/3.7.secure-defaults-url-credential-redaction.md` (new)
- `docs/stories/4.48.fallback-redaction-list-recursion.md` (new)
- `docs/stories/10.17.schema-contract-test-infrastructure.md` (new)
- `docs/stories/10.18.documentation-accuracy-redaction-envelope.md` (new)
- `.claude/skills/code-review/SKILL.md` (modified)
- `.claude/skills/story-creation/SKILL.md` (modified)
- `CLAUDE.md` (modified)

## Stories Added

| Story | Priority | Description |
|-------|----------|-------------|
| 1.26 | High | Canonical log schema v1.1 definition |
| 1.27 | High | Enricher pipeline schema alignment |
| 1.28 | High | Serialization path cleanup (removes exception-driven hot path) |
| 1.29 | Medium | Backpressure startup validation warning |
| 3.7 | Medium | Secure defaults - URL credential redaction |
| 4.48 | High | Fallback redaction list recursion (security fix) |
| 10.17 | Medium | Schema contract test infrastructure |
| 10.18 | Critical | Documentation accuracy - redaction and envelope |

## Guidelines Added

Contract test guidelines added to prevent schema drift:
- Producer/consumer alignment checks
- Warning signs to flag during code review
- Testing principles for internal interfaces

## Test Plan

- [x] All stories reviewed and marked Ready
- [x] Pre-commit hooks pass