### PR TITLE
docs: update tagline to emphasize batteries-included value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fapilog - Production-ready logging for the modern Python stack
+# Fapilog - Batteries-included, async-first logging for Python services
 
 **fapilog** delivers production-ready logging for the modern Python stack—async-first, structured, and optimized for FastAPI and cloud-native apps. It’s equally suitable for **on-prem**, **desktop**, or **embedded** projects where structured, JSON-ready, and pluggable logging is required.
 
@@ -350,4 +350,4 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 ---
 
-**Fapilog** - The future of async-first logging for Python applications.
+**Fapilog** - Batteries-included, async-first logging for Python services.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Fapilog - Production-ready logging for the modern Python stack
+# Fapilog - Batteries-included, async-first logging for Python services
 
 **fapilog** is a high-performance logging pipeline that eliminates the bottlenecks of traditional Python logging. By replacing blocking I/O with a lock-free, async-native architecture, it ensures your application never stalls to write a log. While it’s an excellent choice for FastAPI and microservices, its lightweight footprint and pluggable sinks make it equally powerful for on-prem, desktop, or embedded projects.
 


### PR DESCRIPTION
## Summary

Updates the project tagline from "Production-ready logging for the modern Python stack" to "Batteries-included, async-first logging for Python services."

This change better communicates fapilog's value proposition:
- **Batteries-included** — highlights the DX benefits (presets, built-in redaction, cloud sinks, trace enrichment)
- **Async-first** — signals the architectural approach and FastAPI alignment
- **Python services** — more specific about the target audience than "modern stack"

## Changes

- `README.md` (modified) - header and footer taglines
- `docs/index.md` (modified) - header tagline

## Test Plan

- [x] Documentation renders correctly
- [x] No broken links or formatting issues