### PR TITLE
docs: update SECURITY.md supported versions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -316,6 +316,7 @@ Before creating a release tag, perform a dry-run:
 - [ ] Type checking passes (`hatch run typecheck:typecheck`)
 - [ ] Version bumped in `pyproject.toml`
 - [ ] CHANGELOG.md updated with new version section
+- [ ] Update SECURITY.md supported versions table
 - [ ] Changes committed and pushed to main
 - [ ] Tag created and pushed
 - [ ] GitHub Actions workflow completed successfully

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,15 @@ The following versions of fapilog are currently supported with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.3.x   | :white_check_mark: |
-| < 0.3   | :x:                |
+| 0.7.x   | :white_check_mark: |
+| 0.6.x   | :white_check_mark: |
+| < 0.6   | :x:                |
+
+## Version Support Policy
+
+- **Current release (0.7.x)**: Full security support
+- **Previous minor (0.6.x)**: Security fixes only, 6 months after next minor release
+- **Older versions**: No support, upgrade recommended
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Update SECURITY.md supported versions table from stale 0.3.x to current 0.7.x release line. Add version support policy section and release checklist item to maintain documentation going forward.

## Changes

- `SECURITY.md` (modified)
- `RELEASING.md` (modified)

## Acceptance Criteria

- [x] Supported versions table updated to 0.7.x and 0.6.x
- [x] Version support policy section added
- [x] RELEASING.md checklist includes SECURITY.md update step

## Test Plan

- [x] Manual review - versions table is accurate
- [x] Manual review - policy is clear and reasonable

## Story

[12.25 - Update SECURITY.md Supported Versions](docs/stories/12.25.security-md-supported-versions.md)