### PR TITLE
docs(stories): add security audit findings as stories

### DIFF
--- a/docs/stories/4.51.secure-header-redaction-defaults.md
+++ b/docs/stories/4.51.secure-header-redaction-defaults.md
@@ -1,0 +1,289 @@
+# Story 4.51: Secure Header Redaction Defaults
+
+**Status:** Ready
+**Priority:** High (P1 - Security)
+**Depends on:** None
+
+---
+
+## Context / Background
+
+The `LoggingMiddleware` in `src/fapilog/fastapi/logging.py:163-171` uses an opt-in redaction model when `include_headers=True` is enabled. Only headers explicitly listed in `redact_headers` are masked—all others are logged in plaintext.
+
+This is a security footgun: if a user enables header logging without carefully configuring `redact_headers`, sensitive headers like `Authorization`, `Cookie`, `X-API-Key`, and others will be written to logs in cleartext.
+
+**Current behavior:**
+```python
+if self._include_headers:
+    headers = {}
+    for key, value in request.headers.items():
+        lk = key.lower()
+        if lk in self._redact_headers:  # Only explicit redactions
+            headers[lk] = "***"
+        else:
+            headers[lk] = value  # Everything else logged in plaintext
+```
+
+**Problem:** Common sensitive headers are logged unless users remember to add them to `redact_headers`.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Add default redaction list for common sensitive headers
+- Make redaction opt-out (redact by default) rather than opt-in
+- Add `additional_redact_headers` parameter for extending defaults
+- Add `allow_headers` parameter for explicit allowlist approach
+- Documentation and migration guide
+
+### Out of Scope
+
+- Automatic PII detection in header values (future ML/regex work)
+- Body content redaction (separate concern)
+- Retroactive log scrubbing
+
+---
+
+## Acceptance Criteria
+
+### AC1: Default Sensitive Headers Redacted
+
+**Description:** When `include_headers=True`, common sensitive headers are redacted by default without explicit configuration.
+
+**Default redaction list:**
+- `authorization`
+- `cookie`
+- `set-cookie`
+- `x-api-key`
+- `x-auth-token`
+- `x-csrf-token`
+- `x-forwarded-authorization`
+- `proxy-authorization`
+- `www-authenticate`
+
+**Validation:**
+```python
+middleware = LoggingMiddleware(app, include_headers=True)
+# Authorization header should be redacted without explicit config
+assert "authorization" in middleware._default_redact_headers
+```
+
+### AC2: Extend Default Redactions
+
+**Description:** Users can add to the default list without replacing it.
+
+**Validation:**
+```python
+middleware = LoggingMiddleware(
+    app,
+    include_headers=True,
+    additional_redact_headers=["x-custom-secret"]
+)
+# Both defaults and custom headers redacted
+```
+
+### AC3: Explicit Allowlist Mode
+
+**Description:** Users can switch to allowlist mode where only specified headers are logged.
+
+**Validation:**
+```python
+middleware = LoggingMiddleware(
+    app,
+    include_headers=True,
+    allow_headers=["content-type", "accept", "user-agent"]
+)
+# Only these three headers logged, all others excluded
+```
+
+### AC4: Override Default Redactions
+
+**Description:** Users can disable default redactions if they have a legitimate need (with warning).
+
+**Validation:**
+```python
+middleware = LoggingMiddleware(
+    app,
+    include_headers=True,
+    redact_headers=[],  # Explicit empty list
+    disable_default_redactions=True  # Must be explicit
+)
+# Logs warning about security implications
+```
+
+### AC5: Documentation Updated
+
+**Description:** Security implications documented with examples.
+
+**Validation:**
+- README security section mentions header redaction
+- Docstrings explain default behavior
+- Migration guide for existing users
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/fastapi/logging.py (MODIFIED - add default redactions)
+tests/unit/test_logging_middleware.py (MODIFIED - add security tests)
+docs/user-guide/security.md (NEW or MODIFIED)
+```
+
+### Key Code
+
+```python
+DEFAULT_REDACT_HEADERS = frozenset({
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "x-auth-token",
+    "x-csrf-token",
+    "x-forwarded-authorization",
+    "proxy-authorization",
+    "www-authenticate",
+})
+
+def __init__(
+    self,
+    app: Any,
+    *,
+    include_headers: bool = False,
+    redact_headers: Iterable[str] | None = None,
+    additional_redact_headers: Iterable[str] | None = None,
+    allow_headers: Iterable[str] | None = None,
+    disable_default_redactions: bool = False,
+    ...
+) -> None:
+    # Build effective redaction set
+    if allow_headers is not None:
+        # Allowlist mode: only log specified headers
+        self._allow_headers = {h.lower() for h in allow_headers}
+        self._redact_headers = set()
+    else:
+        # Redaction mode (default)
+        self._allow_headers = None
+        base = set() if disable_default_redactions else set(DEFAULT_REDACT_HEADERS)
+        if redact_headers:
+            base = {h.lower() for h in redact_headers}
+        if additional_redact_headers:
+            base.update(h.lower() for h in additional_redact_headers)
+        self._redact_headers = base
+
+        if disable_default_redactions:
+            warnings.warn(
+                "Default header redactions disabled. Sensitive headers may be logged.",
+                SecurityWarning,
+                stacklevel=2,
+            )
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [ ] Add `DEFAULT_REDACT_HEADERS` constant
+- [ ] Add `additional_redact_headers` parameter
+- [ ] Add `allow_headers` parameter for allowlist mode
+- [ ] Add `disable_default_redactions` parameter with warning
+- [ ] Update `_log_completion` to use new logic
+
+### Phase 2: Testing
+
+- [ ] Add tests for default redaction behavior
+- [ ] Add tests for extending defaults
+- [ ] Add tests for allowlist mode
+- [ ] Add tests for override with warning
+- [ ] Add security-focused test cases
+
+### Phase 3: Documentation
+
+- [ ] Update docstrings with security notes
+- [ ] Add security section to user guide
+- [ ] Add migration guide for existing users
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_logging_middleware.py`
+  - `test_default_headers_redacted_without_config`
+  - `test_authorization_header_redacted_by_default`
+  - `test_cookie_header_redacted_by_default`
+  - `test_additional_redact_headers_extends_defaults`
+  - `test_allow_headers_excludes_unlisted`
+  - `test_disable_default_redactions_warns`
+  - `test_empty_redact_headers_uses_defaults`
+
+### Integration Tests
+
+- `tests/integration/test_middleware_security.py`
+  - End-to-end test with real FastAPI app
+  - Verify sensitive headers never appear in log output
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] Code follows project patterns
+- [ ] No new linting errors
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] Integration tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Code has docstrings where needed
+- [ ] Security guide updated
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Breaking change for users who rely on seeing all headers
+   - **Mitigation:** Provide `disable_default_redactions=True` escape hatch with warning
+
+2. **Risk:** Incomplete default list misses sensitive headers
+   - **Mitigation:** Research common header names, allow easy extension
+
+### Rollback Plan
+
+If issues occur:
+1. Revert to previous opt-in behavior
+2. Keep new parameters but default `disable_default_redactions=True`
+
+---
+
+## Related Stories
+
+- **Related:** Story 4.47 - Redaction defaults alignment
+- **Related:** Story 4.46 - Fallback sink PII protection
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-01-23 | Initial draft from security audit | Claude |

--- a/docs/stories/4.52.enforce-security-scanning-ci.md
+++ b/docs/stories/4.52.enforce-security-scanning-ci.md
@@ -1,0 +1,294 @@
+# Story 4.52: Enforce Security Scanning in CI
+
+**Status:** Ready
+**Priority:** Medium (P2 - Security Hygiene)
+**Depends on:** Story 4.13 (CI Security Scanning & SBOM Publishing) - Note: 4.13 partially implemented (scanning exists, enforcement missing)
+
+---
+
+## Context / Background
+
+Story 4.13 introduced security scanning with `pip-audit` and SBOM generation in `.github/workflows/security-sbom.yml`. However, the current implementation only uploads artifacts—it does not fail the build when vulnerabilities are found.
+
+**Current behavior** (`.github/workflows/security-sbom.yml:29-39`):
+```yaml
+- name: Vulnerability Scan (pip-audit)
+  run: |
+    pip install pip-audit
+    pip-audit -f json -o audit.json
+- name: Upload artifacts
+  uses: actions/upload-artifact@v4
+```
+
+**Problem:** Known vulnerabilities can be merged and released without any CI gate. The scan runs but results are ignored for pass/fail determination.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Add failure threshold to `pip-audit` step
+- Configure severity-based gating (fail on HIGH/CRITICAL)
+- Add PR comment with vulnerability summary
+- Allow temporary bypass with explicit label (e.g., `security-override`)
+- Documentation for maintainers
+
+### Out of Scope
+
+- Fixing existing vulnerabilities (separate work)
+- Adding new scanning tools (bandit already covered in 4.13)
+- Automatic dependency updates (Dependabot config)
+
+---
+
+## Acceptance Criteria
+
+### AC1: CI Fails on Critical/High Vulnerabilities
+
+**Description:** The security workflow fails when `pip-audit` finds HIGH or CRITICAL severity vulnerabilities.
+
+**Validation:**
+```yaml
+- name: Vulnerability Scan (pip-audit)
+  run: |
+    pip install pip-audit
+    pip-audit --strict --ignore-vuln GHSA-xxx  # Known false positives
+    # Exit code non-zero on any vulnerability
+```
+
+### AC2: Configurable Severity Threshold
+
+**Description:** Severity threshold is configurable by parsing JSON output and failing conditionally.
+
+**Note:** `pip-audit --strict` fails on ANY vulnerability. For severity-based filtering, parse the JSON output.
+
+**Validation:**
+```yaml
+- name: Check severity threshold
+  run: |
+    # Parse audit.json and fail only on high/critical
+    python -c "
+    import json, sys
+    audit = json.load(open('audit.json'))
+    high_crit = [d for d in audit.get('dependencies', [])
+                 if any(v.get('fix_versions') for v in d.get('vulns', []))]
+    if high_crit:
+        print(f'Found {len(high_crit)} vulnerable dependencies')
+        sys.exit(1)
+    "
+```
+
+### AC3: PR Summary Comment
+
+**Description:** On PRs, post a comment summarizing vulnerabilities found (even if passing).
+
+**Validation:**
+- Comment shows count by severity
+- Comment includes link to full artifact
+- Comment is updated on re-runs (not duplicated)
+
+### AC4: Override Label for Emergencies
+
+**Description:** PRs with `security-override` label can bypass the check (with audit trail).
+
+**Validation:**
+```yaml
+if: ${{ !contains(github.event.pull_request.labels.*.name, 'security-override') }}
+```
+
+### AC5: Release Workflow Integration
+
+**Description:** Release workflow also enforces the security gate.
+
+**Validation:**
+- Release workflow references security job
+- Cannot release with known HIGH/CRITICAL vulnerabilities
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+.github/workflows/security-sbom.yml (MODIFIED - add enforcement)
+.github/workflows/release.yml (MODIFIED - add security dependency)
+docs/SECURITY.md (NEW or MODIFIED - document process)
+```
+
+### Key Code
+
+```yaml
+name: Security Scan & SBOM
+
+on:
+  push:
+    branches: [main, "feat/**", "feature/**"]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write  # For PR comments
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Generate SBOM (cyclonedx)
+        run: |
+          pip install cyclonedx-bom
+          cyclonedx-py environment -o sbom.json
+
+      - name: Vulnerability Scan (pip-audit)
+        id: audit
+        continue-on-error: true  # Capture result for comment
+        run: |
+          pip install pip-audit
+          pip-audit --strict --progress-spinner off \
+            --format json --output audit.json 2>&1 | tee audit-output.txt
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-artifacts
+          path: |
+            sbom.json
+            audit.json
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const audit = JSON.parse(fs.readFileSync('audit.json', 'utf8'));
+            const vulnCount = audit.dependencies?.filter(d => d.vulns?.length > 0).length || 0;
+
+            const body = vulnCount > 0
+              ? `## ⚠️ Security Scan Found ${vulnCount} Vulnerable Dependencies\n\nSee workflow artifacts for details.`
+              : `## ✅ Security Scan Passed\n\nNo known vulnerabilities found.`;
+
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });
+
+      - name: Fail on vulnerabilities
+        if: |
+          steps.audit.outputs.exit_code != '0' &&
+          !contains(github.event.pull_request.labels.*.name, 'security-override')
+        run: |
+          echo "::error::Vulnerabilities found. Add 'security-override' label to bypass (requires justification)."
+          exit 1
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Enforcement
+
+- [ ] Update `pip-audit` step to use `--strict` flag
+- [ ] Add exit code capture and conditional failure
+- [ ] Test with intentionally vulnerable dependency
+
+### Phase 2: PR Integration
+
+- [ ] Add PR comment step with vulnerability summary
+- [ ] Add `security-override` label bypass logic
+- [ ] Ensure comment updates on re-runs
+
+### Phase 3: Release Integration
+
+- [ ] Add security job as dependency in release workflow
+- [ ] Document release security requirements
+
+### Phase 4: Documentation
+
+- [ ] Create/update SECURITY.md with process
+- [ ] Document override label usage and audit requirements
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Manual Verification
+
+- [ ] Workflow fails when vulnerability exists
+- [ ] Workflow passes when no vulnerabilities
+- [ ] PR comment appears with correct summary
+- [ ] Override label allows merge (with warning)
+- [ ] Release blocked without security check passing
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] Workflow syntax validated
+- [ ] No new linting errors
+
+### Quality Assurance
+
+- [ ] Workflow tested on test branch with known vuln
+- [ ] Override label tested
+- [ ] PR comment verified
+
+### Documentation
+
+- [ ] SECURITY.md updated
+- [ ] CONTRIBUTING.md mentions security checks
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** False positives block legitimate PRs
+   - **Mitigation:** `security-override` label with audit trail
+
+2. **Risk:** pip-audit service unavailable
+   - **Mitigation:** `continue-on-error` with manual review fallback
+
+### Rollback Plan
+
+If issues occur:
+1. Remove `--strict` flag to make advisory-only
+2. Keep artifact upload for visibility
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 4.13 - CI Security Scanning & SBOM Publishing
+- **Related:** Story 4.15 - Developer Docs for Security Scans
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-01-23 | Initial draft from security audit | Claude |

--- a/docs/stories/6.13.graceful-drain-on-shutdown.md
+++ b/docs/stories/6.13.graceful-drain-on-shutdown.md
@@ -1,0 +1,316 @@
+# Story 6.13: Graceful Log Drain on Abrupt Shutdown
+
+**Status:** Ready
+**Priority:** Medium (P2 - Reliability)
+**Depends on:** None
+
+---
+
+## Context / Background
+
+The logger's thread loop mode creates a daemon thread for background log processing (`src/fapilog/core/logger.py:248-250`):
+
+```python
+# Start the worker thread (daemon=True so it won't block process exit)
+self._worker_thread = threading.Thread(target=_run, daemon=True)
+self._worker_thread.start()
+```
+
+**Problem:** Daemon threads are terminated immediately when the main process exits. If the process exits abruptly (SIGKILL, crash, `os._exit()`, or simply finishing without calling `drain()`), any logs still in the queue are lost.
+
+This is especially problematic for error logs—the most critical logs to preserve are often generated right before a crash.
+
+**Current mitigations:**
+- `runtime()` context manager drains on exit
+- `__del__` emits `ResourceWarning` if not drained
+- Documentation recommends explicit `drain()` calls
+
+**Gap:** No mechanism to flush critical logs on abrupt shutdown.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Add `atexit` handler for best-effort drain on normal exit
+- Add signal handlers for SIGTERM/SIGINT graceful shutdown
+- Add configurable "critical flush" for ERROR/CRITICAL logs
+- Document shutdown behavior and limitations
+- Add metrics for logs lost on shutdown
+
+### Out of Scope
+
+- Protection against SIGKILL (impossible by design)
+- Persistent queue across restarts (WAL-style, future work)
+- Distributed logging guarantees
+- Full Windows SIGTERM support (not available on Windows)
+
+---
+
+## Acceptance Criteria
+
+### AC1: Atexit Handler for Normal Exit
+
+**Description:** When Python exits normally, pending logs are flushed before the daemon thread is killed.
+
+**Validation:**
+```python
+import fapilog
+
+logger = fapilog.get_logger()
+logger.info("test message")
+# No explicit drain() - atexit handler should flush
+# Exit normally - message should appear in output
+```
+
+### AC2: Signal Handler for SIGTERM/SIGINT
+
+**Description:** On SIGTERM or SIGINT, attempt graceful drain with timeout before allowing termination.
+
+**Validation:**
+```python
+# Process receives SIGTERM
+# Handler sets stop flag, waits up to N seconds for drain
+# If timeout, proceeds with exit (logs warning about lost messages)
+```
+
+### AC3: Configurable via Settings
+
+**Description:** Shutdown behavior is configurable.
+
+**Validation:**
+```toml
+[core]
+atexit_drain_enabled = true  # Default: true
+atexit_drain_timeout_seconds = 2.0  # Default: 2.0
+signal_handler_enabled = true  # Default: true
+```
+
+### AC4: Metrics for Lost Logs
+
+**Description:** Track count of logs that could not be flushed on shutdown.
+
+**Validation:**
+```python
+result = logger.drain()
+print(f"Lost on shutdown: {result.dropped}")
+# Or via metrics collector if enabled
+```
+
+### AC5: Critical Log Immediate Flush Option
+
+**Description:** ERROR and CRITICAL logs can be configured to flush immediately (bypass batching).
+
+**Validation:**
+```toml
+[core]
+flush_on_critical = true  # Immediately flush ERROR/CRITICAL
+```
+
+```python
+logger.error("something bad")  # Immediately flushed, not batched
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/logger.py (MODIFIED - add atexit/signal handlers)
+src/fapilog/core/settings.py (MODIFIED - add shutdown settings)
+src/fapilog/__init__.py (MODIFIED - register atexit handler)
+tests/unit/test_shutdown.py (NEW)
+docs/user-guide/shutdown.md (NEW)
+```
+
+### Key Code
+
+```python
+# In __init__.py or logger.py
+import atexit
+import signal
+
+_shutdown_in_progress = False
+_registered_loggers: weakref.WeakSet[SyncLoggerFacade] = weakref.WeakSet()
+
+def _atexit_handler() -> None:
+    """Best-effort drain of all loggers on normal exit."""
+    global _shutdown_in_progress
+    _shutdown_in_progress = True
+
+    timeout = 2.0  # From settings
+    for logger in list(_registered_loggers):
+        try:
+            # Run async drain in sync context
+            # Note: asyncio.run() is safe here since we're in atexit
+            coro = logger.stop_and_drain()
+            try:
+                import asyncio
+                asyncio.run(asyncio.wait_for(coro, timeout=timeout))
+            except asyncio.TimeoutError:
+                pass  # Best effort - proceed with exit
+            except RuntimeError:
+                # Event loop already running - try thread approach
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                    ex.submit(lambda: asyncio.run(coro)).result(timeout=timeout)
+        except Exception:
+            pass
+
+def _signal_handler(signum: int, frame: Any) -> None:
+    """Graceful shutdown on SIGTERM/SIGINT."""
+    global _shutdown_in_progress
+    if _shutdown_in_progress:
+        return  # Already shutting down
+    _shutdown_in_progress = True
+
+    _atexit_handler()
+
+    # Re-raise to allow default handler
+    signal.signal(signum, signal.SIG_DFL)
+    signal.raise_signal(signum)
+
+# Register on module load
+atexit.register(_atexit_handler)
+
+# Signal handlers (only if enabled in settings)
+# Note: SIGTERM not available on Windows
+if settings.core.signal_handler_enabled:
+    signal.signal(signal.SIGINT, _signal_handler)
+    if hasattr(signal, 'SIGTERM'):  # Not available on Windows
+        signal.signal(signal.SIGTERM, _signal_handler)
+```
+
+### Critical Flush Implementation
+
+```python
+def _enqueue(self, level: str, message: str, **metadata: Any) -> None:
+    payload = self._prepare_payload(level, message, **metadata)
+    if payload is None:
+        return
+
+    # Immediate flush for critical logs if configured
+    if self._flush_on_critical and level in {"ERROR", "CRITICAL"}:
+        self._flush_immediate(payload)
+        return
+
+    # Normal batched path
+    self._queue.put(payload)
+```
+
+---
+
+## Tasks
+
+### Phase 1: Atexit Handler
+
+- [ ] Add `_atexit_handler` function
+- [ ] Register handler in `__init__.py`
+- [ ] Track active loggers with WeakSet
+- [ ] Add `atexit_drain_timeout_seconds` setting
+- [ ] Add `atexit_drain_enabled` setting
+
+### Phase 2: Signal Handlers
+
+- [ ] Add `_signal_handler` function
+- [ ] Register for SIGTERM and SIGINT
+- [ ] Add `signal_handler_enabled` setting
+- [ ] Handle re-entrancy (multiple signals)
+
+### Phase 3: Critical Flush
+
+- [ ] Add `flush_on_critical` setting
+- [ ] Implement immediate flush path in `_enqueue`
+- [ ] Ensure thread safety for immediate flush
+
+### Phase 4: Documentation
+
+- [ ] Document shutdown behavior
+- [ ] Document limitations (SIGKILL)
+- [ ] Add troubleshooting guide
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_shutdown.py`
+  - `test_atexit_handler_drains_loggers`
+  - `test_atexit_respects_timeout`
+  - `test_signal_handler_drains_on_sigterm`
+  - `test_flush_on_critical_immediate`
+  - `test_shutdown_disabled_via_settings`
+  - `test_weakref_cleanup_dead_loggers`
+
+### Integration Tests
+
+- `tests/integration/test_shutdown_integration.py`
+  - Subprocess test: normal exit flushes logs
+  - Subprocess test: SIGTERM allows drain
+  - Subprocess test: verify lost log count
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] Code follows project patterns
+- [ ] No new linting errors
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] Integration tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Code has docstrings where needed
+- [ ] Shutdown guide created
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Signal handler interferes with application's own handlers
+   - **Mitigation:** Make signal handling opt-in via setting, chain to previous handler
+
+2. **Risk:** Atexit handler delays shutdown noticeably
+   - **Mitigation:** Short timeout (2s default), configurable
+
+3. **Risk:** Deadlock if drain is called during shutdown
+   - **Mitigation:** `_shutdown_in_progress` flag to short-circuit
+
+### Rollback Plan
+
+If issues occur:
+1. Disable atexit handler via setting
+2. Disable signal handlers via setting
+3. Revert to current daemon-only behavior
+
+---
+
+## Related Stories
+
+- **Related:** Story 6.8 - Unify logger facade implementations
+- **Related:** Story 5.30 - Document event loop lifecycle
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2025-01-23 | Initial draft from reliability audit | Claude |


### PR DESCRIPTION
## Summary

Adds three stories from a security/reliability audit of the codebase:

| Story | Priority | Issue |
|-------|----------|-------|
| **4.51** | P1 (High) | Header logging can leak secrets if `include_headers=True` without proper `redact_headers` config |
| **4.52** | P2 (Medium) | Security scanning (`pip-audit`) runs but doesn't fail builds on vulnerabilities |
| **6.13** | P2 (Medium) | Daemon worker thread can lose queued logs on abrupt shutdown |

## Changes

- `docs/stories/4.51.secure-header-redaction-defaults.md` (new)
- `docs/stories/4.52.enforce-security-scanning-ci.md` (new)
- `docs/stories/6.13.graceful-drain-on-shutdown.md` (new)

## Acceptance Criteria

- [x] Stories follow template format
- [x] Stories reviewed and set to Ready status
- [x] Code references verified against codebase
- [x] Related stories identified

## Test Plan

- [x] Stories pass review validation
- [x] No broken internal references