### PR TITLE
docs(stories): add stories from external security audit

### DIFF
--- a/docs/stories/10.31.backpressure-docs-accuracy.md
+++ b/docs/stories/10.31.backpressure-docs-accuracy.md
@@ -1,0 +1,236 @@
+# Story 10.31: Backpressure Documentation Accuracy
+
+**Status:** Ready
+**Priority:** Medium
+**Depends on:** None
+
+---
+
+## Context / Background
+
+An external audit (GPT-5.2 assessment, 2026-01-27) identified a documentation mismatch regarding backpressure policies:
+
+### The Problem
+
+Documentation in `docs/why-fapilog.md` claims three backpressure policies exist:
+
+```markdown
+- **drop** - Discard new logs when queue is full (protect latency)
+- **wait** - Block until queue has space (protect durability)
+- **discard_oldest** - Drop oldest logs to make room (balance both)
+```
+
+And shows this example:
+```python
+logger = (
+    LoggerBuilder()
+    .with_backpressure(policy="wait")  # Never lose logs
+    .build()
+)
+```
+
+However, the actual `LoggerBuilder.with_backpressure()` API is:
+
+```python
+# src/fapilog/builder.py:683-701
+def with_backpressure(
+    self,
+    *,
+    wait_ms: int = 50,
+    drop_on_full: bool = True,
+) -> LoggerBuilder:
+```
+
+**Issues:**
+1. `policy="wait"` parameter doesn't exist
+2. `discard_oldest` policy is not implemented
+3. Users will get errors trying to use documented examples
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Update `docs/why-fapilog.md` to reflect actual API
+- Review all docs for backpressure-related accuracy
+- Update code examples to use correct API
+- Add clarifying comments about what each parameter does
+
+### Out of Scope
+
+- Implementing `discard_oldest` policy (separate story if desired)
+- Changing the existing backpressure API
+- Adding a `policy` parameter to match old docs
+
+---
+
+## Acceptance Criteria
+
+### AC1: Why-fapilog docs use correct API
+
+**Description:** The backpressure section in `docs/why-fapilog.md` shows the actual API.
+
+**Validation:**
+```python
+# This example from docs must work without modification
+from fapilog import LoggerBuilder
+
+logger = (
+    LoggerBuilder()
+    .with_backpressure(wait_ms=100, drop_on_full=False)  # Never lose logs
+    .build()
+)
+```
+
+### AC2: Remove references to discard_oldest
+
+**Description:** All docs remove mentions of `discard_oldest` policy since it's not implemented.
+
+**Validation:**
+```bash
+# Should return no matches
+grep -r "discard_oldest" docs/
+```
+
+### AC3: Backpressure behavior clearly documented
+
+**Description:** Docs clearly explain what `wait_ms` and `drop_on_full` do and how they combine.
+
+**Validation:**
+- `wait_ms=0, drop_on_full=True` → immediate drop if queue full
+- `wait_ms=50, drop_on_full=True` → wait up to 50ms, then drop
+- `wait_ms=0, drop_on_full=False` → block indefinitely (wait forever)
+- `wait_ms=50, drop_on_full=False` → wait 50ms, then block indefinitely
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+docs/why-fapilog.md (MODIFIED - fix backpressure section)
+docs/user-guide/configuration.md (VERIFY - check for similar issues)
+docs/user-guide/reliability-defaults.md (VERIFY - check backpressure docs)
+```
+
+### Corrected Documentation
+
+```markdown
+## 2. Backpressure Handling
+
+What happens when logs arrive faster than they can be written? Most libraries
+either block (hurting latency) or silently drop logs (hurting reliability).
+Fapilog lets you configure the tradeoff:
+
+```python
+from fapilog import LoggerBuilder
+
+# Protect latency: wait briefly, then drop if still full
+logger = (
+    LoggerBuilder()
+    .with_backpressure(wait_ms=50, drop_on_full=True)
+    .build()
+)
+
+# Protect durability: never lose logs (may block longer)
+logger = (
+    LoggerBuilder()
+    .with_backpressure(wait_ms=0, drop_on_full=False)
+    .build()
+)
+```
+
+| Configuration | Behavior |
+|--------------|----------|
+| `wait_ms=50, drop_on_full=True` | Wait up to 50ms for space, then drop (default) |
+| `wait_ms=0, drop_on_full=True` | Drop immediately if queue full |
+| `wait_ms=0, drop_on_full=False` | Block indefinitely until space available |
+| `wait_ms=100, drop_on_full=False` | Wait 100ms, then block indefinitely |
+```
+
+---
+
+## Tasks
+
+### Phase 1: Audit Existing Docs
+
+- [ ] Search all docs for "backpressure" mentions
+- [ ] Search all docs for "discard_oldest" mentions
+- [ ] Search all docs for `policy=` in backpressure context
+- [ ] List all files needing updates
+
+### Phase 2: Fix Documentation
+
+- [ ] Update `docs/why-fapilog.md` backpressure section
+- [ ] Update any other files found in Phase 1
+- [ ] Verify all code examples actually work
+
+### Phase 3: Validation
+
+- [ ] Run doc-accuracy check script
+- [ ] Build docs with warnings-as-errors
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Validation Scripts
+
+- Run `python scripts/check_doc_accuracy.py` to catch code/doc drift
+- Run `sphinx-build -W` to catch doc build issues
+
+### Manual Verification
+
+- Copy each code example from updated docs
+- Paste into Python REPL
+- Verify no errors
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All documentation files updated
+- [ ] No references to non-existent features
+
+### Quality Assurance
+
+- [ ] Doc accuracy script passes
+- [ ] Sphinx build passes with warnings-as-errors
+- [ ] All code examples tested manually
+
+### Documentation
+
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Users may have workflows expecting `policy=` parameter
+   - **Mitigation:** This parameter never existed in code, so no user code would work with it
+
+### Rollback Plan
+
+If issues occur:
+1. Git revert the docs changes
+
+---
+
+## Related Stories
+
+- **Related:** Story 10.27 - Builder API parity enforcement (prevents future drift)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-27 | Initial draft from audit findings | Claude |

--- a/docs/stories/10.32.production-safety-defaults.md
+++ b/docs/stories/10.32.production-safety-defaults.md
@@ -1,0 +1,401 @@
+# Story 10.32: Production Safety Defaults Hardening
+
+**Status:** Draft
+**Priority:** Low
+**Depends on:** None
+
+---
+
+## Context / Background
+
+An external audit (GPT-5.2 assessment, 2026-01-27) identified several default values that may surprise users in production environments:
+
+### Issue 1: Postgres sink auto-creates tables by default
+
+```python
+# src/fapilog/plugins/sinks/contrib/postgres.py:62
+create_table: bool = Field(default=True)
+```
+
+In regulated environments, DDL execution at runtime may violate change management policies or fail due to restricted permissions. Users discovering this behavior in production is undesirable.
+
+### Issue 2: Plugin metadata helper uses wrong version default
+
+```python
+# src/fapilog/plugins/metadata.py:204
+compatibility=PluginCompatibility(min_fapilog_version="3.0.0")
+```
+
+The project is at version 0.7.x, but the helper defaults to requiring version 3.0.0. This is confusing for plugin authors and will cause compatibility check failures.
+
+### Issue 3: Worker loop uses fixed 1ms sleep
+
+```python
+# src/fapilog/core/worker.py:225
+await asyncio.sleep(0.001)
+```
+
+While not a correctness issue, this causes unnecessary CPU wakeups when the queue is empty. An event-based approach would be more efficient.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Document Postgres `create_table` behavior prominently with warning
+- Disable `create_table` by default in production preset sink config
+- Fix plugin metadata helper to use sensible default version
+- Replace fixed sleep with event-based wakeup in worker loop
+
+### Out of Scope
+
+- Changing Postgres sink global default (only preset default)
+- Major worker loop redesign
+- Adding plugin marketplace features
+
+---
+
+## Acceptance Criteria
+
+### AC1: Postgres create_table documented with warning
+
+**Description:** The Postgres sink documentation clearly warns about auto-DDL behavior.
+
+**Validation:**
+```bash
+# Docs should contain a warning about create_table
+grep -i "warning\|caution\|note" docs/plugins/sinks/postgres.md | grep -i "create_table\|ddl\|schema"
+```
+
+### AC2: Production preset disables auto table creation
+
+**Description:** The `production` preset sets `create_table=False` for Postgres sink config.
+
+**Validation:**
+```python
+from fapilog.core.presets import get_preset
+
+preset = get_preset("production")
+# Check that sink_config.postgres.create_table is False
+postgres_config = preset.get("sink_config", {}).get("postgres", {})
+assert postgres_config.get("create_table") is False
+```
+
+### AC3: Production preset documentation updated
+
+**Description:** Documentation notes that production preset disables Postgres auto-DDL.
+
+**Validation:**
+```bash
+# Presets docs should mention the production preset Postgres behavior
+grep -A10 "production" docs/user-guide/presets.md | grep -i "create_table\|postgres\|ddl"
+```
+
+### AC4: Plugin metadata helper uses reasonable default
+
+**Description:** `create_plugin_metadata()` defaults to a minimum version that makes sense for 0.x releases.
+
+**Validation:**
+```python
+from fapilog.plugins.metadata import create_plugin_metadata
+
+metadata = create_plugin_metadata(
+    name="test",
+    version="1.0.0",
+    plugin_type="sink",
+    entry_point="test:TestSink",
+)
+# Should NOT require fapilog 3.0.0
+assert metadata.compatibility.min_fapilog_version != "3.0.0"
+# Should use a sensible default like "0.1.0"
+assert metadata.compatibility.min_fapilog_version == "0.1.0"
+```
+
+### AC5: Worker loop uses event-based wakeup
+
+**Description:** The worker loop waits on an asyncio.Event instead of fixed sleep when queue is empty.
+
+**Validation:**
+```python
+# Worker should have an _enqueue_event that gets set on enqueue
+# and cleared after wakeup
+from fapilog.core.worker import LoggerWorker
+
+# Verify the worker accepts an enqueue_event parameter
+import inspect
+sig = inspect.signature(LoggerWorker.__init__)
+assert "enqueue_event" in sig.parameters
+```
+
+### AC6: Worker wakes immediately on enqueue
+
+**Description:** When an item is enqueued, the worker wakes up immediately instead of waiting up to 1ms.
+
+**Validation:**
+```python
+import asyncio
+import time
+
+# Create worker with event
+event = asyncio.Event()
+# ... setup worker with event ...
+
+# Measure time from enqueue to worker seeing item
+# Should be < 1ms (previously could be up to 1ms)
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/plugins/sinks/contrib/postgres.py (MODIFIED - add docstring warning)
+src/fapilog/core/presets.py (MODIFIED - production preset postgres defaults)
+src/fapilog/plugins/metadata.py (MODIFIED - fix default version)
+src/fapilog/core/worker.py (MODIFIED - event-based wakeup)
+src/fapilog/core/logger.py (MODIFIED - pass enqueue event to worker)
+docs/plugins/sinks/postgres.md (MODIFIED - document create_table warning)
+docs/user-guide/presets.md (MODIFIED - document production preset postgres behavior)
+```
+
+### Key Code Changes
+
+#### Fix plugin metadata default
+
+```python
+# metadata.py - change line 204
+def create_plugin_metadata(...) -> PluginMetadata:
+    return PluginMetadata(
+        ...
+        compatibility=PluginCompatibility(min_fapilog_version="0.1.0"),  # Was "3.0.0"
+        ...
+    )
+```
+
+#### Production preset postgres config
+
+```python
+# presets.py - add to production preset
+PRODUCTION_PRESET = {
+    # ... existing config ...
+    "sink_config": {
+        "postgres": {
+            "create_table": False,  # Require explicit table creation in production
+        },
+    },
+}
+```
+
+#### Event-based worker wakeup
+
+```python
+# worker.py
+class LoggerWorker:
+    def __init__(
+        self,
+        *,
+        # ... existing params ...
+        enqueue_event: asyncio.Event | None = None,
+    ):
+        # ... existing init ...
+        self._enqueue_event = enqueue_event
+
+    async def run(self, *, in_thread_mode: bool = False) -> None:
+        batch: list[dict[str, Any]] = []
+        next_flush_deadline: float | None = None
+        try:
+            while True:
+                # ... existing stop/flush checks ...
+
+                ok, item = self._queue.try_dequeue()
+                if ok and item is not None:
+                    batch.append(item)
+                    # ... existing batch logic ...
+                    continue
+
+                # Check batch timeout
+                now = time.perf_counter()
+                if next_flush_deadline is not None and now >= next_flush_deadline:
+                    await self._flush_batch(batch)
+                    next_flush_deadline = None
+                    continue
+
+                # Wait for enqueue signal OR batch timeout
+                if self._enqueue_event is not None:
+                    timeout = None
+                    if next_flush_deadline is not None:
+                        timeout = max(0, next_flush_deadline - now)
+                    elif batch:
+                        timeout = self._batch_timeout_seconds
+
+                    try:
+                        await asyncio.wait_for(
+                            self._enqueue_event.wait(),
+                            timeout=timeout or self._batch_timeout_seconds,
+                        )
+                        self._enqueue_event.clear()
+                    except asyncio.TimeoutError:
+                        pass  # Timeout expired, check batch
+                else:
+                    # Fallback to polling (backwards compatibility)
+                    await asyncio.sleep(0.001)
+```
+
+```python
+# logger.py - signal event on enqueue
+class _LoggerMixin:
+    def __init__(self, ...):
+        # ... existing init ...
+        self._enqueue_event = asyncio.Event()
+
+    def _create_worker(self, ...) -> LoggerWorker:
+        return LoggerWorker(
+            # ... existing params ...
+            enqueue_event=self._enqueue_event,
+        )
+
+    async def _enqueue(self, payload: dict[str, Any]) -> bool:
+        # ... existing enqueue logic ...
+        if success:
+            self._enqueue_event.set()  # Wake worker immediately
+        return success
+```
+
+#### Postgres documentation warning
+
+```markdown
+<!-- docs/plugins/sinks/postgres.md -->
+
+## Configuration
+
+### Auto Table Creation
+
+> **Warning:** By default, `create_table=True` causes the sink to execute DDL
+> (CREATE TABLE, CREATE INDEX) at startup. In production environments with
+> restricted permissions or change management policies, set `create_table=False`
+> and provision tables via migrations.
+>
+> The `production` preset automatically sets `create_table=False`.
+
+| Setting | Default | Production Preset |
+|---------|---------|-------------------|
+| `create_table` | `True` | `False` |
+```
+
+---
+
+## Tasks
+
+### Phase 1: Documentation and Postgres Preset
+
+- [ ] Add warning to Postgres sink docstring about `create_table`
+- [ ] Add warning section to `docs/plugins/sinks/postgres.md`
+- [ ] Add `sink_config.postgres.create_table=False` to production preset
+- [ ] Document production preset Postgres behavior in `docs/user-guide/presets.md`
+
+### Phase 2: Fix Plugin Metadata
+
+- [ ] Change default `min_fapilog_version` from "3.0.0" to "0.1.0" in `metadata.py`
+- [ ] Update any tests that check the old default
+
+### Phase 3: Worker Event-Based Wakeup
+
+- [ ] Add `enqueue_event: asyncio.Event | None` parameter to `LoggerWorker.__init__`
+- [ ] Replace `await asyncio.sleep(0.001)` with event wait + timeout
+- [ ] Pass event from logger facade to worker
+- [ ] Signal event on successful enqueue
+- [ ] Maintain backwards compatibility (event is optional)
+
+### Phase 4: Testing
+
+- [ ] Add tests for production preset Postgres config
+- [ ] Add tests for plugin metadata version default
+- [ ] Add tests for worker event-based wakeup
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_presets.py`
+  - test_production_preset_disables_postgres_create_table
+
+- `tests/unit/test_plugin_metadata_defaults.py`
+  - test_create_plugin_metadata_reasonable_version_default
+  - test_create_plugin_metadata_version_is_valid
+
+- `tests/unit/test_worker_event_wakeup.py`
+  - test_worker_accepts_enqueue_event_parameter
+  - test_worker_wakes_on_event_set
+  - test_worker_respects_batch_timeout_with_event
+  - test_worker_falls_back_to_polling_without_event
+
+### Integration Tests
+
+- `tests/integration/test_worker_efficiency.py`
+  - test_enqueue_wakes_worker_immediately
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] Code follows project patterns
+- [ ] No new linting errors
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Postgres sink docs updated with warning
+- [ ] Presets docs updated with production Postgres behavior
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Changing production preset `create_table` default may surprise users upgrading
+   - **Mitigation:** Document in CHANGELOG; only affects production preset, not global default
+
+2. **Risk:** Event-based wakeup may have subtle timing differences
+   - **Mitigation:** Extensive testing; keep backwards-compatible polling fallback
+
+3. **Risk:** Plugin metadata change may affect existing plugins
+   - **Mitigation:** The old default (3.0.0) would fail anyway on 0.x; this is a fix
+
+### Rollback Plan
+
+If issues occur:
+1. Revert individual changes as needed
+2. Each fix is independent and can be reverted separately
+
+---
+
+## Related Stories
+
+- **Related:** Story 4.54 - Redaction fail-closed mode (also improves production safety)
+- **Related:** Story 4.55 - Lazy signal handler installation (also improves defaults)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-27 | Initial draft from audit findings | Claude |
+| 2026-01-27 | Revised: fixed docs path, added documentation AC for preset change | Claude |

--- a/docs/stories/4.54.redaction-fail-closed-mode.md
+++ b/docs/stories/4.54.redaction-fail-closed-mode.md
@@ -1,0 +1,380 @@
+# Story 4.54: Redaction Fail-Closed Mode and Fallback Hardening
+
+**Status:** Draft
+**Priority:** High
+**Depends on:** None
+
+---
+
+## Context / Background
+
+An external audit (GPT-5.2 assessment, 2026-01-27) identified two security concerns with the current redaction implementation:
+
+### Problem 1: No global fail-closed mode for redaction errors
+
+When a redactor encounters an exception, the original unredacted entry is passed through to sinks:
+
+```python
+# src/fapilog/core/worker.py:355-375
+async def _apply_redactors(self, entry: dict[str, Any]) -> dict[str, Any]:
+    try:
+        return await redact_in_order(entry, redactors, metrics=self._metrics)
+    except Exception:
+        # Fail-open: returns original entry unchanged
+        return entry
+```
+
+**Existing mechanism**: Individual redactors have `block_on_unredactable` settings (e.g., `redactor_config.field_mask.block_on_unredactable`). However:
+- This only handles cases where the redactor *itself* decides to block (e.g., can't parse a value)
+- It doesn't handle unexpected exceptions in redactor code
+- There's no global setting to enforce fail-closed across all redactors
+
+### Problem 2: Serialized fallback path writes unredacted data
+
+Story 4.46 implemented `fallback_redact_mode` with options `inherit`/`minimal`/`none` (default: `minimal`). However, this only applies to dict payloads. When a sink fails with pre-serialized data, the fallback writes raw bytes without redaction:
+
+```python
+# src/fapilog/plugins/sinks/fallback.py:80-94
+def _format_payload(payload: Any, *, serialized: bool) -> str:
+    if serialized:
+        # Raw bytes decoded and written - NO REDACTION
+        data = bytes(payload) if isinstance(payload, memoryview) else payload.data
+        return data.decode("utf-8", errors="replace")
+```
+
+This creates a security gap where secrets can leak to stderr during sink failures on the serialized path.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Add `core.redaction_fail_mode` global setting with options: `"open"` (current), `"closed"`, `"warn"`
+- This setting governs behavior when `_apply_redactors()` catches an unexpected exception
+- Default to `"warn"` for production/fastapi/serverless presets
+- Extend `_write_to_stderr()` to deserialize and redact serialized payloads
+- Emit diagnostics when fail-closed mode drops an event
+- Update docs to explain the relationship between settings
+
+### Out of Scope
+
+- Changes to per-redactor `block_on_unredactable` behavior (orthogonal mechanism)
+- Full re-parse of serialized payloads for redaction (only fallback path)
+- Content-based PII detection (explicitly documented as not supported)
+
+---
+
+## Relationship to Existing Settings
+
+| Setting | Scope | Purpose | Default |
+|---------|-------|---------|---------|
+| `redactor_config.*.block_on_unredactable` | Per-redactor | Block when redactor can't process a value | `False` |
+| `core.fallback_redact_mode` | Fallback sink | How to redact dict payloads on fallback | `"minimal"` |
+| `core.redaction_fail_mode` (NEW) | Global | What to do when `_apply_redactors()` throws | `"open"` |
+
+The new `redaction_fail_mode` handles the "outer" exception case - when the entire redaction pipeline fails unexpectedly, not when a specific redactor decides it can't redact a value.
+
+---
+
+## Acceptance Criteria
+
+### AC1: Global redaction fail mode setting
+
+**Description:** New `core.redaction_fail_mode` setting controls behavior on unexpected redactor exceptions.
+
+**Validation:**
+```python
+from fapilog.core.settings import Settings, CoreSettings
+
+# Default for dev preset
+settings = Settings(preset="dev")
+assert settings.core.redaction_fail_mode == "open"
+
+# Default for production presets
+settings = Settings(preset="production")
+assert settings.core.redaction_fail_mode == "warn"
+
+# Explicit override
+settings = Settings(core=CoreSettings(redaction_fail_mode="closed"))
+assert settings.core.redaction_fail_mode == "closed"
+```
+
+### AC2: Fail-closed mode drops events on redaction exception
+
+**Description:** When `redaction_fail_mode="closed"`, events are dropped (not logged) if `_apply_redactors()` catches an exception.
+
+**Validation:**
+```python
+# Configure with fail-closed and inject a redactor that raises
+# Event should be dropped, not written to sink
+# Diagnostic warning should be emitted
+# Metrics counter `redaction_exceptions_total` should increment
+```
+
+### AC3: Warn mode logs diagnostic but passes event
+
+**Description:** When `redaction_fail_mode="warn"`, events pass through but a diagnostic warning is emitted.
+
+**Validation:**
+```python
+# With warn mode (default for production)
+# Redaction exception should:
+# 1. Emit diagnostic warning with rate limiting (key: "redaction_exception")
+# 2. Pass original event to sink (fail-open behavior)
+# 3. Increment metrics counter `redaction_exceptions_total`
+```
+
+### AC4: Serialized fallback path applies minimal redaction
+
+**Description:** When `_write_to_stderr()` handles a serialized payload with `redact_mode="minimal"`, it deserializes, redacts, and re-serializes.
+
+**Validation:**
+```python
+from fapilog.plugins.sinks.fallback import _write_to_stderr
+from fapilog.core.serialization import SerializedView
+import io
+import sys
+
+# Capture stderr
+captured = io.StringIO()
+sys.stderr = captured
+
+# Serialized payload containing secrets
+payload = SerializedView(data=b'{"password": "secret123", "user": "alice"}')
+
+# Write with minimal redaction (the actual integration point)
+_write_to_stderr(payload, serialized=True, redact_mode="minimal")
+
+output = captured.getvalue()
+assert "secret123" not in output
+assert '"password"' in output  # Key present
+assert '"user": "alice"' in output or '"user":"alice"' in output
+```
+
+### AC5: Invalid JSON in serialized fallback handled gracefully
+
+**Description:** If serialized payload isn't valid JSON, fall back to raw output with diagnostic warning.
+
+**Validation:**
+```python
+# Payload that isn't valid JSON
+payload = SerializedView(data=b'not valid json {{{')
+
+# Should not raise, should write raw bytes
+_write_to_stderr(payload, serialized=True, redact_mode="minimal")
+
+# Diagnostic warning should be emitted about deserialization failure
+```
+
+### AC6: Documentation explains setting relationships
+
+**Description:** `docs/redaction/behavior.md` updated to explain the three redaction-related settings and when each applies.
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/settings.py (MODIFIED - add redaction_fail_mode to CoreSettings)
+src/fapilog/core/worker.py (MODIFIED - honor fail mode in _apply_redactors)
+src/fapilog/core/presets.py (MODIFIED - set warn mode for production presets)
+src/fapilog/plugins/sinks/fallback.py (MODIFIED - redact serialized in _write_to_stderr)
+docs/redaction/behavior.md (MODIFIED - document setting relationships)
+```
+
+### Key Code
+
+```python
+# settings.py - add to CoreSettings
+redaction_fail_mode: Literal["open", "closed", "warn"] = Field(
+    default="open",
+    description=(
+        "Behavior when _apply_redactors() catches an unexpected exception: "
+        "'open' passes original event (current behavior), "
+        "'closed' drops the event, "
+        "'warn' passes event but emits diagnostic warning"
+    ),
+)
+
+# worker.py - updated _apply_redactors
+async def _apply_redactors(self, entry: dict[str, Any]) -> dict[str, Any] | None:
+    redactors = self._redactors_getter()
+    if not redactors:
+        return entry
+    try:
+        return await redact_in_order(entry, redactors, metrics=self._metrics)
+    except Exception as exc:
+        fail_mode = self._redaction_fail_mode  # Injected from settings
+        if self._metrics:
+            await self._metrics.increment("redaction_exceptions_total")
+
+        if fail_mode == "closed":
+            warn("redactor", "dropping event due to redaction exception",
+                 error=str(exc), _rate_limit_key="redaction_exception")
+            return None  # Signal to drop event
+
+        if fail_mode == "warn":
+            warn("redactor", "redaction exception, passing original",
+                 error=str(exc), _rate_limit_key="redaction_exception")
+
+        return entry
+
+# fallback.py - updated _write_to_stderr (the integration point)
+def _write_to_stderr(
+    payload: Any,
+    *,
+    serialized: bool,
+    redact_mode: RedactMode = "minimal",
+) -> None:
+    if serialized and redact_mode == "minimal":
+        # Attempt to deserialize, redact, re-serialize
+        try:
+            data = _extract_bytes(payload)
+            parsed = json.loads(data)
+            if isinstance(parsed, dict):
+                parsed = minimal_redact(parsed)
+            text = json.dumps(parsed, separators=(",", ":"), default=str)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            diagnostics.warn(
+                "fallback",
+                "serialized payload not valid JSON, writing raw",
+                error=str(exc),
+                _rate_limit_key="fallback_json_error",
+            )
+            text = _format_payload(payload, serialized=True)
+    elif not serialized and isinstance(payload, dict):
+        if redact_mode == "minimal":
+            payload = minimal_redact(payload)
+        text = _format_payload(payload, serialized=False)
+    else:
+        text = _format_payload(payload, serialized=serialized)
+
+    if not text.endswith("\n"):
+        text += "\n"
+    sys.stderr.write(text)
+    sys.stderr.flush()
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [ ] Add `redaction_fail_mode` to `CoreSettings` with Literal type and validation
+- [ ] Add `_redaction_fail_mode` injection to `LoggerWorker.__init__`
+- [ ] Update `LoggerWorker._apply_redactors()` to honor fail mode
+- [ ] Update `_flush_batch()` to skip entries where redactors returned `None`
+
+### Phase 2: Fallback Hardening
+
+- [ ] Refactor `_write_to_stderr()` to handle serialized redaction
+- [ ] Add `_extract_bytes()` helper for consistent byte extraction
+- [ ] Handle JSON decode errors gracefully with diagnostic
+- [ ] Add test coverage for serialized fallback redaction
+
+### Phase 3: Presets
+
+- [ ] Set `redaction_fail_mode="warn"` in production preset
+- [ ] Set `redaction_fail_mode="warn"` in fastapi preset
+- [ ] Set `redaction_fail_mode="warn"` in serverless preset
+- [ ] Update env var docs for `FAPILOG__CORE__REDACTION_FAIL_MODE`
+
+### Phase 4: Documentation
+
+- [ ] Update `docs/redaction/behavior.md` with setting relationship table
+- [ ] Add example configurations for compliance environments
+- [ ] Update CHANGELOG
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_worker_redaction_fail_modes.py`
+  - test_fail_open_passes_original_on_exception
+  - test_fail_closed_drops_event_on_exception
+  - test_fail_closed_emits_diagnostic
+  - test_fail_warn_emits_diagnostic_and_passes
+  - test_fail_mode_metrics_incremented
+  - test_none_return_skipped_in_flush_batch
+
+- `tests/unit/test_fallback_serialized_redaction.py`
+  - test_serialized_dict_redacted_on_minimal_mode
+  - test_serialized_nested_secrets_redacted
+  - test_invalid_json_falls_back_to_raw_with_warning
+  - test_serialized_non_dict_passes_through
+  - test_inherit_mode_not_affected (serialized path)
+
+### Integration Tests
+
+- `tests/integration/test_redaction_fail_closed.py`
+  - end-to-end test with broken redactor and fail-closed mode
+  - verify event is not written to any sink
+  - verify diagnostic warning emitted
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] Code follows project patterns
+- [ ] No new linting errors
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] Integration tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Code has docstrings where needed
+- [ ] Redaction docs updated with setting relationships
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Fail-closed mode could drop legitimate logs if redactors have bugs
+   - **Mitigation:** Default to "warn" mode; require explicit opt-in for "closed"
+
+2. **Risk:** Deserializing serialized payloads for fallback redaction adds overhead
+   - **Mitigation:** Only applies during sink failures (rare path); worth the security tradeoff
+
+3. **Risk:** JSON parsing may fail on valid serialized payloads (e.g., non-JSON formats)
+   - **Mitigation:** Graceful fallback to raw output with diagnostic warning
+
+### Rollback Plan
+
+If issues occur:
+1. Set `FAPILOG__CORE__REDACTION_FAIL_MODE=open` to restore original behavior
+2. Revert PR if fundamental issues discovered
+
+---
+
+## Related Stories
+
+- **Related:** Story 4.46 - Fallback sink PII protection (implemented `fallback_redact_mode`)
+- **Related:** Story 4.50 - Regex ReDoS protection
+- **Related:** Story 4.51 - Secure header redaction defaults
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-27 | Initial draft from audit findings | Claude |
+| 2026-01-27 | Revised: clarified relationship to existing settings, fixed AC4 | Claude |

--- a/docs/stories/4.55.lazy-signal-handler-installation.md
+++ b/docs/stories/4.55.lazy-signal-handler-installation.md
@@ -1,0 +1,419 @@
+# Story 4.55: Lazy Signal Handler Installation
+
+**Status:** Draft
+**Priority:** Medium
+**Depends on:** None
+
+---
+
+## Context / Background
+
+An external audit (GPT-5.2 assessment, 2026-01-27) identified that signal handlers are installed at module import time, which can conflict with host frameworks:
+
+```python
+# src/fapilog/core/shutdown.py:196-200
+# Register atexit handler on module import
+atexit.register(_atexit_handler)
+
+# Install signal handlers (if enabled)
+_install_signal_handlers()
+```
+
+This creates problems because:
+
+1. **Framework conflicts:** FastAPI, Uvicorn, Gunicorn, and other frameworks manage their own signal handlers. Fapilog overriding them at import time can break graceful shutdown.
+
+2. **Library etiquette:** Libraries should not install global handlers at import time. This is surprising behavior that violates the principle of least surprise.
+
+3. **No opt-out before installation:** By the time user code runs, handlers are already installed. The `signal_handler_enabled` setting only affects whether new handlers are installed, not whether the import-time installation occurred.
+
+4. **Testing interference:** Tests that import fapilog get signal handlers installed, which can interfere with test frameworks.
+
+### Existing Code
+
+There are currently **two** signal handler mechanisms:
+
+1. **`shutdown.py`** - Global handlers installed at import time, drain all registered loggers
+2. **`lifecycle.py`** - Per-logger `install_signal_handlers(logger)` function for explicit use
+
+```python
+# src/fapilog/core/lifecycle.py:10-72
+def install_signal_handlers(
+    logger: Any, *, timeout_seconds: float | None = None
+) -> None:
+    """Install SIGINT/SIGTERM handlers to drain the logger gracefully."""
+    # ... installs handlers that drain a specific logger
+```
+
+This story consolidates these into a single, lazy-installation approach.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Remove import-time handler installation from `shutdown.py`
+- Move handler installation to logger start-time (lazy)
+- Consolidate `shutdown.py` global handlers and `lifecycle.py` per-logger handlers
+- Add explicit `fapilog.install_shutdown_handlers()` for manual control
+- Ensure handlers are only installed once (idempotent)
+- Document the change and migration path
+
+### Out of Scope
+
+- Changes to the actual signal handling logic (drain behavior)
+- Changes to the atexit drain behavior
+- Automatic detection of framework signal handlers
+
+---
+
+## Acceptance Criteria
+
+### AC1: No handlers installed at import time
+
+**Description:** Importing fapilog should not install any signal handlers or atexit handlers.
+
+**Validation:**
+```python
+import signal
+import atexit
+
+# Capture state before import
+original_sigterm = signal.getsignal(signal.SIGTERM)
+original_sigint = signal.getsignal(signal.SIGINT)
+original_atexit_count = len(atexit._exithandlers) if hasattr(atexit, '_exithandlers') else 0
+
+# Import fapilog
+import fapilog
+
+# Handlers should be unchanged
+assert signal.getsignal(signal.SIGTERM) == original_sigterm
+assert signal.getsignal(signal.SIGINT) == original_sigint
+```
+
+### AC2: Handlers installed on first logger start
+
+**Description:** Signal and atexit handlers are installed when the first logger is started (via `get_logger()`, `runtime()`, etc.).
+
+**Validation:**
+```python
+import signal
+import fapilog
+
+original_sigterm = signal.getsignal(signal.SIGTERM)
+
+# Get a logger (this starts the pipeline)
+logger = fapilog.get_logger()
+
+# Now handlers should be installed (if enabled in settings)
+# Note: May be SIG_DFL or a custom handler depending on platform
+assert signal.getsignal(signal.SIGTERM) != original_sigterm
+```
+
+### AC3: Manual handler installation function
+
+**Description:** Users can explicitly install handlers via `fapilog.install_shutdown_handlers()`.
+
+**Validation:**
+```python
+import signal
+import fapilog
+
+original_sigterm = signal.getsignal(signal.SIGTERM)
+
+# Explicitly install handlers before creating any loggers
+fapilog.install_shutdown_handlers()
+
+assert signal.getsignal(signal.SIGTERM) != original_sigterm
+```
+
+### AC4: Idempotent installation
+
+**Description:** Calling install multiple times or starting multiple loggers only installs handlers once.
+
+**Validation:**
+```python
+import fapilog
+
+# Install multiple times - should not raise or double-install
+fapilog.install_shutdown_handlers()
+fapilog.install_shutdown_handlers()
+
+# Start multiple loggers
+logger1 = fapilog.get_logger("a")
+logger2 = fapilog.get_logger("b")
+
+# Should work without issues
+```
+
+### AC5: Opt-out via settings prevents installation
+
+**Description:** Setting `signal_handler_enabled=False` prevents handler installation even on logger start.
+
+**Validation:**
+```python
+import os
+import signal
+import fapilog
+
+# Disable signal handlers via environment
+os.environ["FAPILOG__CORE__SIGNAL_HANDLER_ENABLED"] = "false"
+
+original_sigterm = signal.getsignal(signal.SIGTERM)
+
+# Get logger - should NOT install signal handlers
+logger = fapilog.get_logger()
+
+# Handlers should NOT be installed
+assert signal.getsignal(signal.SIGTERM) == original_sigterm
+
+# Cleanup
+del os.environ["FAPILOG__CORE__SIGNAL_HANDLER_ENABLED"]
+```
+
+### AC6: Lifecycle.install_signal_handlers deprecated
+
+**Description:** `lifecycle.install_signal_handlers()` is deprecated in favor of `fapilog.install_shutdown_handlers()`.
+
+**Validation:**
+```python
+import warnings
+from fapilog.core.lifecycle import install_signal_handlers
+
+with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    install_signal_handlers(logger)
+    assert len(w) == 1
+    assert "deprecated" in str(w[0].message).lower()
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/shutdown.py (MODIFIED - remove import-time installation, add install function)
+src/fapilog/core/lifecycle.py (MODIFIED - deprecate install_signal_handlers)
+src/fapilog/core/logger.py (MODIFIED - call lazy install in _LoggerMixin.start)
+src/fapilog/__init__.py (MODIFIED - export install_shutdown_handlers)
+docs/user-guide/configuration.md (MODIFIED - document handler installation)
+```
+
+### Key Code
+
+```python
+# shutdown.py
+import threading
+
+_handlers_installed: bool = False
+_install_lock = threading.Lock()
+
+def install_shutdown_handlers() -> bool:
+    """Install signal and atexit handlers for graceful shutdown.
+
+    Called automatically on first logger start. Can be called manually
+    for early installation or in frameworks that need explicit control.
+
+    Returns:
+        True if handlers were installed, False if already installed or disabled.
+
+    Example:
+        # Install before creating loggers (optional)
+        import fapilog
+        fapilog.install_shutdown_handlers()
+
+        # Or let it happen automatically
+        logger = fapilog.get_logger()  # Installs handlers on first call
+    """
+    global _handlers_installed
+
+    with _install_lock:
+        if _handlers_installed:
+            return False
+
+        settings = _get_shutdown_settings()
+
+        if settings["atexit_drain_enabled"]:
+            atexit.register(_atexit_handler)
+
+        if settings["signal_handler_enabled"]:
+            _do_install_signal_handlers()
+
+        _handlers_installed = True
+        return True
+
+# Remove import-time calls (DELETE these lines):
+# atexit.register(_atexit_handler)
+# _install_signal_handlers()
+```
+
+```python
+# logger.py - in _LoggerMixin.start()
+from .shutdown import install_shutdown_handlers
+
+class _LoggerMixin:
+    def start(self) -> None:
+        # ... existing start logic ...
+
+        # Lazy install shutdown handlers on first logger start
+        install_shutdown_handlers()
+
+        # ... rest of start logic ...
+```
+
+```python
+# lifecycle.py - deprecate old function
+import warnings
+
+def install_signal_handlers(
+    logger: Any, *, timeout_seconds: float | None = None
+) -> None:
+    """Install SIGINT/SIGTERM handlers to drain the logger gracefully.
+
+    .. deprecated:: 0.8.0
+        Use :func:`fapilog.install_shutdown_handlers` instead.
+        This function will be removed in version 1.0.0.
+    """
+    warnings.warn(
+        "install_signal_handlers() is deprecated. "
+        "Use fapilog.install_shutdown_handlers() instead. "
+        "Handlers are now installed automatically on first logger start.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    # ... existing implementation for backwards compatibility ...
+```
+
+```python
+# __init__.py
+from .core.shutdown import install_shutdown_handlers
+
+__all__ = [
+    # ... existing exports ...
+    "install_shutdown_handlers",
+]
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Changes
+
+- [ ] Add `_handlers_installed` flag and `_install_lock` to `shutdown.py`
+- [ ] Rename internal `_install_signal_handlers()` to `_do_install_signal_handlers()`
+- [ ] Create public `install_shutdown_handlers()` function with idempotency
+- [ ] Remove import-time `atexit.register()` and `_install_signal_handlers()` calls
+- [ ] Export `install_shutdown_handlers` from `fapilog.__init__`
+
+### Phase 2: Integration
+
+- [ ] Call `install_shutdown_handlers()` in `_LoggerMixin.start()`
+- [ ] Verify `runtime()` and `runtime_async()` context managers work correctly
+- [ ] Verify FastAPI lifespan integration still works
+
+### Phase 3: Deprecation
+
+- [ ] Add deprecation warning to `lifecycle.install_signal_handlers()`
+- [ ] Update docstring with deprecation notice
+- [ ] Keep backwards compatibility for now (function still works)
+
+### Phase 4: Documentation
+
+- [ ] Document the lazy installation behavior
+- [ ] Add "Framework Integration" section explaining signal handler considerations
+- [ ] Add migration note for users calling `lifecycle.install_signal_handlers()`
+- [ ] Update CHANGELOG with behavior change notice
+
+### Phase 5: Test Isolation
+
+- [ ] Add `_reset_shutdown_state()` test helper for test isolation
+- [ ] Update existing tests that depend on import-time installation
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/test_shutdown_lazy_install.py`
+  - test_import_does_not_install_handlers
+  - test_get_logger_installs_handlers
+  - test_install_shutdown_handlers_explicit
+  - test_installation_is_idempotent
+  - test_disabled_setting_prevents_installation
+  - test_atexit_disabled_prevents_atexit_registration
+
+- `tests/unit/test_lifecycle_deprecation.py`
+  - test_install_signal_handlers_emits_deprecation_warning
+  - test_deprecated_function_still_works
+
+### Integration Tests
+
+- `tests/integration/test_shutdown_integration.py`
+  - test_fastapi_lifespan_with_lazy_handlers
+  - test_multiple_loggers_single_handler_installation
+  - test_runtime_context_manager_installs_handlers
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] Code follows project patterns
+- [ ] No new linting errors
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] Integration tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Code has docstrings where needed
+- [ ] Configuration docs updated
+- [ ] CHANGELOG updated with behavior change and migration note
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Users relying on import-time handler installation may experience different shutdown behavior
+   - **Mitigation:** Document the change clearly; provide `install_shutdown_handlers()` for explicit early installation
+
+2. **Risk:** Race condition if multiple threads start loggers simultaneously
+   - **Mitigation:** Use threading lock for idempotent installation
+
+3. **Risk:** Deprecation of `lifecycle.install_signal_handlers()` may break existing code
+   - **Mitigation:** Keep function working with deprecation warning; remove in 1.0.0
+
+### Rollback Plan
+
+If issues occur:
+1. Users can call `fapilog.install_shutdown_handlers()` immediately after import
+2. Revert PR if fundamental issues discovered
+
+---
+
+## Related Stories
+
+- **Related:** Story 6.13 - Graceful shutdown handling (original implementation)
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-27 | Initial draft from audit findings | Claude |
+| 2026-01-27 | Revised: addressed existing lifecycle.py function, fixed Settings API, updated implementation location | Claude |


### PR DESCRIPTION
## Summary

Add four stories derived from GPT-5.2 security assessment (2026-01-27) covering security hardening, documentation accuracy, and production defaults.

## Changes

- `docs/stories/4.54.redaction-fail-closed-mode.md` (new)
- `docs/stories/4.55.lazy-signal-handler-installation.md` (new)
- `docs/stories/10.31.backpressure-docs-accuracy.md` (new)
- `docs/stories/10.32.production-safety-defaults.md` (new)

## Stories Added

| Story | Title | Priority | Status |
|-------|-------|----------|--------|
| **4.54** | Redaction fail-closed mode and fallback hardening | High | Draft |
| **4.55** | Lazy signal handler installation | Medium | Draft |
| **10.31** | Backpressure documentation accuracy | Medium | Ready |
| **10.32** | Production safety defaults hardening | Low | Draft |

## Key Issues Addressed

1. **Redaction security** (4.54): Adds `redaction_fail_mode` setting and fixes unredacted serialized fallback path
2. **Signal handlers** (4.55): Moves handler installation from import-time to logger start to avoid framework conflicts  
3. **Docs accuracy** (10.31): Removes references to non-existent "discard_oldest" backpressure policy
4. **Production defaults** (10.32): Documents Postgres auto-DDL, fixes plugin metadata version, improves worker efficiency

## Test Plan

- [x] Stories follow template format
- [x] Acceptance criteria are testable
- [x] File paths reference existing code
- [x] Related stories reference valid story numbers