### PR TITLE
chore: cancel story 4.49 - scope creep

### DIFF
--- a/docs/stories/4.49.access-control-enforcement.md
+++ b/docs/stories/4.49.access-control-enforcement.md
@@ -1,6 +1,6 @@
 # Story 4.49: Access Control Enforcement
 
-**Status:** Planned
+**Status:** Cancelled
 **Priority:** Medium
 **Depends on:** None
 
@@ -347,3 +347,4 @@ If issues occur:
 | Date | Change | Author |
 |------|--------|--------|
 | 2026-01-19 | Initial story creation from doc review | Claude |
+| 2026-01-21 | Cancelled: scope creep - generic RBAC middleware not logging-specific | Claude |


### PR DESCRIPTION
## Summary

Cancels story 4.49 (Access Control Enforcement) after implementation review revealed scope creep.

## Rationale

The implementation built generic RBAC middleware (FastAPI dependency, ASGI middleware) that has no specific connection to fapilog's core logging functionality. 

The original `AccessControlSettings` model is a configuration primitive - the "enforcement utilities" we built don't actually protect anything logging-specific. They're just generic auth middleware that happened to use fapilog's settings model.

This is out of scope for a logging library.

## Changes

- `docs/stories/4.49.access-control-enforcement.md` - Status changed to Cancelled