### PR TITLE
fix(docs): use absolute positioning for centered footer link

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,19 +1,15 @@
 {# Custom footer with centered homepage link between prev/next buttons #}
 <footer>
   {%- if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
-    <div class="rst-footer-buttons" role="navigation" aria-label="{{ _('Footer') }}" style="display: flex; justify-content: space-between; align-items: center; width: 100%;">
-      <div style="flex: 1; text-align: left;">
-        {%- if prev %}
-          <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
-        {%- endif %}
-      </div>
-      <div style="flex: 1; text-align: center;">
+    <div class="rst-footer-buttons" role="navigation" aria-label="{{ _('Footer') }}" style="position: relative;">
+      {%- if prev %}
+        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
+      {%- endif %}
+      {%- if next %}
+        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
+      {%- endif %}
+      <div style="position: absolute; left: 50%; transform: translateX(-50%); top: 50%; margin-top: -0.5em;">
         <a href="https://fapilog.dev">www.fapilog.dev</a>
-      </div>
-      <div style="flex: 1; text-align: right;">
-        {%- if next %}
-          <a href="{{ next.link|e }}" class="btn btn-neutral" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
-        {%- endif %}
       </div>
     </div>
   {%- endif %}


### PR DESCRIPTION
## Summary

Fix footer layout so Previous/Next buttons go to edges with center link properly centered.

## Changes

- `docs/_templates/footer.html` - Use float for buttons + absolute positioning for center link

## Approach

- Float-left/right for Previous/Next (naturally go to container edges)
- Absolute positioning with `left: 50%; transform: translateX(-50%)` for center link