### PR TITLE
docs: fix documentation accuracy for enrichers, redaction, and file sink

### DIFF
--- a/docs/api-reference/plugins/enrichers.md
+++ b/docs/api-reference/plugins/enrichers.md
@@ -39,7 +39,7 @@ class MyEnricher:
 
 ### RuntimeInfoEnricher
 
-Adds system and runtime information:
+Adds system and runtime information under the `diagnostics` semantic group:
 
 - `service`: from `FAPILOG_SERVICE` env var (default: "fapilog")
 - `env`: from `FAPILOG_ENV` or `ENV` env var (default: "dev")
@@ -48,13 +48,18 @@ Adds system and runtime information:
 - `pid`: process ID
 - `python`: Python version
 
+Returns: `{"diagnostics": {"service": "...", "env": "...", "host": "...", "pid": 1234, "python": "3.11.0"}}`
+
 ### ContextVarsEnricher
 
-Adds values from context variables when present:
+Adds values from context variables under the `context` semantic group when present:
 
 - `request_id`: from fapilog's request context
 - `user_id`: from fapilog's user context
 - `trace_id`, `span_id`: when OpenTelemetry is available
+- `tenant_id`: from event data if present
+
+Returns: `{"context": {"request_id": "...", "user_id": "...", "trace_id": "...", "span_id": "..."}}`
 
 ### KubernetesEnricher
 

--- a/docs/redaction-guarantees.md
+++ b/docs/redaction-guarantees.md
@@ -8,7 +8,7 @@ This document defines the guarantees, guardrails, and configuration for data red
 
 - URL credentials are scrubbed from string values resembling `scheme://user:pass@host...` across all fields **by default** (the `url_credentials` redactor is enabled in all configurations).
 - Explicitly configured dotted field paths are masked, including nested objects and lists, **when the `field_mask` redactor is enabled**. Arrays support `*`/`[*]` wildcard and numeric indices.
-- Regex-based masks are applied to dotted field paths that match configured regular expressions **when the `regex_mask` redactor is enabled**.
+- Regex-based masks are applied to dotted field paths that match configured regular expressions **when the `regex_mask` redactor is enabled**. Note: patterns match against field paths (e.g., `context.password`, `user.api_key`), not field content. Use patterns like `(?i).*password.*` to mask all fields containing "password" in their path.
 - Redactors never raise upstream; failures are recorded via diagnostics with a `{ redactor, reason }` payload.
 
 ## Deterministic Order
@@ -49,8 +49,10 @@ redactors:
       - diagnostics.secrets[*].value
   regex_mask:
     patterns:
-      - "(?i)password=([^&\\s]+)"
-      - "(?i)api[_-]?key([=:])([A-Za-z0-9_-]{16,})"
+      - "(?i).*password.*"
+      - "(?i).*api[_-]?key.*"
+      - "(?i).*secret.*"
+      - "(?i).*token.*"
 ```
 
 ## Example Before/After

--- a/docs/user-guide/rotating-file-sink.md
+++ b/docs/user-guide/rotating-file-sink.md
@@ -68,6 +68,26 @@ logger = get_logger()
 logger.info("to file", event="startup")
 ```
 
+## Direct Class Usage
+
+For full control, instantiate the sink class directly:
+
+```python
+from pathlib import Path
+from fapilog.plugins.sinks.rotating_file import RotatingFileSink, RotatingFileSinkConfig
+
+config = RotatingFileSinkConfig(
+    directory=Path("./logs"),
+    filename_prefix="app",
+    max_bytes=10_000_000,  # 10 MB
+    max_files=5,
+    compress_rotated=True,
+)
+sink = RotatingFileSink(config)
+```
+
+Config fields: `directory`, `filename_prefix`, `mode`, `max_bytes`, `interval_seconds`, `max_files`, `max_total_bytes`, `compress_rotated`, `strict_envelope_mode`.
+
 ## Migration
 
 See `docs/guides/migration-file-rotation.md` for a before/after conversion from


### PR DESCRIPTION
## Summary

Fix documentation accuracy issues discovered during story review process.

## Changes

- `docs/api-reference/plugins/enrichers.md` (modified)
  - Update RuntimeInfoEnricher to reflect v1.1 schema `diagnostics` semantic group
  - Update ContextVarsEnricher to reflect v1.1 schema `context` semantic group
  - Add return format examples showing nested structure

- `docs/redaction-guarantees.md` (modified)
  - Clarify that regex_mask patterns match field **paths** (e.g., `context.password`), not field content
  - Fix example patterns to use correct path-matching syntax (`(?i).*password.*`)

- `docs/user-guide/rotating-file-sink.md` (modified)
  - Add "Direct Class Usage" section showing how to instantiate RotatingFileSink directly
  - Document all RotatingFileSinkConfig fields

## Acceptance Criteria

- [x] Enricher docs reflect v1.1 schema semantic groups
- [x] Redaction docs clarify regex pattern behavior
- [x] File sink docs show direct instantiation pattern

## Test Plan

- [x] Documentation-only changes, no code tests required
- [x] Examples match actual API behavior

## Related

Part of ongoing documentation accuracy improvements identified during story reviews.