### PR TITLE
docs: clarify fapilog is not a wrapper over existing libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Fapilog - Batteries-included, async-first logging for Python services
 
-**fapilog** delivers production-ready logging for the modern Python stack—async-first, structured, and optimized for FastAPI and cloud-native apps. It’s equally suitable for **on-prem**, **desktop**, or **embedded** projects where structured, JSON-ready, and pluggable logging is required.
+**fapilog** delivers production-ready logging for the modern Python stack—async-first, structured, and optimized for FastAPI and cloud-native apps. It's equally suitable for **on-prem**, **desktop**, or **embedded** projects where structured, JSON-ready, and pluggable logging is required.
+
+Fapilog isn't a thin wrapper over existing logging libraries—it's an async-first logging pipeline designed to keep your app responsive under slow or bursty log sinks, with backpressure policies, redaction, and first-class FastAPI integration built in.
 
 ![Async-first](https://img.shields.io/badge/async-first-008080?style=flat-square&logo=python&logoColor=white)
 ![JSON Ready](https://img.shields.io/badge/json-ready-008080?style=flat-square&logo=json&logoColor=white)

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -32,6 +32,8 @@ fapilog is built around a few core concepts that make it fast, reliable, and dev
 
 ## Key Principles
 
+Fapilog isn't a thin wrapper over existing logging libraries—it's an async-first logging pipeline designed to keep your app responsive under slow or bursty log sinks, with backpressure policies, redaction, and first-class FastAPI integration built in.
+
 ### 1. Async-First Design
 
 Everything in fapilog is async by default. This means:


### PR DESCRIPTION
## Summary

Adds a positioning statement to clarify that fapilog is not a thin wrapper over existing logging libraries (structlog, loguru, etc.), but rather a purpose-built async-first logging pipeline with backpressure, redaction, and FastAPI integration.

## Changes

- `README.md` (modified) - Added positioning statement after intro paragraph
- `docs/core-concepts/index.md` (modified) - Added same statement before Key Principles section

## Test Plan

- [x] Documentation renders correctly
- [x] No code changes, documentation only