### PR TITLE
docs: lead with developer benefit, not implementation detail

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -136,8 +136,8 @@ This page compares five Python logging libraries that developers most commonly e
 Log Event → Enrichment → Redaction → Processing → Queue → Background Worker → Sinks
 ```
 
-- **Both `get_logger()` and `get_async_logger()` use the same background worker**
-- Bounded queue with configurable overflow policies
+- **Log calls never block on I/O** - both sync and async APIs write to background workers
+- Bounded queue with configurable overflow policies (slow sinks won't stall your app)
 - Batching reduces I/O operations
 
 ### structlog

--- a/docs/cookbook/non-blocking-async-logging.md
+++ b/docs/cookbook/non-blocking-async-logging.md
@@ -2,7 +2,7 @@
 
 Slow log sinks can stall your async application. When a network hiccup delays CloudWatch or your disk fills up, synchronous logging blocks the event loop, affecting every concurrent request. fapilog's async pipeline with configurable backpressure lets you choose: drop logs to protect latency, or block to guarantee delivery.
 
-> **Note:** Both `get_logger()` and `get_async_logger()` use the same async background worker architecture described here. The non-blocking benefits apply to both APIs.
+> **Note:** Whether you use `get_logger()` in sync code or `get_async_logger()` in async code, your log calls never block on I/O. The non-blocking benefits described here apply to both APIs.
 
 ## The Problem: Slow Sinks Block Your App
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,7 +2,7 @@
 
 Get logging with fapilog in 2 minutes.
 
-> **Choosing async vs sync:** Both `get_logger()` and `get_async_logger()` use the same async background worker—your log calls never block on I/O. The difference is the calling API: use `get_logger()` for sync code, `get_async_logger()` when you want `await` syntax in async code.
+> **Choosing async vs sync:** Your log calls never block on I/O—both `get_logger()` and `get_async_logger()` write to background workers. A slow sink won't stall your app. The only difference is the calling API: use `get_logger()` for sync code, `get_async_logger()` when you want `await` syntax.
 
 ## Zero-Config Logging
 
@@ -143,7 +143,7 @@ When you call `get_logger()` or `get_async_logger()`:
 3. **Queue setup** - Configures the buffer between your code and sink writes
 4. **Context binding** - Sets up request correlation and context propagation
 
-Both functions create the same async processing pipeline. Your log calls enqueue immediately and return—actual sink I/O happens in background worker tasks.
+Your log calls enqueue and return immediately—actual sink I/O happens in background workers. A slow disk or network sink won't affect your application's response time.
 
 ## Environment Variables
 

--- a/docs/why-fapilog.md
+++ b/docs/why-fapilog.md
@@ -30,7 +30,7 @@ Use fapilog if you're building:
 
 ### 1. True Async-First Architecture
 
-Most Python logging libraries are synchronous—they block your application while writing to disk or network. **Both `get_logger()` and `get_async_logger()` use the same async background worker.** Log calls enqueue immediately; sink writes happen in parallel worker tasks.
+Most Python logging libraries are synchronous—they block your application while writing to disk or network. **With fapilog, your log calls never block on I/O.** Whether you use `get_logger()` in sync code or `get_async_logger()` in async code, the actual writes happen in background workers. A slow CloudWatch API or full disk won't stall your request handlers.
 
 ```
 Your code          Background worker


### PR DESCRIPTION
## Summary

Updates documentation messaging to lead with the practical developer benefit rather than implementation details.

## Changes

- `docs/why-fapilog.md` (modified)
- `docs/comparisons.md` (modified)
- `docs/getting-started/quickstart.md` (modified)
- `docs/cookbook/non-blocking-async-logging.md` (modified)

## Key Messaging Change

**Before:** "Both `get_logger()` and `get_async_logger()` use the same background worker"

**After:** "Your log calls never block on I/O" + "A slow sink won't stall your app"

Developers care about what it means for them, not the implementation mechanism.

## Test Plan

- [x] Documentation builds without warnings
- [x] Messaging is consistent across all updated files