### PR TITLE
docs(stories): add story 3.9 redaction preset env var

### DIFF
--- a/docs/stories/3.9.redaction-preset-env-var.md
+++ b/docs/stories/3.9.redaction-preset-env-var.md
@@ -1,0 +1,132 @@
+# Story 3.9: Environment Variable for Redaction Presets
+
+**Status:** Draft
+**Priority:** Medium
+**Depends on:** 3.8 (Composable Redaction Presets)
+
+---
+
+## Context / Background
+
+Story 3.8 introduced composable redaction presets (`GDPR_PII`, `HIPAA_PHI`, `PCI_DSS`, etc.) accessible via the Builder API:
+
+```python
+LoggerBuilder().with_redaction(preset="GDPR_PII").build()
+```
+
+**The gap:** There's no environment variable equivalent. Users following 12-factor app principles or deploying to Kubernetes cannot configure redaction presets without code changes.
+
+**Current state:**
+- Redaction presets work via Builder: `with_redaction(preset="...")`
+- Other redaction settings have env vars: `FAPILOG_CORE__REDACTORS`, `FAPILOG_REDACTOR_CONFIG__FIELD_MASK__*`
+- No env var for preset selection
+
+**User problem:** A platform team wants to enforce HIPAA compliance across all services via environment configuration, without requiring each service to change code.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Single preset via environment variable
+```bash
+export FAPILOG_REDACTION_PRESET=GDPR_PII
+```
+
+When set, the preset fields/patterns are automatically applied to the redaction configuration.
+
+### AC2: Multiple presets via comma-separated list
+```bash
+export FAPILOG_REDACTION_PRESET=GDPR_PII,PCI_DSS,CREDENTIALS
+```
+
+Presets are applied in order, with fields/patterns merged additively.
+
+### AC3: Works with Settings-based configuration
+```python
+from fapilog import get_logger, Settings
+
+# Env var is respected when using Settings
+logger = get_logger()  # Picks up FAPILOG_REDACTION_PRESET from environment
+```
+
+### AC4: Builder can override env var
+```python
+# Builder takes precedence over env var
+logger = LoggerBuilder().with_redaction(preset="PCI_DSS", replace=True).build()
+```
+
+### AC5: Invalid preset name raises clear error
+```bash
+export FAPILOG_REDACTION_PRESET=INVALID_PRESET
+```
+
+Error message should list available presets.
+
+### AC6: Documentation updated
+- `docs/env-vars.md` includes new variable
+- `docs/redaction/configuration.md` shows env var usage
+- Decision guide updated to mention env var for presets
+
+---
+
+## Technical Notes
+
+### Settings field location
+
+Add to `RedactorConfigSettings` or `CoreSettings`:
+
+```python
+class RedactorConfigSettings(BaseSettings):
+    preset: str | list[str] | None = Field(
+        default=None,
+        description="Redaction preset(s) to apply: GDPR_PII, HIPAA_PHI, PCI_DSS, etc."
+    )
+```
+
+### Env var naming options
+
+| Option | Example | Pros | Cons |
+|--------|---------|------|------|
+| `FAPILOG_REDACTION_PRESET` | Simple, clear | New top-level namespace | Not nested under existing |
+| `FAPILOG_REDACTOR_CONFIG__PRESET` | Follows existing pattern | Consistent | Longer |
+| `FAPILOG_CORE__REDACTION_PRESET` | Under core | Groups with other core settings | Mixed concerns |
+
+**Recommendation:** `FAPILOG_REDACTION_PRESET` - clear and discoverable.
+
+### Interaction with existing config
+
+The preset should merge with (not replace) existing field_mask/regex_mask configuration:
+
+```bash
+export FAPILOG_REDACTION_PRESET=GDPR_PII
+export FAPILOG_REDACTOR_CONFIG__FIELD_MASK__FIELDS_TO_MASK=["internal_id"]
+# Result: GDPR_PII fields + internal_id
+```
+
+---
+
+## Out of Scope
+
+- Runtime preset switching (presets resolved at logger creation time)
+- Custom preset registration via env var (use code for custom presets)
+
+---
+
+## Test Plan
+
+1. Unit test: Preset applied when env var set
+2. Unit test: Multiple presets comma-separated
+3. Unit test: Invalid preset raises ValueError with available presets
+4. Unit test: Builder `replace=True` overrides env var
+5. Integration test: End-to-end with real logging
+6. Parity test: `check_builder_parity.py` passes
+
+---
+
+## Story Points
+
+**Estimate:** 3 points (small-medium)
+
+- Settings field addition: 1 point
+- Preset resolution logic: 1 point
+- Documentation: 1 point


### PR DESCRIPTION
## Summary

Adds story 3.9 for environment variable support for redaction presets.

## Problem

Users following 12-factor app principles cannot configure redaction presets (`GDPR_PII`, `HIPAA_PHI`, etc.) without code changes. This is a configuration parity gap.

## Proposed Solution

```bash
# Single preset
export FAPILOG_REDACTION_PRESET=GDPR_PII

# Multiple presets
export FAPILOG_REDACTION_PRESET=GDPR_PII,PCI_DSS,CREDENTIALS
```

## Story

[3.9 - Redaction Preset Env Var](docs/stories/3.9.redaction-preset-env-var.md)