### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,5 +1,8 @@
 name: Validate Workflows
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/chris-haste/fapilog/security/code-scanning/18](https://github.com/chris-haste/fapilog/security/code-scanning/18)

In general, this issue is fixed by explicitly specifying a `permissions` block for the workflow or individual jobs so that the `GITHUB_TOKEN` is limited to the minimal scopes needed. For this workflow, the steps only need to read the repository contents (to check out and read `.github/workflows/*.yml` and `ci.yml`), so `contents: read` is sufficient.

The best fix without changing existing functionality is to add a top-level `permissions` block just under the workflow `name:` (and before `on:`) in `.github/workflows/validate-workflows.yml`. This will apply to all jobs in the workflow (currently just `validate`) and restrict the `GITHUB_TOKEN` to read-only repository contents. No changes are needed inside the job itself, and no extra imports or dependencies are required, since we are only modifying YAML configuration.

Concretely:
- Edit `.github/workflows/validate-workflows.yml`.
- After line 1 (`name: Validate Workflows`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- Leave the remainder of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
