### PR TITLE
docs: remove obsolete configure_logging() references

### DIFF
--- a/docs/documentation-guide-for-contributors.md
+++ b/docs/documentation-guide-for-contributors.md
@@ -50,11 +50,11 @@ Use the `@docs:` marker system to embed documentation directly in your source co
 Add `@docs:` markers directly in your Python docstrings:
 
 ````python
-async def configure_logging(level: str = "INFO") -> None:
+async def get_async_logger(name: str | None = None) -> AsyncLoggerFacade:
     """
-    Configure the logging system with the specified settings.
+    Get a configured async logger instance.
 
-    This function must be called before any logging operations can occur.
+    Returns a fully configured async logger ready for use.
     It sets up sinks, processors, and enrichers based on the provided configuration.
 
     @docs:use_cases
@@ -64,22 +64,21 @@ async def configure_logging(level: str = "INFO") -> None:
 
     @docs:examples
     ```python
-    from fapilog import configure_logging
+    from fapilog import get_async_logger
 
-    # Basic configuration
-    await configure_logging(level="DEBUG", format="pretty")
+    # Basic usage
+    logger = await get_async_logger()
 
-    # With custom sinks
-    await configure_logging(
-        level="INFO",
-        format="json",
-        sinks=["stdout", "file", "http"]
-    )
+    # With format
+    logger = await get_async_logger(format="pretty")
+
+    # With preset
+    logger = await get_async_logger(preset="dev")
     ```
 
     @docs:notes
     - All timestamps are emitted in **RFC3339 UTC format**
-    - Configuration is **immutable** after initialization
+    - Logger should be drained on shutdown with `await logger.drain()`
     - See [Logging Levels](../concepts/logging-levels.md) for details
     """
     pass
@@ -220,19 +219,16 @@ This function initializes the internal logging infrastructure by creating sink i
 **Good Example:**
 
 ```python
-from fapilog import configure_logging, LoggingSettings
+from fapilog import get_logger, Settings
 
 # Basic configuration
-settings = LoggingSettings(level="DEBUG", format="pretty")
-configure_logging(settings)
+logger = get_logger(format="pretty")
 
-# With custom sinks
-settings = LoggingSettings(
-    level="INFO",
-    sinks=["stdout", "file"],
-    file_path="/var/log/app.log"
+# With custom settings
+settings = Settings(
+    core={"log_level": "INFO", "sinks": ["stdout_json", "file"]},
 )
-configure_logging(settings)
+logger = get_logger(settings=settings)
 ```
 
 #### @docs: Examples Best Practices

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -111,8 +111,9 @@ Explain why this feature exists and what problems it solves.
 
 ```python
 # Copy-paste ready example
-from fapilog import configure_logging
-configure_logging()
+from fapilog import get_logger
+
+logger = get_logger()
 ```
 ````
 
@@ -143,34 +144,35 @@ For each API function, class, or method:
 
 **Example Structure:**
 ```markdown
-## configure_logging()
+## get_logger()
 
-**Configure the Fapilog logging system with the given settings.**
+**Get a configured sync logger instance.**
 
 ### Purpose
 
-Initialize the logging system with sinks, enrichers, and middleware as configured.
+Create and return a configured logger with sinks, enrichers, and processors.
 
 ### Parameters
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `settings` | `LoggingSettings` | `None` | Complete configuration object |
-| `app` | `Any` | `None` | FastAPI app instance |
+| `name` | `str` | `None` | Optional logger name |
+| `preset` | `str` | `None` | Built-in preset (dev, production, fastapi, minimal) |
+| `format` | `str` | `None` | Output format (json, pretty, auto) |
+| `settings` | `Settings` | `None` | Complete configuration object |
 
 ### Example
 
 ```python
-from fapilog import configure_logging
-from fapilog.settings import LoggingSettings
+from fapilog import get_logger, Settings
 
-# Basic configuration
-configure_logging()
+# Basic usage
+logger = get_logger()
 
 # Custom configuration
-settings = LoggingSettings(level="DEBUG", sinks=["stdout"])
-configure_logging(settings=settings)
-````
+settings = Settings(core={"log_level": "DEBUG", "sinks": ["stdout_json"]})
+logger = get_logger(settings=settings)
+```
 
 ### See Also
 
@@ -188,9 +190,10 @@ configure_logging(settings=settings)
 **Language Specification:**
 ```python
 # Always specify the language for syntax highlighting
-from fapilog import configure_logging
-configure_logging()
-````
+from fapilog import get_logger
+
+logger = get_logger()
+```
 
 ```bash
 # Shell commands
@@ -227,32 +230,30 @@ python -m pytest tests/
 **Good Example:**
 
 ```python
-from fapilog import configure_logging, log
+from fapilog import get_logger
 
-# Configure logging
-configure_logging()
+# Get logger
+logger = get_logger()
 
 # Basic logging
-log.info("Application started", version="1.0.0")
-log.error("Database connection failed", database="postgres")
+logger.info("Application started", version="1.0.0")
+logger.error("Database connection failed", database="postgres")
 ```
 
 **Bad Example:**
 
 ```python
 # Too complex for basic example
-from fapilog import configure_logging, log
-from fapilog.settings import LoggingSettings
+from fapilog import get_logger, Settings
 from fapilog.sinks import CustomSink
 from fapilog.enrichers import CustomEnricher
 
-settings = LoggingSettings(
-    level="DEBUG",
-    sinks=["stdout", "file", "loki"],
+settings = Settings(
+    core={"log_level": "DEBUG", "sinks": ["stdout_json", "file", "loki"]},
     custom_sinks={"custom": CustomSink()},
     enrichers=[CustomEnricher()]
 )
-configure_logging(settings=settings)
+logger = get_logger(settings=settings)
 ```
 
 ### **Error Handling Examples**
@@ -260,11 +261,11 @@ configure_logging(settings=settings)
 **Include error scenarios:**
 
 ```python
-from fapilog.exceptions import ConfigurationError
+from fapilog import get_logger
 
 try:
-    configure_logging(settings=invalid_settings)
-except ConfigurationError as e:
+    logger = get_logger(settings=invalid_settings)
+except ValueError as e:
     print(f"Configuration error: {e}")
     # Handle error appropriately
 ```
@@ -343,7 +344,7 @@ except ConfigurationError as e:
 
 ```markdown
 [User Guide](user-guide.md)
-[API Reference](api-reference.md#configure_logging)
+[API Reference](api-reference.md#get_logger)
 [Examples](examples/index.md)
 ```
 
@@ -453,15 +454,15 @@ Structured logging provides machine-readable logs that work seamlessly with mode
 ### Usage
 
 ```python
-from fapilog import configure_logging, log
+from fapilog import get_logger
 
-configure_logging()
+logger = get_logger()
 
 # Structured logging with context
-log.info("User logged in",
-         user_id="123",
-         ip_address="192.168.1.100",
-         duration_ms=45.2)
+logger.info("User logged in",
+            user_id="123",
+            ip_address="192.168.1.100",
+            duration_ms=45.2)
 ```
 ````
 
@@ -483,10 +484,9 @@ log.info("User logged in",
 Enable structured logging with the `format` setting:
 
 ```python
-from fapilog.settings import LoggingSettings
+from fapilog import get_logger
 
-settings = LoggingSettings(format="json")  # Default
-configure_logging(settings=settings)
+logger = get_logger(format="json")  # Default
 ```
 
 ### See Also

--- a/docs/test_api.py
+++ b/docs/test_api.py
@@ -8,13 +8,15 @@ to automatically generate formatted API documentation.
 from typing import Any, Dict, List, Optional
 
 
-async def configure_logging(
-    level: str = "INFO", format: str = "json", sinks: Optional[List[str]] = None
+async def get_async_logger(
+    name: Optional[str] = None,
+    preset: Optional[str] = None,
+    format: Optional[str] = None,
 ) -> None:
     """
-    Configure the logging system with the specified settings.
+    Get a configured async logger instance.
 
-    This function must be called before any logging operations can occur.
+    Returns a fully configured async logger ready for use.
     It sets up sinks, processors, and enrichers based on the provided configuration.
 
     @docs:use_cases
@@ -25,22 +27,21 @@ async def configure_logging(
 
     @docs:examples
     ```python
-    from fapilog import configure_logging, LoggingSettings
+    from fapilog import get_async_logger
 
-    # Basic configuration
-    await configure_logging(level="DEBUG", format="pretty")
+    # Basic usage
+    logger = await get_async_logger()
 
-    # With custom sinks
-    await configure_logging(
-        level="INFO",
-        format="json",
-        sinks=["stdout", "file", "http"]
-    )
+    # With format
+    logger = await get_async_logger(format="pretty")
+
+    # With preset
+    logger = await get_async_logger(preset="dev")
     ```
 
     @docs:notes
     - All timestamps are emitted in **RFC3339 UTC format**
-    - The configuration is **immutable** after initialization - changes require restart
+    - Logger should be drained on shutdown with `await logger.drain()`
     - See [Logging Levels](../concepts/logging-levels.md) for detailed level descriptions
     - Related: [Custom Sinks](../examples/custom-sinks.md), [Environment Configuration](../config.md)
     """


### PR DESCRIPTION
## Summary

Removes remaining references to the non-existent `configure_logging()` function that were missed during story 5.22 cleanup. The current fapilog API uses `get_logger()` and `get_async_logger()` instead.

## Changes

- `docs/style-guide.md` (modified) - 9 code example updates
- `docs/documentation-guide-for-contributors.md` (modified) - 2 code example updates  
- `docs/test_api.py` (modified) - Updated sample function and examples

## Acceptance Criteria

- [x] All `configure_logging()` references replaced with correct API
- [x] Examples use `get_logger()` / `get_async_logger()` 
- [x] Pre-commit hooks pass

## Test Plan

- [x] Grep confirms no remaining incorrect references
- [x] All pre-commit checks pass

## Story

Completes cleanup missed by [5.22 - Remove Obsolete structlog References](docs/stories/5.22.remove-obsolete-structlog-references.md) AC7 verification