### PR TITLE
docs: add homepage link to documentation footer

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -17,3 +17,10 @@
 <meta name="robots" content="noindex, follow" />
 {% endif %}
 {% endblock %}
+
+{% block footer %}
+{{ super() }}
+<div style="text-align: center; padding: 1rem; font-size: 0.9em;">
+  <a href="https://fapilog.dev">← Back to fapilog.dev</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds a "Back to fapilog.dev" link to the footer of all documentation pages, providing consistent navigation back to the project homepage.

## Changes

- `docs/_templates/layout.html` (modified) - Added footer block with homepage link

## Test Plan

- [x] Build docs locally and verify footer link appears
- [x] Link points to https://fapilog.dev