### PR TITLE
fix(docs): move homepage link between prev/next nav buttons

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,8 +1,58 @@
-{# Override footer to add link back to fapilog.dev #}
-{% extends "!footer.html" %}
+{# Custom footer with centered homepage link between prev/next buttons #}
+<footer>
+  {%- if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
+    <div class="rst-footer-buttons" role="navigation" aria-label="{{ _('Footer') }}">
+      {%- if prev %}
+        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
+      {%- endif %}
+      <a href="https://fapilog.dev" style="display: block; text-align: center;">www.fapilog.dev</a>
+      {%- if next %}
+        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
+      {%- endif %}
+    </div>
+  {%- endif %}
 
-{% block extrafooter %}
-<p style="text-align: center; margin-top: 1rem;">
-  <a href="https://fapilog.dev">← Back to fapilog.dev</a>
-</p>
-{% endblock %}
+  <hr/>
+
+  <div role="contentinfo">
+  {%- block contentinfo %}
+    <p>
+    {%- if show_copyright %}
+      {%- if hasdoc('copyright') %}
+        {%- trans path=pathto('copyright'), copyright=copyright|e %}&#169; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+      {%- else %}
+        {%- trans copyright=copyright|e %}&#169; Copyright {{ copyright }}.{% endtrans %}
+      {%- endif %}
+    {%- endif %}
+
+    {%- if build_id and build_url %}
+      <span class="build">
+        {%- trans %}Build{% endtrans -%}
+        <a href="{{ build_url }}">{{ build_id }}</a>.
+      </span>
+    {%- elif commit %}
+      <span class="commit">
+        {%- trans %}Revision{% endtrans %} <code>{{ commit }}</code>.
+      </span>
+    {%- endif %}
+    {%- if last_updated %}
+      <span class="lastupdated">
+        {%- trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+      </span>
+    {%- endif -%}
+
+    </p>
+  {%- endblock %}
+  </div>
+
+  {% if show_sphinx %}
+    {%- set sphinx_web = '<a href="https://www.sphinx-doc.org/">Sphinx</a>' %}
+    {%- set readthedocs_web = '<a href="https://readthedocs.org">Read the Docs</a>'  %}
+    {%- trans sphinx_web=sphinx_web, readthedocs_web=readthedocs_web %}Built with {{ sphinx_web }} using a{% endtrans %}
+    <a href="https://github.com/readthedocs/sphinx_rtd_theme">{% trans %}theme{% endtrans %}</a>
+    {% trans %}provided by {{ readthedocs_web }}{% endtrans %}.
+  {% endif %}
+
+  {%- block extrafooter %} {% endblock %}
+
+</footer>


### PR DESCRIPTION
## Summary

Move the www.fapilog.dev link from the bottom of the footer to between the Previous/Next navigation buttons.

## Changes

- `docs/_templates/footer.html` (modified) - Full footer override

## Result

```
[← Previous]     www.fapilog.dev     [Next →]
```

Styled as a plain link (not a button) for subtlety. Works correctly on:
- First page (Next only)
- Middle pages (both buttons)
- Last page (Prev only)