### PR TITLE
docs(seo): sitemap generation for RTD and GH Pages canonical tags

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -54,10 +54,38 @@ jobs:
       - name: Build docs
         env:
           FAPILOG_DOC_VERSION: ${{ steps.version.outputs.label }}
+          # Set canonical URL for GH Pages builds to point to RTD stable docs
+          # This triggers canonical tag injection and robots.txt deployment
+          GHPAGES_CANONICAL_URL: "https://docs.fapilog.dev/en/stable/"
         run: |
           hatch run docs:build || {
             echo "Docs build failed"; exit 1;
           }
+
+      - name: Verify GH Pages SEO configuration
+        run: |
+          echo "Verifying canonical tags in HTML files..."
+          if ! grep -r 'rel="canonical"' docs/_build/html/*.html > /dev/null 2>&1; then
+            echo "ERROR: No canonical tags found in HTML files"
+            exit 1
+          fi
+          echo "Canonical tags found in HTML files"
+
+          echo "Verifying robots.txt exists..."
+          if [ ! -f docs/_build/html/robots.txt ]; then
+            echo "ERROR: robots.txt not found in build output"
+            exit 1
+          fi
+          echo "robots.txt found at docs/_build/html/robots.txt"
+
+          echo "Verifying noindex meta tags..."
+          if ! grep -r 'name="robots" content="noindex' docs/_build/html/*.html > /dev/null 2>&1; then
+            echo "ERROR: No noindex meta tags found in HTML files"
+            exit 1
+          fi
+          echo "noindex meta tags found in HTML files"
+
+          echo "GH Pages SEO configuration verified successfully"
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/docs/_extra/robots.txt
+++ b/docs/_extra/robots.txt
@@ -1,0 +1,9 @@
+# GitHub Pages mirror of fapilog documentation
+# Canonical documentation: https://docs.fapilog.dev/
+#
+# This mirror provides preview access to unreleased documentation changes.
+# To avoid duplicate content SEO penalties, search engine indexing is discouraged.
+# Users can still browse this site normally.
+
+User-agent: *
+Disallow: /

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,19 @@
+{#
+  Template override for sphinx_rtd_theme to add canonical tags and noindex meta.
+
+  This is used by GitHub Pages builds to:
+  1. Point search engines to the canonical RTD docs (docs.fapilog.dev)
+  2. Discourage indexing of the GH Pages mirror (prevents duplicate content penalty)
+
+  For RTD builds, these variables are not set, so no extra tags are added.
+#}
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+{{ super() }}
+{# Canonical URL pointing to RTD stable docs #}
+{% if ghpages_canonical_url %}
+<link rel="canonical" href="{{ ghpages_canonical_url }}{{ pagename }}.html" />
+<meta name="robots" content="noindex, follow" />
+{% endif %}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 import importlib.util
+import os
 import sys
 import warnings
 from pathlib import Path
@@ -65,6 +66,7 @@ extensions = [
     "myst_parser",
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
+    "sphinx_sitemap",
 ]
 
 # Optional extensions
@@ -166,10 +168,40 @@ html_theme_options = {
     "style_nav_header_background": "#2980B9",
 }
 
+# -- Sitemap and SEO configuration -------------------------------------------
+
+# Detect if this is a GitHub Pages build (canonical URL env var is set)
+_ghpages_canonical = os.getenv("GHPAGES_CANONICAL_URL")
+
+# Base URL for sitemap generation
+# - RTD builds: Use RTD stable URL for sitemap.xml generation
+# - GH Pages builds: No sitemap (would point to wrong domain)
+if not _ghpages_canonical:
+    # RTD build: generate sitemap with correct URLs
+    html_baseurl = "https://docs.fapilog.dev/en/stable/"
+    sitemap_filename = "sitemap.xml"
+    # Disable language/version URL prefixes (RTD handles this via html_baseurl)
+    sitemap_url_scheme = "{link}"
+
+# For GH Pages builds, canonical URLs point to RTD stable docs via template.
+# RTD builds don't need this (RTD handles canonical URLs automatically).
+html_context = {
+    "ghpages_canonical_url": _ghpages_canonical,
+}
+
+# Add any paths that contain custom templates
+templates_path = ["_templates"]
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# Extra path for root-level files (robots.txt for GH Pages builds)
+# Only include _extra for GH Pages builds (when GHPAGES_CANONICAL_URL is set)
+# RTD should not have robots.txt blocking indexing
+if _ghpages_canonical:
+    html_extra_path = ["_extra"]
 
 # Custom CSS for additional styling
 html_css_files = [

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -24,3 +24,4 @@ sphinxext-opengraph
 sphinx-issues
 sphinx-rtd-dark-mode
 sphinxcontrib-mermaid>=0.9.0
+sphinx-sitemap>=2.5.0

--- a/docs/stories/12.11.sitemap-generation-ci-pipeline.md
+++ b/docs/stories/12.11.sitemap-generation-ci-pipeline.md
@@ -1,6 +1,6 @@
 # Story 12.11: Sitemap Generation for RTD (Stable/Canonical) and GH Pages (Latest/Edge)
 
-**Status:** Ready
+**Status:** Complete
 **Priority:** P1 (High)
 **Depends on:** 12.12 (Custom Domain Setup) - for correct canonical URLs
 **Epic:** 12.0 Cookbook (SEO-Driven Documentation)
@@ -293,8 +293,39 @@ docs/_templates/layout.html (NEW or MODIFIED - canonical tag injection)
 
 ---
 
+## Code Review
+
+**Date:** 2026-01-21
+**Reviewer:** Claude
+**Verdict:** OK to PR
+
+### Summary
+
+Implemented dual-mode Sphinx configuration for RTD sitemap generation and GH Pages SEO controls (canonical tags, robots.txt, noindex meta).
+
+### AC Verification
+
+| Criterion | Evidence |
+|-----------|----------|
+| AC1: RTD Sitemap | `docs/conf.py:181-184` - html_baseurl, sitemap_filename, sitemap_url_scheme configured |
+| AC2: Canonical Tags | `docs/_templates/layout.html:16` - canonical link injection via template |
+| AC3: Indexing Prevention | `docs/_extra/robots.txt:8-9` + `layout.html:17` - robots.txt and noindex meta |
+| AC4: CI Pipeline | `.github/workflows/docs-deploy.yml:57-88` - env var config and verification step |
+| AC5: Search Console | N/A - manual user step |
+
+### Quality Gates
+
+- [x] ruff check passed
+- [x] ruff format passed
+- [x] RTD build succeeds with sitemap
+- [x] GH Pages build succeeds with canonical tags
+- [x] CI verification step validates SEO elements
+
+---
+
 ## Change Log
 
 | Date | Change | Author |
 |------|--------|--------|
 | 2026-01-21 | Initial draft | Claude |
+| 2026-01-21 | Implementation complete | Claude |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ dependencies = [
     "myst-parser>=1.0.0",
     "sphinx-autodoc-typehints>=1.24.0",
     "sphinx-copybutton>=0.5.0",
+    "sphinx-sitemap>=2.5.0",
 ]
 
 [tool.hatch.envs.docs.scripts]


### PR DESCRIPTION
## Summary

Configure dual-mode documentation builds for SEO: RTD gets sitemap.xml generation while GH Pages gets canonical tags pointing to RTD stable docs, robots.txt, and noindex meta tags to prevent duplicate content penalties.

## Changes

- `.github/workflows/docs-deploy.yml` (modified) - Add GHPAGES_CANONICAL_URL env var and SEO verification step
- `docs/_extra/robots.txt` (new) - Discourage search engine indexing of GH Pages mirror
- `docs/_templates/layout.html` (new) - Template override for canonical tags and noindex meta
- `docs/conf.py` (modified) - Add sphinx-sitemap config and GH Pages canonical URL handling
- `docs/requirements.txt` (modified) - Add sphinx-sitemap dependency
- `pyproject.toml` (modified) - Add sphinx-sitemap to hatch docs environment

## Acceptance Criteria

- [x] AC1: RTD sitemap generated with correct URLs
- [x] AC2: GH Pages has canonical tags pointing to RTD stable
- [x] AC3: GH Pages discourages indexing (robots.txt + noindex meta)
- [x] AC4: CI pipeline handles both deployment targets
- [x] AC5: Sitemap registration (manual user step)

## Test Plan

- [x] RTD build generates sitemap.xml with docs.fapilog.dev URLs
- [x] GH Pages build includes canonical tags in all HTML files
- [x] GH Pages build includes robots.txt at root
- [x] GH Pages build includes noindex meta tags
- [x] CI verification step validates SEO configuration

## Story

[12.11 - Sitemap Generation for RTD and GH Pages](docs/stories/12.11.sitemap-generation-ci-pipeline.md)