### PR TITLE
chore(core): improve package metadata and Python version support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ Project maintainers are responsible for clarifying standards of acceptable behav
 
 ## Contact
 
-For conduct-related concerns, contact: **chris@fapilog.dev**
+For conduct-related concerns, contact: **conduct@fapilog.dev**
 
 ## Attribution
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ Custom styling is applied through:
 
 The documentation is automatically built and deployed via GitHub Actions:
 
-- **Build**: Runs on all Python versions (3.10-3.12)
+- **Build**: Runs on all Python versions (3.10-3.14)
 - **Validation**: Checks for broken links and build issues
 - **Deployment**: Automatically deploys to GitHub Pages on main branch
 - **Quality Checks**: Runs on pull requests

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -43,8 +43,8 @@ PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.v
 PYTHON_MAJOR=$(echo $PYTHON_VERSION | cut -d. -f1)
 PYTHON_MINOR=$(echo $PYTHON_VERSION | cut -d. -f2)
 
-if [ "$PYTHON_MAJOR" -lt 3 ] || ([ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 8 ]); then
-    print_error "Python 3.8 or higher is required (found $PYTHON_VERSION)"
+if [ "$PYTHON_MAJOR" -lt 3 ] || ([ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 10 ]); then
+    print_error "Python 3.10 or higher is required (found $PYTHON_VERSION)"
     exit 1
 fi
 

--- a/packages/fapilog-audit/pyproject.toml
+++ b/packages/fapilog-audit/pyproject.toml
@@ -7,9 +7,9 @@ name = "fapilog-audit"
 version = "0.1.0"
 description = "Audit trail and compliance add-on for fapilog"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 authors = [
-    {name = "Chris Haste", email = "chris@haste.dev"}
+    {name = "Chris Haste", email = "dev@fapilog.dev"}
 ]
 keywords = ["logging", "audit", "compliance", "tamper-evident", "enterprise"]
 classifiers = [
@@ -21,6 +21,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: System :: Logging",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/packages/fapilog-tamper/pyproject.toml
+++ b/packages/fapilog-tamper/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Tamper-evident logging add-on for fapilog"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 authors = [{name = "Fapilog", email = "dev@fapilog.dev"}]
 dependencies = [
   "fapilog>=0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,13 @@ name = "fapilog"
 dynamic = ["version"]
 description = "Async-first structured logging for Python services"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
-    {name = "Chris Haste", email = "chris@haste.dev"}
+    {name = "Chris Haste", email = "dev@fapilog.dev"}
 ]
 maintainers = [
-    {name = "Chris Haste", email = "chris@haste.dev"}
+    {name = "Chris Haste", email = "dev@fapilog.dev"}
 ]
 keywords = ["logging", "async", "fastapi", "observability", "enterprise"]
 classifiers = [
@@ -24,6 +25,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: System :: Logging",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Framework :: FastAPI",
@@ -115,11 +118,12 @@ all = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/chris-haste/fapilog"
-Documentation = "https://fapilog.readthedocs.io/"
+Homepage = "https://fapilog.dev"
+Documentation = "https://fapilog.readthedocs.io/en/stable/"
 Repository = "https://github.com/chris-haste/fapilog"
 "Bug Tracker" = "https://github.com/chris-haste/fapilog/issues"
 Discord = "https://discord.gg/gHaNsczWte"
+Changelog = "https://github.com/chris-haste/fapilog/blob/main/CHANGELOG.md"
 
 # [project.scripts]
 # fapilog = "fapilog.cli:main"  # CLI coming in future release

--- a/src/fapilog/plugins/metadata.py
+++ b/src/fapilog/plugins/metadata.py
@@ -20,7 +20,7 @@ class PluginCompatibility(BaseModel):
         default=None,
         description="Maximum supported Fapilog version (None for no limit)",
     )
-    python_version: str = Field(default=">=3.8", description="Required Python version")
+    python_version: str = Field(default=">=3.10", description="Required Python version")
 
     @field_validator("min_fapilog_version", "max_fapilog_version")
     @classmethod

--- a/tests/plugin_examples/fapilog-sample-plugin/pyproject.toml
+++ b/tests/plugin_examples/fapilog-sample-plugin/pyproject.toml
@@ -9,7 +9,7 @@ description = "Sample plugin skeleton for fapilog CI smoke tests"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{name = "Fapilog", email = "dev@fapilog.dev"}]
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 dependencies = [
   "fapilog>=3,<4",
 ]


### PR DESCRIPTION
## Summary

Improves PyPI package metadata following the Python packaging guide and adds Python 3.13/3.14 support to nightly CI.

## Changes

- `pyproject.toml` (modified) - PEP 639 license format, license-files, updated URLs, Python 3.13/3.14 classifiers, dev@fapilog.dev email
- `.github/workflows/nightly.yml` (modified) - Added Python 3.13 and 3.14 to test matrix
- `CODE_OF_CONDUCT.md` (modified) - Updated contact email to conduct@fapilog.dev
- `docs/README.md` (modified) - Updated Python version range to 3.10-3.14
- `docs/build.sh` (modified) - Fixed Python version check from 3.8 to 3.10
- `packages/fapilog-audit/pyproject.toml` (modified) - PEP 639 license, Python classifiers, email
- `packages/fapilog-tamper/pyproject.toml` (modified) - PEP 639 license format
- `src/fapilog/plugins/metadata.py` (modified) - Default python_version from >=3.8 to >=3.10
- `tests/plugin_examples/fapilog-sample-plugin/pyproject.toml` (modified) - PEP 639 license format

## Acceptance Criteria

- [x] License format updated to PEP 639 SPDX string
- [x] Project URLs include Homepage (fapilog.dev) and Changelog
- [x] Python 3.13 and 3.14 added to classifiers and nightly CI
- [x] All Python version references consistently require 3.10+
- [x] Author emails standardized to dev@fapilog.dev

## Test Plan

- [x] Pre-commit hooks pass
- [x] No functional changes - metadata only