### PR TITLE
fix(docs): fix incorrect async usage in documentation examples

### DIFF
--- a/docs/examples/fastapi-logging.md
+++ b/docs/examples/fastapi-logging.md
@@ -44,10 +44,10 @@ from fastapi import FastAPI, Request
 from fapilog import get_async_logger
 
 app = FastAPI()
-logger = await get_async_logger("api")
 
 @app.middleware("http")
 async def bind_http_context(request: Request, call_next):
+    logger = await get_async_logger("api")
     with logger.bind(http_method=request.method, http_path=request.url.path):
         return await call_next(request)
 ```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -194,13 +194,13 @@ async def risky_operation():
         # Attempt operation
         result = await perform_operation()
 
-        await logger.info("Operation successful", operation="risky_operation", result=result)
+        logger.info("Operation successful", operation="risky_operation", result=result)
 
         return result
 
     except ValueError as e:
         # Handle specific error type
-        await logger.warning(
+        logger.warning(
             "Operation failed with invalid input",
             operation="risky_operation",
             error_type="ValueError",
@@ -211,7 +211,7 @@ async def risky_operation():
 
     except Exception as e:
         # Handle unexpected errors
-        await logger.error(
+        logger.error(
             "Operation failed unexpectedly",
             exc_info=True,
             operation="risky_operation",

--- a/docs/examples/sampling-debug-logs.md
+++ b/docs/examples/sampling-debug-logs.md
@@ -12,10 +12,11 @@ export FAPILOG_FILTER_CONFIG__SAMPLING__CONFIG__SAMPLE_RATE=0.2
 ```python
 from fapilog import get_async_logger
 
-logger = await get_async_logger()
-await logger.debug("expensive debug payload", detail="...")
-await logger.info("high-volume event")
-# Sampling applies only to DEBUG/INFO; WARN/ERROR always pass.
+async def log_with_sampling():
+    logger = await get_async_logger()
+    await logger.debug("expensive debug payload", detail="...")
+    await logger.info("high-volume event")
+    # Sampling applies only to DEBUG/INFO; WARN/ERROR always pass.
 ```
 
 ## Adaptive sampling (target EPS)

--- a/docs/examples/structured-error-logging.md
+++ b/docs/examples/structured-error-logging.md
@@ -6,12 +6,13 @@ Capture exceptions with structured stack data.
 ```python
 from fapilog import get_async_logger
 
-logger = await get_async_logger("worker")
+async def process_job():
+    logger = await get_async_logger("worker")
 
-try:
-    raise ValueError("bad input")
-except Exception:
-    await logger.error("Processing failed", exc_info=True, job_id="job-1")
+    try:
+        raise ValueError("bad input")
+    except Exception:
+        await logger.error("Processing failed", exc_info=True, job_id="job-1")
 ```
 
 Output includes exception fields (type/message/stack/frames) merged into the log entry for easier parsing in aggregators.


### PR DESCRIPTION
## Summary

Fix incorrect async logger usage in documentation examples. The examples at `docs/examples/index.md` and other files incorrectly used `await` with the sync logger returned by `get_logger()`, which would cause runtime errors for users following the documentation.

## Changes

- `docs/examples/index.md` (modified) - Remove await from sync logger calls in error handling example
- `docs/examples/fastapi-logging.md` (modified) - Move async logger creation inside async function
- `docs/examples/sampling-debug-logs.md` (modified) - Wrap async logger usage in async function
- `docs/examples/structured-error-logging.md` (modified) - Wrap async logger usage in async function
- `scripts/check_doc_accuracy.py` (modified) - Add async usage validation for CI
- `tests/unit/test_check_doc_accuracy.py` (modified) - Add 7 tests for async validation

## Acceptance Criteria

- [x] AC1: Error Handling Example Fixed - sync logger calls no longer use await
- [x] AC2: All Example Files Reviewed - 4 files fixed, grep validation passes
- [x] AC3: CI Validation Added - `check_example_async_usage` runs on all example docs
- [x] AC4: Doc Accuracy Script Enhanced - detects await with sync logger and module-level await

## Test Plan

- [x] Unit tests pass (20 tests)
- [x] Doc accuracy script passes (10/10 checks)
- [x] Documentation builds without warnings
- [x] grep validation shows no remaining issues

## Story

[10.33 - Fix Incorrect Async Usage in Documentation Examples](docs/stories/10.33.fix-async-examples-docs.md)