### PR TITLE
fix(docs): use flexbox for footer nav alignment

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,14 +1,20 @@
 {# Custom footer with centered homepage link between prev/next buttons #}
 <footer>
   {%- if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
-    <div class="rst-footer-buttons" role="navigation" aria-label="{{ _('Footer') }}">
-      {%- if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
-      {%- endif %}
-      <a href="https://fapilog.dev" style="display: block; text-align: center;">www.fapilog.dev</a>
-      {%- if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
-      {%- endif %}
+    <div class="rst-footer-buttons" role="navigation" aria-label="{{ _('Footer') }}" style="display: flex; justify-content: space-between; align-items: center;">
+      <div style="flex: 1; text-align: left;">
+        {%- if prev %}
+          <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
+        {%- endif %}
+      </div>
+      <div style="flex: 1; text-align: center;">
+        <a href="https://fapilog.dev">www.fapilog.dev</a>
+      </div>
+      <div style="flex: 1; text-align: right;">
+        {%- if next %}
+          <a href="{{ next.link|e }}" class="btn btn-neutral" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
+        {%- endif %}
+      </div>
     </div>
   {%- endif %}
 


### PR DESCRIPTION
## Summary

Fix vertical misalignment between Previous/Next buttons and the www.fapilog.dev link.

## Changes

- `docs/_templates/footer.html` (modified)

## Problem

The float-based layout caused the three elements to render at different vertical positions.

## Solution

Use flexbox with three equal-width columns:
- Left: Previous button
- Center: www.fapilog.dev link  
- Right: Next button

All elements are now vertically aligned with `align-items: center`.