### PR TITLE
docs(stories): add story 3.9 redaction preset env var

### DIFF
--- a/docs/stories/3.8.composable-redaction-presets.md
+++ b/docs/stories/3.8.composable-redaction-presets.md
@@ -1,6 +1,6 @@
 # Story 3.8: Composable Redaction Presets
 
-**Status:** Ready for Code Review
+**Status:** Complete (v0.7.0)
 **Priority:** High
 **Depends on:** None (builds on existing redactor infrastructure)
 

--- a/docs/stories/3.9.redaction-preset-env-var.md
+++ b/docs/stories/3.9.redaction-preset-env-var.md
@@ -1,0 +1,158 @@
+# Story 3.9: Environment Variable for Redaction Presets
+
+**Status:** Ready
+**Priority:** Medium
+**Depends on:** 3.8 (Composable Redaction Presets - Complete)
+
+---
+
+## Context / Background
+
+Story 3.8 introduced composable redaction presets (`GDPR_PII`, `HIPAA_PHI`, `PCI_DSS`, etc.) accessible via the Builder API:
+
+```python
+LoggerBuilder().with_redaction(preset="GDPR_PII").build()
+```
+
+**The gap:** There's no environment variable equivalent. Users following 12-factor app principles or deploying to Kubernetes cannot configure redaction presets without code changes.
+
+**Current state:**
+- Redaction presets work via Builder: `with_redaction(preset="...")`
+- Other redaction settings have env vars: `FAPILOG_REDACTOR_CONFIG__FIELD_MASK__*`
+- No env var for preset selection
+
+**User problem:** A platform team wants to enforce HIPAA compliance across all services via environment configuration, without requiring each service to change code.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Single preset via environment variable
+```bash
+export FAPILOG_REDACTOR_CONFIG__PRESET=GDPR_PII
+```
+
+When set, the preset fields/patterns are automatically applied to the redaction configuration.
+
+### AC2: Multiple presets via comma-separated list
+```bash
+export FAPILOG_REDACTOR_CONFIG__PRESET=GDPR_PII,PCI_DSS,CREDENTIALS
+```
+
+Presets are applied in order, with fields/patterns merged additively.
+
+### AC3: Case-insensitive preset names
+```bash
+export FAPILOG_REDACTOR_CONFIG__PRESET=gdpr_pii  # Works same as GDPR_PII
+```
+
+### AC4: Works with Settings-based configuration
+```python
+from fapilog import get_logger
+
+# Env var is respected when using get_logger()
+logger = get_logger()  # Picks up FAPILOG_REDACTOR_CONFIG__PRESET from environment
+```
+
+### AC5: Builder overrides env var when replace=True
+```python
+# Env var preset is ignored when Builder uses replace=True
+logger = LoggerBuilder().with_redaction(preset="PCI_DSS", replace=True).build()
+```
+
+### AC6: Builder merges with env var by default
+```python
+# Env var: FAPILOG_REDACTOR_CONFIG__PRESET=GDPR_PII
+# Builder adds to env var preset (additive)
+logger = LoggerBuilder().with_redaction(fields=["internal_id"]).build()
+# Result: GDPR_PII fields + internal_id
+```
+
+### AC7: Invalid preset name raises clear error
+```bash
+export FAPILOG_REDACTOR_CONFIG__PRESET=INVALID_PRESET
+```
+
+Error message should list available presets:
+```
+ValueError: Unknown redaction preset 'INVALID_PRESET'. Available: GDPR_PII, HIPAA_PHI, PCI_DSS, ...
+```
+
+### AC8: Documentation updated
+- `docs/env-vars.md` includes new variable
+- `docs/redaction/configuration.md` shows env var usage
+- `docs/user-guide/configuration.md` decision guide mentions env var for presets
+
+---
+
+## Technical Notes
+
+### Settings field location
+
+Add `preset` field to `Settings.RedactorConfig` (nested class in `src/fapilog/core/settings.py:996`):
+
+```python
+class RedactorConfig(BaseModel):
+    """Per-redactor configuration for built-in redactors."""
+
+    preset: str | list[str] | None = Field(
+        default=None,
+        description="Redaction preset(s) to apply: GDPR_PII, HIPAA_PHI, PCI_DSS, CCPA_PII, CREDENTIALS",
+    )
+    field_mask: RedactorFieldMaskSettings = ...
+    # ... existing fields
+```
+
+### Env var naming
+
+Use `FAPILOG_REDACTOR_CONFIG__PRESET` to match existing pattern:
+- `FAPILOG_REDACTOR_CONFIG__FIELD_MASK__*`
+- `FAPILOG_REDACTOR_CONFIG__REGEX_MASK__*`
+- `FAPILOG_REDACTOR_CONFIG__PRESET` ← new
+
+### Preset resolution order
+
+1. Env var preset(s) applied first (if set)
+2. Builder `with_redaction(preset=...)` merges additively (or replaces if `replace=True`)
+3. Builder `with_redaction(fields=...)` merges additively
+
+### Interaction with existing config
+
+The preset merges with (not replaces) existing field_mask/regex_mask configuration:
+
+```bash
+export FAPILOG_REDACTOR_CONFIG__PRESET=GDPR_PII
+export FAPILOG_REDACTOR_CONFIG__FIELD_MASK__FIELDS_TO_MASK='["internal_id"]'
+# Result: GDPR_PII fields + internal_id
+```
+
+---
+
+## Out of Scope
+
+- Runtime preset switching (presets resolved at logger creation time)
+- Custom preset registration via env var (use code for custom presets)
+- Env var alias (e.g., `FAPILOG_REDACTION_PRESET`) - stick with consistent naming
+
+---
+
+## Test Plan
+
+1. Unit test: Preset applied when env var set
+2. Unit test: Multiple presets comma-separated
+3. Unit test: Case-insensitive preset names
+4. Unit test: Invalid preset raises ValueError with available presets listed
+5. Unit test: Builder `replace=True` overrides env var
+6. Unit test: Builder without `replace` merges with env var
+7. Integration test: End-to-end with real logging
+8. Parity test: `check_builder_parity.py` passes
+
+---
+
+## Story Points
+
+**Estimate:** 3 points (small-medium)
+
+- Settings field addition: 1 point
+- Preset resolution logic: 1 point
+- Documentation: 1 point


### PR DESCRIPTION
## Summary

Adds story 3.9 for environment variable support for redaction presets, enabling 12-factor app configuration.

## Changes

- **Story 3.9**: `FAPILOG_REDACTOR_CONFIG__PRESET` env var support
- **Story 3.8**: Updated status to Complete (released in v0.7.0)

## Key Features (Story 3.9)

```bash
# Single preset
export FAPILOG_REDACTOR_CONFIG__PRESET=GDPR_PII

# Multiple presets
export FAPILOG_REDACTOR_CONFIG__PRESET=GDPR_PII,PCI_DSS,CREDENTIALS
```

## Review Fixes Applied

- ✅ Corrected Settings class name (`Settings.RedactorConfig` not `RedactorConfigSettings`)
- ✅ Consistent env var naming (`FAPILOG_REDACTOR_CONFIG__PRESET`)
- ✅ Added case-insensitivity AC
- ✅ Clarified Builder merge vs replace behavior

## Story

[3.9 - Redaction Preset Env Var](docs/stories/3.9.redaction-preset-env-var.md)