### PR TITLE
fix(tests): correct schema path and version check test

### DIFF
--- a/tests/contract/test_schema_validation.py
+++ b/tests/contract/test_schema_validation.py
@@ -2,7 +2,7 @@
 JSON Schema validation tests for pipeline output.
 
 These tests validate that serialized log envelopes conform to the published
-JSON schema (jsonschema/log_envelope_v1.json). If these tests fail, the
+JSON schema (schemas/log_envelope_v1.json). If these tests fail, the
 pipeline output has drifted from the documented schema.
 """
 

--- a/tests/integration/test_envelope_serialization_roundtrip.py
+++ b/tests/integration/test_envelope_serialization_roundtrip.py
@@ -103,7 +103,7 @@ class TestJsonSchemaValidation:
         """Serialized envelope should pass JSON schema validation."""
         jsonschema = pytest.importorskip("jsonschema")
 
-        schema_path = Path(__file__).parents[2] / "jsonschema" / "log_envelope_v1.json"
+        schema_path = Path(__file__).parents[2] / "schemas" / "log_envelope_v1.json"
         schema = json.loads(schema_path.read_text())
 
         envelope = build_envelope(
@@ -122,7 +122,7 @@ class TestJsonSchemaValidation:
         """Envelope with all optional fields should validate."""
         jsonschema = pytest.importorskip("jsonschema")
 
-        schema_path = Path(__file__).parents[2] / "jsonschema" / "log_envelope_v1.json"
+        schema_path = Path(__file__).parents[2] / "schemas" / "log_envelope_v1.json"
         schema = json.loads(schema_path.read_text())
 
         try:

--- a/tests/unit/test_check_plugin_versions.py
+++ b/tests/unit/test_check_plugin_versions.py
@@ -209,7 +209,7 @@ PLUGIN_METADATA = {"compatibility": {"min_fapilog_version": "0.3.0"}}
         plugins_dir = tmp_path / "src" / "fapilog" / "plugins"
         plugins_dir.mkdir(parents=True)
         (plugins_dir / "invalid.py").write_text("""
-PLUGIN_METADATA = {"compatibility": {"min_fapilog_version": "0.4.0"}}
+PLUGIN_METADATA = {"compatibility": {"min_fapilog_version": "99.0.0"}}
 """)
 
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

Fixes 3 test failures in the v0.4.0 release CI.

## Changes

- `tests/integration/test_envelope_serialization_roundtrip.py` - Update `jsonschema/` to `schemas/`
- `tests/contract/test_schema_validation.py` - Update comment to reflect correct path
- `tests/unit/test_check_plugin_versions.py` - Use `99.0.0` instead of `0.4.0` for future version test

## Root Cause

1. Schema directory was renamed from `jsonschema/` to `schemas/` but integration tests weren't updated
2. Plugin version test used `0.4.0` as a "future" version, but that's now the current version