### PR TITLE
docs(stories): add story 4.53 write_serialized correctness standardiz…

### DIFF
--- a/docs/stories/4.41.sink-failure-signaling.md
+++ b/docs/stories/4.41.sink-failure-signaling.md
@@ -1,6 +1,6 @@
 # Story 4.41: Sink Failure Signaling and Fallback Policy
 
-**Status:** Ready for Code Review  
+**Status:** Partially Implemented  
 **Priority:** High  
 **Depends on:** Story 10.6 (Enhanced Default Behaviors)  
 **Effort:** 2-3 days

--- a/docs/stories/4.53.write-serialized-correctness-standardization.md
+++ b/docs/stories/4.53.write-serialized-correctness-standardization.md
@@ -1,0 +1,393 @@
+# Story 4.53: Standardize write_serialized Error Handling and Eliminate Silent Data Loss
+
+**Status:** Ready
+**Priority:** High
+**Depends on:** Story 4.41 (Sink Failure Signaling and Fallback Policy) — partially implemented; core infrastructure exists but http/webhook/contrib sinks were not updated
+**Effort:** 2-3 days
+
+---
+
+## Context / Background
+
+An external audit (v0.7.0 assessment) identified a **correctness risk** in the HTTP sink's `write_serialized` fallback path. Investigation revealed this is a **systemic pattern** across multiple sinks.
+
+### The Problem
+
+When `write_serialized()` fails to deserialize a `SerializedView`, sinks silently replace the original log data with placeholder values like `{"message": "fallback"}`. This causes:
+
+1. **Silent data loss** — Original log entry is discarded
+2. **Audit trail pollution** — Meaningless placeholder data is written instead
+3. **No observability** — No logging, warnings, or metrics when failures occur
+4. **Inconsistent behavior** — Each sink handles failures differently
+
+### Evidence
+
+**HTTP Sink** (`src/fapilog/plugins/sinks/http_client.py:156-167`):
+```python
+async def write_serialized(self, view: SerializedView) -> None:
+    try:
+        data = json.loads(bytes(view.data))
+    except Exception:
+        data = None
+    if data is not None:
+        await self.write(data)
+        return
+    await self._sender.post_json(
+        self._config.endpoint,
+        json={"message": "fallback"},  # ← Silent data loss
+    )
+```
+
+**Webhook Sink** (`src/fapilog/plugins/sinks/webhook.py:144-151`):
+```python
+async def write_serialized(self, view: SerializedView) -> None:
+    try:
+        import json
+        data = json.loads(bytes(view.data))
+    except Exception:
+        data = {"message": "fallback"}  # ← Silent data loss
+    await self.write(data)
+```
+
+**Loki Sink** (`src/fapilog/plugins/sinks/contrib/loki.py:102-107`):
+```python
+async def write_serialized(self, view: SerializedView) -> None:
+    try:
+        log_line = bytes(view.data).decode("utf-8")
+    except Exception:
+        log_line = json.dumps({"raw": str(view.data)})  # ← Data transformation
+    await self.write({"_raw": log_line, "level": "INFO"})
+```
+
+**CloudWatch Sink** (`src/fapilog/plugins/sinks/contrib/cloudwatch.py:142-152`):
+- Similar pattern, uses `{"raw": str(view.data)}` fallback
+
+### Good Implementations (Reference)
+
+**PostgreSQL Sink** (`src/fapilog/plugins/sinks/contrib/postgres.py:150-161`):
+```python
+async def write_serialized(self, view: SerializedView) -> None:
+    try:
+        payload = json.loads(bytes(view.data).decode("utf-8"))
+        if isinstance(payload, dict):
+            await self._enqueue_for_batch(payload)
+    except Exception as exc:
+        diagnostics.warn(  # ← Logs the error (good)
+            "postgres-sink",
+            "failed to decode serialized payload",
+            error=str(exc),
+        )
+        # But silently drops the entry (still problematic)
+```
+
+**StdoutJson/RotatingFile Sinks**:
+- Raise `SinkWriteError` on failure (correct behavior per Story 4.41)
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Define standard `write_serialized` error handling contract
+- Update all sinks with silent data loss patterns to:
+  - Log/warn on deserialization failures
+  - Signal failure via `SinkWriteError` or return `False` (per Story 4.41)
+  - Record metrics for dropped/failed events
+- Add contract tests ensuring `write_serialized` implementations comply
+- Document the standard pattern for plugin authors
+
+### Out of Scope
+
+- Changes to `write()` method error handling (covered by Story 4.41)
+- New sink implementations
+- Changes to serialization format or `SerializedView` structure
+- Performance optimizations
+
+---
+
+## Acceptance Criteria
+
+### AC1: No Silent Data Loss
+
+**Description:** `write_serialized` implementations must never silently replace log data with placeholder values.
+
+**Validation:**
+```python
+# These patterns are FORBIDDEN:
+data = {"message": "fallback"}  # ✗ Placeholder substitution
+json={"message": "fallback"}    # ✗ Hardcoded fallback payload
+log_line = json.dumps({"raw": str(view.data)})  # ✗ Data transformation on error
+
+# Correct pattern:
+except Exception as exc:
+    diagnostics.warn("sink-name", "failed to decode", error=str(exc))
+    raise SinkWriteError("...", cause=exc)  # ✓ Signal failure
+```
+
+### AC2: Failures Are Observable
+
+**Description:** All `write_serialized` failures must emit diagnostics and/or metrics.
+
+**Validation:**
+```python
+# On deserialization failure, sink MUST:
+# 1. Call diagnostics.warn() with context
+# 2. Record metric if metrics are configured
+# 3. Signal failure to core (raise or return False)
+
+async def write_serialized(self, view: SerializedView) -> None:
+    try:
+        data = json.loads(bytes(view.data))
+    except Exception as exc:
+        from ...core.diagnostics import warn
+        warn(
+            "http-sink",
+            "write_serialized deserialization failed",
+            error=str(exc),
+            data_size=len(view.data),
+        )
+        if self._metrics is not None:
+            await self._metrics.record_events_dropped(1)
+        raise SinkWriteError(
+            "Failed to deserialize payload in write_serialized",
+            sink_name=self.name,
+            cause=exc,
+        ) from exc
+    await self.write(data)
+```
+
+### AC3: Consistent Exception Handling
+
+**Description:** All `write_serialized` implementations use specific exception types, not bare `except Exception:`.
+
+**Validation:**
+```python
+# FORBIDDEN:
+except Exception:
+    data = None
+
+# REQUIRED (catch specific exceptions or re-raise):
+except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+    # Handle known deserialization errors
+    raise SinkWriteError(...) from exc
+except Exception as exc:
+    # Unexpected errors must still signal failure
+    raise SinkWriteError(...) from exc
+```
+
+### AC4: All Affected Sinks Updated
+
+**Description:** All sinks identified in the audit are updated to comply.
+
+**Affected sinks:**
+| Sink | File | Status |
+|------|------|--------|
+| HttpSink | `src/fapilog/plugins/sinks/http_client.py` | ☐ |
+| WebhookSink | `src/fapilog/plugins/sinks/webhook.py` | ☐ |
+| LokiSink | `src/fapilog/plugins/sinks/contrib/loki.py` | ☐ |
+| CloudWatchSink | `src/fapilog/plugins/sinks/contrib/cloudwatch.py` | ☐ |
+| PostgresSink | `src/fapilog/plugins/sinks/contrib/postgres.py` | ☐ |
+
+### AC5: Contract Tests
+
+**Description:** Tests verify `write_serialized` implementations handle errors correctly.
+
+**Validation:**
+```python
+# tests/unit/test_write_serialized_contract.py
+
+@pytest.mark.parametrize("sink_class", [
+    HttpSink, WebhookSink, LokiSink, CloudWatchSink, PostgresSink
+])
+async def test_write_serialized_signals_failure_on_invalid_data(sink_class):
+    """write_serialized must raise SinkWriteError on deserialization failure."""
+    sink = create_test_sink(sink_class)
+    await sink.start()
+
+    # Invalid JSON in SerializedView
+    invalid_view = SerializedView(memoryview(b"not valid json {{{"))
+
+    with pytest.raises(SinkWriteError):
+        await sink.write_serialized(invalid_view)
+
+    await sink.stop()
+
+async def test_write_serialized_emits_diagnostics_on_failure():
+    """write_serialized must emit diagnostics when deserialization fails."""
+    sink = HttpSink(config={"endpoint": "http://example.com"})
+    await sink.start()
+
+    with capture_diagnostics() as diags:
+        invalid_view = SerializedView(memoryview(b"invalid"))
+        with pytest.raises(SinkWriteError):
+            await sink.write_serialized(invalid_view)
+
+    assert any("deserialization" in d.message.lower() for d in diags)
+    await sink.stop()
+```
+
+### AC6: Documentation Updated
+
+**Description:** Plugin authoring docs include `write_serialized` error handling guidance.
+
+**Validation:**
+- `docs/plugins/sinks.md` includes error handling section for `write_serialized`
+- `docs/plugins/error-handling.md` references this pattern
+- Example code shows correct error handling
+
+---
+
+## Implementation Notes
+
+### Standard Pattern
+
+All `write_serialized` implementations should follow this pattern:
+
+```python
+async def write_serialized(self, view: SerializedView) -> None:
+    """Fast path for pre-serialized payloads."""
+    try:
+        data = json.loads(bytes(view.data))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        from ...core.diagnostics import warn
+        warn(
+            self.name,
+            "write_serialized deserialization failed",
+            error=str(exc),
+            data_size=len(view.data),
+            _rate_limit_key=f"{self.name}-deserialize",
+        )
+        if self._metrics is not None:
+            await self._metrics.record_events_dropped(1)
+        raise SinkWriteError(
+            f"Failed to deserialize payload in {self.name}.write_serialized",
+            sink_name=self.name,
+            cause=exc,
+        ) from exc
+
+    await self.write(data)
+```
+
+### File Changes
+
+```
+src/fapilog/plugins/sinks/http_client.py    (MODIFIED - fix write_serialized)
+src/fapilog/plugins/sinks/webhook.py        (MODIFIED - fix write_serialized)
+src/fapilog/plugins/sinks/contrib/loki.py   (MODIFIED - fix write_serialized)
+src/fapilog/plugins/sinks/contrib/cloudwatch.py (MODIFIED - fix write_serialized)
+src/fapilog/plugins/sinks/contrib/postgres.py   (MODIFIED - add SinkWriteError)
+tests/unit/test_write_serialized_contract.py    (NEW - contract tests)
+docs/plugins/sinks.md                           (MODIFIED - error handling section)
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Sink Fixes
+
+- [ ] Fix `HttpSink.write_serialized` error handling
+- [ ] Fix `WebhookSink.write_serialized` error handling
+- [ ] Add unit tests for HttpSink and WebhookSink
+
+### Phase 2: Contrib Sink Fixes
+
+- [ ] Fix `LokiSink.write_serialized` error handling
+- [ ] Fix `CloudWatchSink.write_serialized` error handling
+- [ ] Fix `PostgresSink.write_serialized` (add SinkWriteError)
+- [ ] Add unit tests for contrib sinks
+
+### Phase 3: Contract Tests and Documentation
+
+- [ ] Create `tests/unit/test_write_serialized_contract.py`
+- [ ] Add parametrized tests for all sink implementations
+- [ ] Update `docs/plugins/sinks.md` with error handling guidance
+- [ ] Update `docs/plugins/error-handling.md` if it exists
+
+### Phase 4: Cleanup
+
+- [ ] Grep codebase for remaining `{"message": "fallback"}` patterns
+- [ ] Grep for bare `except Exception:` in sink `write_serialized` methods
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_write_serialized_contract.py`
+  - All sinks raise `SinkWriteError` on invalid input
+  - All sinks emit diagnostics on failure
+  - All sinks record dropped event metrics (if metrics configured)
+  - No sink produces placeholder data on failure
+
+### Integration Tests
+
+- `tests/integration/test_write_serialized_fallback.py`
+  - Logger with `serialize_in_flush=True` triggers fallback on `write_serialized` failure
+  - Fallback receives original entry (not placeholder)
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] No `{"message": "fallback"}` patterns remain in sinks
+- [ ] All `write_serialized` methods follow standard pattern
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] Contract tests cover all affected sinks
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Plugin authoring docs updated
+- [ ] CHANGELOG updated with migration notes
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Breaking change for sinks relying on fallback behavior**
+   - **Mitigation:** This is a correctness fix; the previous behavior was incorrect and caused data loss. Document as intentional change.
+
+2. **Increased error visibility may surface latent issues**
+   - **Mitigation:** This is desirable; hidden failures are now observable.
+
+3. **Dependency on Story 4.41 for `SinkWriteError`**
+   - **Mitigation:** `SinkWriteError` already exists (4.41 core infrastructure is complete). This story will complete the sink-level updates that 4.41 planned but did not finish (http, webhook, contrib sinks).
+
+### Rollback Plan
+
+If issues occur:
+1. Revert sink changes individually (each sink is independent)
+2. Contract tests can be retained even if implementation reverts
+
+---
+
+## Related Stories
+
+- **Depends on:** Story 4.41 - Sink Failure Signaling (provides `SinkWriteError`)
+  - Note: 4.41 core infrastructure is implemented (`SinkWriteError`, core handlers, tests, docs)
+  - Note: 4.41 sink updates for http/webhook/contrib were NOT completed — this story will finish that work
+- **Related:** Story 4.39 - Document write_serialized Protocol (documentation)
+- **Enables:** Audit-critical pipeline certification (original audit requirement)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-27 | Initial draft based on v0.7.0 audit findings | Claude |
+| 2026-01-27 | Review: clarified 4.41 partial implementation status; story approved | Claude |


### PR DESCRIPTION
…ation

Add new story to address audit finding about silent data loss in write_serialized implementations across HTTP, webhook, and contrib sinks.

- Add story 4.53 to standardize error handling in write_serialized
- Update story 4.41 status to "Partially Implemented" (core infrastructure done but http/webhook/contrib sink updates were not completed)

Story 4.53 will complete the sink-level work that 4.41 planned but did not finish, ensuring all sinks signal failures via SinkWriteError instead of silently replacing data with placeholder values.