### PR TITLE
fix(ci): correct branch cleanup merge detection logic

### DIFF
--- a/.github/workflows/cleanup-merged-branches.yml
+++ b/.github/workflows/cleanup-merged-branches.yml
@@ -71,8 +71,9 @@ jobs:
                 continue;
               }
 
-              const status = cmp.data.status;
-              const fullyMerged = (status === "ahead" || status === "identical");
+              // A branch is fully merged when it has no commits ahead of main
+              // (all its commits are contained in main)
+              const fullyMerged = (cmp.data.ahead_by === 0);
 
               if (!fullyMerged) {
                 skipped++;


### PR DESCRIPTION
## Summary

Fix inverted merge detection logic in the branch cleanup workflow. The workflow was checking for `status === "ahead"` which actually means a branch is NOT merged (has commits not in main).

## Problem

The previous logic:
```javascript
const fullyMerged = (status === "ahead" || status === "identical");
```

GitHub compare API status values:
- `"behind"` = branch is behind main (main has commits branch doesn't)
- `"ahead"` = branch has commits main doesn't (NOT merged)
- `"diverged"` = both ahead and behind
- `"identical"` = same commit

A merged branch typically has `status: "behind"` with `ahead_by: 0`.

## Fix

```javascript
const fullyMerged = (cmp.data.ahead_by === 0);
```

A branch is fully merged when `ahead_by === 0` (all its commits are contained in main).

## Impact

~129 merged branches with allowed prefixes should now be cleaned up on the next run.

## Test Plan

- [x] Logic verified against actual repo branches
- [x] Merged branches show `ahead_by: 0`
- [x] Unmerged branches show `ahead_by > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)