### PR TITLE
chore(docs): remove internal story references from published docs

### DIFF
--- a/docs/addons/tamper-evident-logging.md
+++ b/docs/addons/tamper-evident-logging.md
@@ -4,22 +4,7 @@ orphan: true
 
 # Tamper-Evident Logging Add-on (Optional)
 
-> **Implementation Stories**: This design is implemented across Stories 4.14–4.18.
-> See the fapilog-audit stories for detailed acceptance criteria and technical design.
-
 This design keeps the core light while offering an opt-in, first-class tamper-evident capability delivered as a separate plugin/package.
-
-## Story Breakdown
-
-| Story | Title                          | Status |
-| ----- | ------------------------------ | ------ |
-| 4.14  | Package Bootstrap              | Done   |
-| 4.15  | IntegrityEnricher & ChainState | Done   |
-| 4.16  | SealedSink & Manifests         | Done   |
-| 4.17  | Verification API & CLI         | Done   |
-| 4.18  | Enterprise Key Management      | Done   |
-
-> **Note**: Story 4.13 (keyless hash chains in core) was cancelled. All tamper-evident functionality is in the plugin.
 
 ## Packaging and Opt-in
 

--- a/docs/contributing/contract-tests.md
+++ b/docs/contributing/contract-tests.md
@@ -13,7 +13,7 @@ If these stages disagree on the data shape, logs may be lost or corrupted. Contr
 
 ### Historical Context
 
-Story 10.17 introduced contract testing after identifying a schema mismatch between `build_envelope()` and `serialize_envelope()`. The mismatch went undetected because:
+Contract testing was introduced after identifying a schema mismatch between `build_envelope()` and `serialize_envelope()`. The mismatch went undetected because:
 
 - Unit tests tested each function in isolation
 - Property tests used synthetic data, not real `build_envelope()` output

--- a/docs/plugins/configuration.md
+++ b/docs/plugins/configuration.md
@@ -1,6 +1,6 @@
 # Plugin Configuration
 
-This guide explains the new configuration-driven plugin wiring introduced in Story 4.19.
+This guide explains configuration-driven plugin wiring.
 
 ## Selecting Plugins
 

--- a/docs/user-guide/benchmarks.md
+++ b/docs/user-guide/benchmarks.md
@@ -130,4 +130,3 @@ Options:
 ## Related
 
 - [Performance Tuning](performance-tuning.md) - Configuration recommendations
-- Story 10.19 - CI-based regression detection (planned)

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -149,7 +149,7 @@ When you call `get_logger()` without a preset or settings, fapilog automatically
 | Lambda | `AWS_LAMBDA_FUNCTION_NAME` env var | Smaller batches (10), faster flush (0.1s), smaller queue (1000) |
 | Kubernetes | `/var/run/secrets/kubernetes.io/serviceaccount` or `POD_NAME` env var | INFO level, `kubernetes` enricher |
 | Docker | `/.dockerenv` file or `/proc/1/cgroup` contains "docker" | INFO level |
-| CI | Common CI env vars (see Story 10.6) | INFO level |
+| CI | Common CI env vars (`CI`, `GITHUB_ACTIONS`, etc.) | INFO level |
 | Local | Default fallback | Uses TTY-based log level defaults |
 
 **Important:** Auto-detection applies incremental tweaks to the base configuration—it does **not** apply full preset configurations. For example:


### PR DESCRIPTION
- Remove story references from user-facing documentation
- Stories are internal planning artifacts, not for public docs