### PR TITLE
fix(docs): move footer link inside footer element

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,0 +1,8 @@
+{# Override footer to add link back to fapilog.dev #}
+{% extends "!footer.html" %}
+
+{% block extrafooter %}
+<p style="text-align: center; margin-top: 1rem;">
+  <a href="https://fapilog.dev">← Back to fapilog.dev</a>
+</p>
+{% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -17,10 +17,3 @@
 <meta name="robots" content="noindex, follow" />
 {% endif %}
 {% endblock %}
-
-{% block footer %}
-{{ super() }}
-<div style="text-align: center; padding: 1rem; font-size: 0.9em;">
-  <a href="https://fapilog.dev">← Back to fapilog.dev</a>
-</div>
-{% endblock %}


### PR DESCRIPTION
## Summary

Fix the "Back to fapilog.dev" link so it renders visibly inside the footer instead of outside the page layout.

## Changes

- `docs/_templates/footer.html` (new) - Override using `extrafooter` block
- `docs/_templates/layout.html` (modified) - Remove non-working footer block

## Problem

The footer link was rendering after the closing `</footer>` tag, placing it outside the visible content area. The `{% block footer %}` in layout.html adds content after the footer include, not inside it.

## Solution

Use `extrafooter` block in a separate `footer.html` template override, which injects content inside the `<footer>` element.