### PR TITLE
docs: fix API documentation issues from spike testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ logger = get_logger(preset="minimal")
 | `fastapi` | INFO | No | Yes (9 fields) | 50 | FastAPI/async apps |
 | `minimal` | INFO | No | No | Default | Backwards compatible |
 
+> **Security Note:** By default, only URL credentials (`user:pass@host`) are stripped. For full field redaction (passwords, API keys, tokens), use a preset like `production`/`fastapi` or configure redactors manually. See [redaction docs](docs/core-concepts/redaction.md).
+
 See [docs/user-guide/configuration.md](docs/user-guide/configuration.md) for full preset details.
 
 ### Sink routing by level

--- a/docs/core-concepts/redaction.md
+++ b/docs/core-concepts/redaction.md
@@ -1,34 +1,108 @@
 # Redaction
 
-
-
 Mask sensitive data before it reaches sinks.
+
+## Quick Start: Enable Full Redaction
+
+Use the `production` or `fastapi` preset for automatic redaction of passwords, API keys, tokens, and other sensitive fields:
+
+```python
+from fapilog import get_logger
+
+# Full redaction enabled: passwords, tokens, API keys masked automatically
+logger = get_logger(preset="production")
+logger.info("User login", password="secret123")  # password auto-redacted
+```
+
+Without a preset, only URL credentials are stripped by default (e.g., `user:pass@host` becomes `***:***@host`).
 
 ## Built-in redactors
 
-- **field-mask**: masks configured fields (from `core.sensitive_fields_policy`).
-- **regex-mask**: masks values matching sensitive patterns (default regex covers passwords, tokens, emails, etc.).
-- **url-credentials**: strips `user:pass@` credentials from URL-like strings.
+| Redactor | What it masks | Default |
+|----------|---------------|---------|
+| **url-credentials** | `user:pass@` in URL strings | Yes |
+| **field-mask** | Configured fields (password, api_key, etc.) | Preset only |
+| **regex-mask** | Values matching sensitive patterns | Preset only |
 
-## Defaults and configuration
+## Default behavior
 
-- Enabled by default: `core.enable_redactors=True`.
-- Default order: `core.redactors_order=["field-mask","regex-mask","url-credentials"]`.
-- Guardrails: `core.redaction_max_depth`, `core.redaction_max_keys_scanned` limit traversal.
+By default (no preset), only `url-credentials` is active:
 
-Override via env:
+```python
+logger = get_logger()  # Only URL credential stripping
+logger.info("Connecting", url="https://user:pass@api.example.com")
+# url becomes: https://***:***@api.example.com
+
+logger.info("Login", password="secret")  # NOT redacted without preset!
+```
+
+## Full redaction with presets
+
+The `production` and `fastapi` presets enable all three redactors with sensible defaults:
+
+```python
+logger = get_logger(preset="production")
+logger.info("Auth", password="secret", api_key="sk-123")
+# Both fields redacted: password="[REDACTED]", api_key="[REDACTED]"
+```
+
+Fields masked by `production`/`fastapi` presets:
+- password, api_key, token, secret
+- authorization, api_secret, private_key
+- ssn, credit_card
+
+## Manual configuration
+
+Enable full redaction without a preset:
+
+### Using the Builder API
+
+```python
+from fapilog import LoggerBuilder
+
+logger = (
+    LoggerBuilder()
+    .with_redaction(fields=["password", "api_key", "ssn"])
+    .with_redaction(patterns=["secret.*", "token.*"])
+    .build()
+)
+logger.info("Login", password="secret123")  # password=[REDACTED]
+```
+
+### Using Environment Variables
 
 ```bash
-export FAPILOG_CORE__ENABLE_REDACTORS=true
+export FAPILOG_CORE__REDACTORS='["field_mask","regex_mask","url_credentials"]'
 export FAPILOG_CORE__SENSITIVE_FIELDS_POLICY=password,api_key,secret,token
+```
+
+### Using Settings
+
+```python
+from fapilog import get_logger, Settings
+
+settings = Settings(
+    core={
+        "redactors": ["field_mask", "regex_mask", "url_credentials"],
+        "sensitive_fields_policy": ["password", "api_key", "secret"],
+    }
+)
+logger = get_logger(settings=settings)
+```
+
+## Guardrails
+
+Limit traversal depth for performance:
+
+```bash
 export FAPILOG_CORE__REDACTION_MAX_DEPTH=8
 export FAPILOG_CORE__REDACTION_MAX_KEYS_SCANNED=5000
 ```
 
 ## Usage notes
 
-- Redactors run after enrichment, before sinks.
-- Keep the order deterministic; regex runs after field masks by default.
-- If you disable redactors, sensitive fields will flow to sinks unmasked.
+- Redactors run after enrichment, before sinks
+- Order is deterministic: field-mask → regex-mask → url-credentials
+- Disabling redactors allows sensitive fields to reach sinks unmasked
 
-See also: plugins/redactors for implementation details.
+See also: [plugins/redactors](../plugins/redactors.md) for implementation details.


### PR DESCRIPTION
## Summary

Fixes documentation discrepancies discovered during spike testing of fapilog v0.4.0. Three issues were investigated:

1. **configure_logging() missing** - Function doesn't exist; docs now use `get_logger()`
2. **add_file() directory vs file path** - Working as designed (two different APIs)
3. **with_redaction() not enabling redaction** - Already fixed in code; docs now explain usage

## Changes

- `README.md` (modified) - Added security note about default redaction behavior
- `docs/contributing.md` (modified) - Replaced `configure_logging()` example with valid `process_request()` example
- `docs/core-concepts/redaction.md` (modified) - Complete rewrite with clearer structure and builder API docs

## Acceptance Criteria

- [x] Remove references to non-existent `configure_logging()` function
- [x] Document builder API for redaction (`with_redaction()`)
- [x] Clarify default redaction behavior (URL credentials only without preset)

## Test Plan

- [x] Documentation builds correctly
- [x] Code examples are valid and match actual API
- [x] No broken links introduced