### PR TITLE
fix(docs): set footer nav to full width

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,7 +1,7 @@
 {# Custom footer with centered homepage link between prev/next buttons #}
 <footer>
   {%- if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
-    <div class="rst-footer-buttons" role="navigation" aria-label="{{ _('Footer') }}" style="display: flex; justify-content: space-between; align-items: center;">
+    <div class="rst-footer-buttons" role="navigation" aria-label="{{ _('Footer') }}" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
       <div style="flex: 1; text-align: left;">
         {%- if prev %}
           <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>


### PR DESCRIPTION
## Summary

Fix footer nav buttons to span full width - Previous at left edge, Next at right edge.

## Changes

- `docs/_templates/footer.html` - Add `width: 100%` to flex container