### PR TITLE
docs(cookbook): add FastAPI request_id logging guide

### DIFF
--- a/docs/cookbook/fastapi-request-id-logging.md
+++ b/docs/cookbook/fastapi-request-id-logging.md
@@ -1,0 +1,134 @@
+# FastAPI request_id logging (correlation ID middleware, concurrency-safe)
+
+Every HTTP request needs a unique identifier for tracing. Without proper request ID propagation, debugging distributed systems becomes nearly impossible—you can't correlate logs from a single user action across services.
+
+## The Problem: Overlapping Request IDs
+
+A common approach is using `threading.local()` to store the request ID:
+
+```python
+import threading
+import uuid
+from fastapi import FastAPI, Request
+
+# DON'T DO THIS - breaks with async
+_local = threading.local()
+
+app = FastAPI()
+
+@app.middleware("http")
+async def add_request_id(request: Request, call_next):
+    _local.request_id = str(uuid.uuid4())  # Set ID
+    response = await call_next(request)
+    return response
+
+def get_request_id():
+    return getattr(_local, "request_id", None)
+```
+
+This breaks under concurrency. When you `await` in async code, Python can switch to another coroutine running on the same thread. That coroutine might overwrite `_local.request_id`, and when your original request resumes, it sees the wrong ID.
+
+**Symptoms:**
+
+- Request IDs appear in logs for the wrong requests
+- The same request_id shows up in multiple unrelated requests
+- Debug sessions become impossible because logs don't correlate
+
+This is a [frequently asked question on Stack Overflow](https://stackoverflow.com/questions/tagged/fastapi+logging+async) and catches many developers off guard.
+
+## The Solution
+
+fapilog uses Python's `contextvars` module, which correctly isolates context per async task:
+
+```python
+from fastapi import FastAPI, Depends
+from fapilog.fastapi import setup_logging, get_request_logger
+
+lifespan = setup_logging()
+app = FastAPI(lifespan=lifespan)
+
+@app.get("/")
+async def root(logger=Depends(get_request_logger)):
+    logger.info("request_id is automatically included")
+    return {"status": "ok"}
+```
+
+That's it. Every log entry automatically includes the `request_id`, and it never leaks between concurrent requests.
+
+**Output:**
+
+```json
+{"timestamp": "2026-01-21T10:30:00.123Z", "level": "INFO", "message": "request_id is automatically included", "request_id": "550e8400-e29b-41d4-a716-446655440000"}
+```
+
+## Accessing request_id in Deeper Layers
+
+The request ID is available anywhere in your async call stack without passing it explicitly:
+
+```python
+from fapilog.core.errors import request_id_var
+
+async def my_service_function():
+    """Called deep in the application - no logger passed in."""
+    current_request_id = request_id_var.get(None)
+    # Use for external API calls, database queries, etc.
+    return current_request_id
+```
+
+For logging in service layers, get a logger directly:
+
+```python
+from fapilog import get_async_logger
+
+async def process_order(order_id: str):
+    """Service layer - request_id flows automatically."""
+    logger = await get_async_logger("orders")
+    await logger.info("Processing order", order_id=order_id)
+    # request_id is automatically included via ContextVarsEnricher
+```
+
+### Passing Context to Sync Code
+
+If you have synchronous code that runs within an async request (e.g., a sync database driver), the context variable is still accessible:
+
+```python
+from fapilog.core.errors import request_id_var
+
+def sync_database_call(query: str):
+    """Sync function called from async context."""
+    request_id = request_id_var.get(None)
+    # request_id is available because contextvars work across sync/async boundaries
+    execute_query(query, correlation_id=request_id)
+```
+
+## Why This Works (Technical Detail)
+
+Python's `contextvars` module (PEP 567) provides task-local storage that correctly handles async context switches:
+
+1. **Per-task isolation**: Each asyncio Task gets its own copy of context variables
+2. **Automatic propagation**: When you `await`, the context follows your execution
+3. **No thread confusion**: Unlike `threading.local()`, context doesn't leak between concurrent tasks on the same thread
+
+fapilog's `RequestContextMiddleware` sets `request_id_var` at the start of each request:
+
+```python
+# Simplified view of what happens internally
+from contextvars import ContextVar
+
+request_id_var: ContextVar[str] = ContextVar("request_id")
+
+# In middleware:
+token = request_id_var.set(str(uuid.uuid4()))
+try:
+    response = await call_next(request)
+finally:
+    request_id_var.reset(token)  # Clean up
+```
+
+The `ContextVarsEnricher` (enabled by default) reads this value and adds it to every log entry.
+
+## Going Deeper
+
+- [FastAPI Logging Example](../examples/fastapi-logging.md) - More middleware options
+- [Context Binding Reference](../api-reference/context-binding.md) - Manual context management
+- [Context Enrichment](../user-guide/context-enrichment.md) - How enrichers work

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -1,0 +1,15 @@
+# Cookbook
+
+Focused, SEO-friendly guides that solve specific problems. Each recipe addresses a common search query with copy-pasteable solutions.
+
+```{toctree}
+:maxdepth: 1
+:titlesonly:
+:caption: Cookbook
+
+fastapi-request-id-logging
+```
+
+## Quick Links
+
+- [FastAPI request_id Logging](fastapi-request-id-logging.md) - Correlation ID middleware that works with async

--- a/docs/examples/fastapi-logging.md
+++ b/docs/examples/fastapi-logging.md
@@ -69,3 +69,7 @@ Query by `request_id` to see all logs for a request, including the HTTP context 
 - `request_id` flows automatically when using `RequestContextMiddleware` + `ContextVarsEnricher`
 - The completion log has method/path/status—use `request_id` to correlate
 - Use `logger.bind()` only if you specifically need HTTP context in every log entry
+
+## See Also
+
+- [FastAPI request_id Logging (Cookbook)](../cookbook/fastapi-request-id-logging.md) - Deep dive into concurrency-safe correlation IDs

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ await logger.error("Database connection failed", exc_info=True)
 getting-started/index
 core-concepts/index
 user-guide/index
+cookbook/index
 enterprise
 api-reference/index
 examples/index
@@ -72,6 +73,7 @@ appendices
 - **[Getting Started](getting-started/index.md)** - Installation and quickstart
 - **[Core Concepts](core-concepts/index.md)** - Understanding the architecture
 - **[User Guide](user-guide/index.md)** - Practical usage and configuration
+- **[Cookbook](cookbook/index.md)** - Focused recipes for common problems
 - **[Enterprise Features](enterprise.md)** - Compliance, audit trails, and security (see the new tamper/KMS guide under Enterprise)
 
 **Reference:**

--- a/docs/stories/12.1.fastapi-request-id-logging.md
+++ b/docs/stories/12.1.fastapi-request-id-logging.md
@@ -1,6 +1,6 @@
 # Story 12.1: FastAPI request_id Logging (Correlation ID Middleware, Concurrency-Safe)
 
-**Status:** Ready
+**Status:** Complete
 **Priority:** P0 (High)
 **Depends on:** None
 **Epic:** 12.0 Cookbook (SEO-Driven Documentation)
@@ -137,13 +137,13 @@ Every request needs a unique ID for tracing...
 
 ## Tasks
 
-- [ ] Create `docs/cookbook/fastapi-request-id-logging.md`
-- [ ] Write problem section with concurrency explanation
-- [ ] Write solution section with working code
-- [ ] Write deep access pattern section
-- [ ] Write technical explanation section
-- [ ] Add cross-links to related docs
-- [ ] Test code examples work
+- [x] Create `docs/cookbook/fastapi-request-id-logging.md`
+- [x] Write problem section with concurrency explanation
+- [x] Write solution section with working code
+- [x] Write deep access pattern section
+- [x] Write technical explanation section
+- [x] Add cross-links to related docs
+- [x] Test code examples work
 
 ---
 
@@ -159,20 +159,20 @@ Every request needs a unique ID for tracing...
 
 ### Content Complete
 
-- [ ] All sections written per template
-- [ ] Code examples tested
-- [ ] Technical accuracy verified
+- [x] All sections written per template
+- [x] Code examples tested
+- [x] Technical accuracy verified
 
 ### SEO Optimized
 
-- [ ] Target keywords in H1
-- [ ] Target keywords in first paragraph
-- [ ] Page under 1000 words
+- [x] Target keywords in H1
+- [x] Target keywords in first paragraph
+- [x] Page under 1000 words
 
 ### Integrated
 
-- [ ] Added to cookbook index
-- [ ] Cross-linked from FastAPI guide
+- [x] Added to cookbook index
+- [x] Cross-linked from FastAPI guide
 
 ---
 
@@ -189,8 +189,41 @@ Revert commit if issues found.
 
 ---
 
+---
+
+## Code Review
+
+**Date:** 2026-01-21
+**Reviewer:** Claude
+**Verdict:** OK to PR
+
+### Summary
+
+Reviewed cookbook page for FastAPI request_id logging covering concurrency-safe correlation ID middleware using contextvars.
+
+### AC Verification
+
+| Criterion | Evidence |
+|-----------|----------|
+| AC1: Page exists with correct title | `docs/cookbook/fastapi-request-id-logging.md:1` - H1 matches exactly |
+| AC2: Problem section explains concurrency | `docs/cookbook/fastapi-request-id-logging.md:5-37` - threading.local() failure, symptoms, SO reference |
+| AC3: Solution shows minimal working code | `docs/cookbook/fastapi-request-id-logging.md:43-54` - exact match to validation snippet |
+| AC4: Deep access pattern documented | `docs/cookbook/fastapi-request-id-logging.md:64-102` - service layer + sync code patterns |
+| AC5: Why it works section | `docs/cookbook/fastapi-request-id-logging.md:104-128` - contextvars, PEP 567, propagation explained |
+
+### Quality Gates
+
+- [x] Docs build passed
+- [x] All links valid
+- [x] Code examples verified against actual API
+- [x] Word count under 1000 (556 words)
+
+---
+
 ## Change Log
 
 | Date | Change | Author |
 |------|--------|--------|
 | 2026-01-21 | Initial draft | Claude |
+| 2026-01-21 | Implementation complete | Claude |
+| 2026-01-21 | Code review passed | Claude |


### PR DESCRIPTION
## Summary

Cookbook page for "FastAPI request id logging" and "FastAPI correlation id middleware" - among the most searched logging queries. Explains why naive threading.local() approaches fail with async concurrency, and shows fapilog's contextvars-based solution.

## Changes

- `docs/cookbook/fastapi-request-id-logging.md` (new)
- `docs/cookbook/index.md` (new)
- `docs/examples/fastapi-logging.md` (modified)
- `docs/index.md` (modified)
- `docs/stories/12.1.fastapi-request-id-logging.md` (modified)

## Acceptance Criteria

- [x] AC1: Page exists with correct title
- [x] AC2: Problem section explains concurrency issue
- [x] AC3: Solution shows minimal working code
- [x] AC4: Deep access pattern documented
- [x] AC5: Why it works section

## Test Plan

- [x] Docs build passes
- [x] All links valid
- [x] Code examples verified against actual API

## Story

[12.1 - FastAPI request_id Logging](docs/stories/12.1.fastapi-request-id-logging.md)