### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,44 +4,66 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
-- **Breaking**: `fastapi` preset now enables redaction by default (`field_mask`, `regex_mask`, `url_credentials`), matching `production` preset security posture (Story 10.21). Use `dev` preset for debugging or explicitly set `redactors=[]` to disable.
-- **Docs**: Added performance benchmarks page with methodology, results, and reproduction instructions (Story 10.20).
-- **Breaking**: Log schema v1.1 with semantic field groupings (`context`, `diagnostics`, `data`); `metadata` renamed to `data`, `correlation_id` moved to `context.correlation_id`, timestamp now RFC3339 string (Story 1.26). See `docs/schema-migration-v1.0-to-v1.1.md`.
-- **Breaking**: Enrichers now return nested dicts targeting semantic groups (`{"diagnostics": {...}}`) instead of flat dicts; `enrich_parallel()` uses deep-merge; `LogEvent` model updated to v1.1 schema with `context`, `diagnostics`, `data` fields replacing `metadata`, `correlation_id`, `component` (Story 1.27).
-- **Changed**: Serialization path cleanup - `serialize_envelope()` now trusts upstream v1.1 schema compliance and only fails for non-JSON-serializable objects; exception-driven fallback is now truly exceptional, not the normal path; `strict_envelope_mode` now works correctly (Story 1.28).
-- **Tooling**: Aligned ruff, black, and mypy target versions with `requires-python = ">=3.10"`; added pre-commit hook to enforce Python 3.10+ (Story 10.16).
-- **Breaking**: Production preset now includes `regex_mask` redactor for broader secret protection; users may see additional fields masked (Story 4.47).
-- **Docs**: Added `redaction-guarantee.md` documenting exact redaction behavior per preset; fixed inaccurate claims in `reliability-defaults.md` (Story 4.47).
-- **Tooling**: Added automated changelog generation with git-cliff and conventional commit linting via pre-commit hooks; release workflow now validates changelog entries match tagged version (Story 10.12).
-- **Docs**: Documented same-thread backpressure behavior where `drop_on_full=False` cannot be honored; enhanced diagnostic warning with `drop_on_full_setting` field (Story 1.19).
-- **Performance**: Cache sampling rate, filter config, and error dedupe window at logger initialization to avoid `Settings()` instantiation on every log call (Story 1.23).
-- **Changed**: Internal diagnostics now write to stderr by default (Unix convention); add `core.diagnostics_output="stdout"` for backward compatibility (Story 6.11).
-- **Security**: WebhookSink now supports HMAC-SHA256 signatures (`signature_mode="hmac"`) instead of sending secrets in headers; legacy header mode emits deprecation warning (Story 4.42).
-- **Security**: External plugins now blocked by default; use `plugins.allow_external=true` or `plugins.allowlist` for explicit opt-in (Story 3.5). This is a **breaking change** for users of external entry point plugins.
-- **Fixed**: Benchmark script key alignment in `derive_verdicts()` to match actual output keys from `benchmark()` (Story 10.11).
-- Added CI smoke test for benchmark script to catch future regressions.
-- **Fixed**: Strict mode serialization drops now correctly increment the `dropped` counter and record metrics; previously these drops were silently unaccounted (Story 1.24).
-- Fixed extras documentation accuracy: removed non-existent extras (enterprise, loki, cloud, siem), documented all real extras with descriptions.
-- **Security**: Bumped orjson minimum version to 3.9.15 (CVE-2024-27454 fix).
-- Added `SECURITY.md` with vulnerability reporting guidance.
-- Added `CODE_OF_CONDUCT.md` (Contributor Covenant).
-- Fixed Python version badge in README (3.8+ → 3.10+).
-- Added production tip callout in README for `preset="production"` guidance.
-- Updated plugin group documentation in architecture docs.
-- Added CloudWatch sink size limit documentation comment.
-- Updated `CONTRIBUTING.md` with correct Python version, repo name, and governance file references.
-- Added `SinkWriteError` for sinks to signal write failures to the core pipeline; core now catches these errors (and `False` returns) to trigger fallback and circuit breaker behavior (Story 4.41).
+## [0.4.0] - 2026-01-19
+
+### Breaking Changes
+
+- `fastapi` preset now enables redaction by default (`field_mask`, `regex_mask`, `url_credentials`), matching `production` preset security posture (Story 10.21). Use `dev` preset for debugging or explicitly set `redactors=[]` to disable.
+- Log schema v1.1 with semantic field groupings (`context`, `diagnostics`, `data`); `metadata` renamed to `data`, `correlation_id` moved to `context.correlation_id`, timestamp now RFC3339 string (Story 1.26). See `docs/schema-migration-v1.0-to-v1.1.md`.
+- Enrichers now return nested dicts targeting semantic groups (`{"diagnostics": {...}}`) instead of flat dicts; `enrich_parallel()` uses deep-merge; `LogEvent` model updated to v1.1 schema with `context`, `diagnostics`, `data` fields replacing `metadata`, `correlation_id`, `component` (Story 1.27).
+- Production preset now includes `regex_mask` redactor for broader secret protection; users may see additional fields masked (Story 4.47).
+- External plugins now blocked by default; use `plugins.allow_external=true` or `plugins.allowlist` for explicit opt-in (Story 3.5).
+
+### Added
+
+- Fluent builder API (`LoggerBuilder`, `AsyncLoggerBuilder`) for chainable logger configuration with IDE autocomplete support.
+- Pretty console output (`stdout_pretty`) and `format` selection for stdout logging.
+- One-liner FastAPI setup helpers (`setup_logging`, `get_request_logger`) with lifespan support.
+- Default log-level selection based on TTY/CI when no preset or explicit log level is set.
+- Stderr fallback for sink write failures with optional diagnostics warnings.
+- `SinkWriteError` for sinks to signal write failures to the core pipeline; core now catches these errors (and `False` returns) to trigger fallback and circuit breaker behavior (Story 4.41).
+- CI smoke test for benchmark script to catch future regressions.
+- CI timeout multiplier (`CI_TIMEOUT_MULTIPLIER`) with `get_test_timeout()` helper for timing-sensitive tests on slow CI runners.
+- `SECURITY.md` with vulnerability reporting guidance.
+- `CODE_OF_CONDUCT.md` (Contributor Covenant).
+- Production tip callout in README for `preset="production"` guidance.
+
+### Changed
+
+- Serialization path cleanup - `serialize_envelope()` now trusts upstream v1.1 schema compliance and only fails for non-JSON-serializable objects; exception-driven fallback is now truly exceptional, not the normal path; `strict_envelope_mode` now works correctly (Story 1.28).
+- Internal diagnostics now write to stderr by default (Unix convention); add `core.diagnostics_output="stdout"` for backward compatibility (Story 6.11).
 - Updated built-in sinks (`stdout_json`, `stdout_pretty`, `rotating_file`, `audit`) to raise `SinkWriteError` instead of swallowing errors, enabling proper fallback handling.
 - Updated `BaseSink` protocol documentation to reflect the new error signaling contract.
-- Split large test files into focused modules: `test_error_handling.py` → 4 files, `test_high_performance_lru_cache.py` → 3 files, `test_logger_pipeline.py` → 3 files, `test_rotating_file_sink.py` → 3 files (total test count preserved at 1704).
-- Added CI timeout multiplier (`CI_TIMEOUT_MULTIPLIER`) with `get_test_timeout()` helper for timing-sensitive tests on slow CI runners.
+- Aligned ruff, black, and mypy target versions with `requires-python = ">=3.10"`; added pre-commit hook to enforce Python 3.10+ (Story 10.16).
 - Standardized Hypothesis property test settings: removed per-test `max_examples` overrides so all tests respect `HYPOTHESIS_MAX_EXAMPLES` env var.
-- Added fluent builder API (`LoggerBuilder`, `AsyncLoggerBuilder`) for chainable logger configuration with IDE autocomplete support.
-- Added pretty console output (`stdout_pretty`) and `format` selection for stdout logging.
-- Added one-liner FastAPI setup helpers (`setup_logging`, `get_request_logger`) with lifespan support.
-- Added default log-level selection based on TTY/CI when no preset or explicit log level is set.
-- Added stderr fallback for sink write failures with optional diagnostics warnings.
-- **Security**: Fallback minimal redaction now recurses into lists, preventing secrets in arrays from leaking to stderr during sink failures (Story 4.48).
+- Split large test files into focused modules: `test_error_handling.py` → 4 files, `test_high_performance_lru_cache.py` → 3 files, `test_logger_pipeline.py` → 3 files, `test_rotating_file_sink.py` → 3 files (total test count preserved at 1704).
+
+### Fixed
+
+- Benchmark script key alignment in `derive_verdicts()` to match actual output keys from `benchmark()` (Story 10.11).
+- Strict mode serialization drops now correctly increment the `dropped` counter and record metrics; previously these drops were silently unaccounted (Story 1.24).
+- Extras documentation accuracy: removed non-existent extras (enterprise, loki, cloud, siem), documented all real extras with descriptions.
+- Python version badge in README (3.8+ → 3.10+).
+- Plugin group documentation in architecture docs.
+- `CONTRIBUTING.md` with correct Python version, repo name, and governance file references.
+
+### Security
+
+- WebhookSink now supports HMAC-SHA256 signatures (`signature_mode="hmac"`) instead of sending secrets in headers; legacy header mode emits deprecation warning (Story 4.42).
+- Bumped orjson minimum version to 3.9.15 (CVE-2024-27454 fix).
+- Fallback minimal redaction now recurses into lists, preventing secrets in arrays from leaking to stderr during sink failures (Story 4.48).
+
+### Performance
+
+- Cache sampling rate, filter config, and error dedupe window at logger initialization to avoid `Settings()` instantiation on every log call (Story 1.23).
+
+### Documentation
+
+- Added performance benchmarks page with methodology, results, and reproduction instructions (Story 10.20).
+- Added `redaction-guarantee.md` documenting exact redaction behavior per preset; fixed inaccurate claims in `reliability-defaults.md` (Story 4.47).
+- Documented same-thread backpressure behavior where `drop_on_full=False` cannot be honored; enhanced diagnostic warning with `drop_on_full_setting` field (Story 1.19).
+- Added automated changelog generation with git-cliff and conventional commit linting via pre-commit hooks; release workflow now validates changelog entries match tagged version (Story 10.12).
+- Added CloudWatch sink size limit documentation comment.
 
 ## [0.3.5] - 2026-01-01
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [![PyPI Version](https://img.shields.io/pypi/v/fapilog.svg?style=flat-square&color=008080&logo=pypi&logoColor=white)](https://pypi.org/project/fapilog/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-008080?style=flat-square&logo=apache&logoColor=white)](https://opensource.org/licenses/Apache-2.0)
 
+> **Save evaluation time:** [Independent technical assessments](docs/audits/) are available from multiple AI reviewers.
+
 ## Why fapilog?
 
 - **Non‑blocking under slow sinks**: Background worker, queue, and batching keep your app responsive when disk/network collectors slow down.
@@ -105,7 +107,7 @@ logger = get_logger(preset="minimal")
 |--------|-----------|--------------|-----------|------------|----------|
 | `dev` | DEBUG | No | No | 1 (immediate) | Local development |
 | `production` | INFO | Yes (50MB rotation) | Yes (9 fields) | 100 | Production deployments |
-| `fastapi` | INFO | No | No | 50 | FastAPI/async apps |
+| `fastapi` | INFO | No | Yes (9 fields) | 50 | FastAPI/async apps |
 | `minimal` | INFO | No | No | Default | Backwards compatible |
 
 See [docs/user-guide/configuration.md](docs/user-guide/configuration.md) for full preset details.
@@ -278,7 +280,7 @@ Fapilog features an extensible plugin ecosystem:
 - **HTTP**: `http` and `webhook` sinks with retry, batching, and HMAC signing
 - **Cloud**: `cloudwatch` (AWS, requires `boto3`), `loki` (Grafana)
 - **Database**: `postgres` (requires `asyncpg`)
-- **Compliance**: `audit` sink with integrity checks, `routing` for level-based fan-out
+- **Routing**: `routing` for level-based fan-out
 
 ### **Processor Plugins**
 

--- a/scripts/check_plugin_versions.py
+++ b/scripts/check_plugin_versions.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import List
 
 # Current released version (update on release)
-CURRENT_VERSION = "0.3.5"
+CURRENT_VERSION = "0.4.0"
 
 # Pattern to match min_fapilog_version in plugin metadata
 VERSION_PATTERN = re.compile(r'"min_fapilog_version":\s*"([^"]+)"')


### PR DESCRIPTION
## Summary

Release 0.4.0 with breaking changes, new features, and security improvements.

## Changes

- `CHANGELOG.md` - Release notes for 0.4.0
- `README.md` - Fixed fastapi preset table, added audit links callout
- `scripts/check_plugin_versions.py` - Updated CURRENT_VERSION

## Highlights

### Breaking Changes
- `fastapi` preset now enables redaction by default
- Log schema v1.1 with semantic field groupings
- Enrichers return nested dicts targeting semantic groups
- External plugins blocked by default

### Security
- WebhookSink HMAC-SHA256 signatures
- orjson CVE-2024-27454 fix
- Fallback redaction recurses into lists

### Added
- Fluent builder API
- FastAPI one-liner setup helpers
- Pretty console output

See [CHANGELOG.md](CHANGELOG.md) for full details.