### PR TITLE
fix(docs): correct README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Fapilog isn't a thin wrapper over existing logging libraries—it's an async-fir
 - **Operational visibility**: Optional metrics for queue depth, drops, and flush latency.
 - **Pre-1.0 stability**: Core logger and FastAPI middleware APIs are stable within minor versions; see [Stability](#stability) for details.
 
-**[Read more →](https://docs.fapilog.dev/why-fapilog/)** | **[Compare with structlog, loguru, and others →](https://docs.fapilog.dev/comparisons/)**
+**[Read more →](https://docs.fapilog.dev/en/latest/why-fapilog.html)** | **[Compare with structlog, loguru, and others →](https://docs.fapilog.dev/en/latest/comparisons.html)**
 
 ## When to use / when stdlib is enough
 


### PR DESCRIPTION
## Summary

Fix broken documentation links in README.

## Changes

- `README.md` - Fix "Read more" and "Compare" links

Before: `https://docs.fapilog.dev/why-fapilog/` (404)
After: `https://docs.fapilog.dev/en/latest/why-fapilog.html` (works)