### PR TITLE
fix(redactors): make core redaction guardrails functional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. This change
 
 ### Fixed
 
+- **Core redaction guardrails now functional:** The `redaction_max_depth` and `redaction_max_keys_scanned` settings in `CoreSettings` were previously defined but never applied (dead code). They are now passed to `FieldMaskRedactor` and `RegexMaskRedactor` during initialization and act as outer limits that override per-redactor settings when more restrictive (Story 4.57).
 - **Silent data loss in `write_serialized`:** Fixed correctness issue where HTTP, Webhook, Loki, CloudWatch, and PostgreSQL sinks silently replaced log data with placeholder values (e.g., `{"message": "fallback"}`) when deserialization failed. All sinks now raise `SinkWriteError` with diagnostics, enabling proper fallback and circuit breaker handling (Story 4.53).
 - **Plugin metadata version default:** Changed `create_plugin_metadata()` default `min_fapilog_version` from `"3.0.0"` to `"0.1.0"`. The previous default was incorrect for a 0.x project and caused compatibility check failures for plugin authors (Story 10.32).
 

--- a/docs/stories/4.57.redaction-guardrail-documentation.md
+++ b/docs/stories/4.57.redaction-guardrail-documentation.md
@@ -1,0 +1,218 @@
+# Story 4.57: Make Core Redaction Guardrails Functional
+
+**Status:** Ready for Code Review
+**Priority:** High
+**Depends on:** None
+**Audit Reference:** v0.7.1-unreleased GPT-5.2 Assessment - P1 Issue
+
+---
+
+## Context / Background
+
+The core redaction guardrails (`redaction_max_depth`, `redaction_max_keys_scanned`) are defined in settings but **never applied**. They are dead code.
+
+Current state:
+- `src/fapilog/core/settings.py:704-712` defines `redaction_max_depth=6` and `redaction_max_keys_scanned=5000`
+- `src/fapilog/builder.py:371-373` sets these values in config
+- **Nothing reads or applies these values** - `redact_in_order()` doesn't reference them
+- Only per-redactor guardrails (FieldMaskConfig `max_depth=16`, `max_keys_scanned=1000`) actually function
+
+This creates a false sense of security. Users configuring core guardrails expect them to work, but they don't.
+
+---
+
+## Scope (In / Out)
+
+### In Scope
+
+- Make `redaction_max_depth` and `redaction_max_keys_scanned` functional
+- Apply core guardrails as outer limits that override per-redactor settings
+- Pass core guardrail values to redactors during initialization
+- Add tests verifying core guardrails take effect
+
+### Out of Scope
+
+- Changing default values
+- Documentation updates (see Story 4.60)
+- New guardrail features beyond making existing settings work
+
+---
+
+## Acceptance Criteria
+
+### AC1: Core Guardrails Override Per-Redactor Settings
+
+**Description:** When core guardrails are more restrictive than per-redactor settings, the core values take effect.
+
+**Validation:**
+```python
+# Core: redaction_max_depth=6 (default)
+# FieldMask: max_depth=16 (default)
+# Effective: max_depth=6 (core wins because more restrictive)
+
+settings = Settings()
+# Configure a deeply nested event (depth > 6)
+event = {"l1": {"l2": {"l3": {"l4": {"l5": {"l6": {"l7": {"password": "secret"}}}}}}}}
+# password at depth 7 should NOT be redacted (exceeds core limit of 6)
+```
+
+### AC2: Per-Redactor Settings Apply When Less Restrictive Than Core
+
+**Description:** When per-redactor settings are more restrictive, they take effect.
+
+**Validation:**
+```python
+# Core: redaction_max_depth=20
+# FieldMask: max_depth=5
+# Effective: max_depth=5 (plugin wins because more restrictive)
+```
+
+### AC3: Core Guardrails Passed to Redactors at Init
+
+**Description:** Core guardrail values are passed to redactors during plugin loading.
+
+**Validation:**
+```python
+# When loading field_mask redactor:
+# - Read core.redaction_max_depth from settings
+# - Pass as max_depth override if more restrictive than plugin default
+```
+
+### AC4: Existing Per-Redactor Behavior Preserved
+
+**Description:** When no core guardrails are set (None), per-redactor defaults still work.
+
+**Validation:**
+```python
+settings = Settings(core=CoreSettings(redaction_max_depth=None))
+# FieldMask uses its own max_depth=16
+```
+
+---
+
+## Implementation Notes
+
+### File Changes
+
+```
+src/fapilog/core/worker.py (MODIFIED - pass guardrails to redactor loader)
+src/fapilog/plugins/redactors/__init__.py (MODIFIED - accept guardrail overrides)
+src/fapilog/plugins/redactors/field_mask.py (MODIFIED - respect passed guardrails)
+src/fapilog/plugins/redactors/regex_mask.py (MODIFIED - respect passed guardrails)
+tests/unit/plugins/redactors/test_guardrails.py (NEW - guardrail tests)
+```
+
+### Key Implementation
+
+**Option 1: Pass at redactor initialization**
+```python
+# In worker or plugin loader:
+core_max_depth = settings.core.redaction_max_depth
+core_max_keys = settings.core.redaction_max_keys_scanned
+
+for redactor in redactors:
+    if hasattr(redactor, 'set_guardrails'):
+        redactor.set_guardrails(
+            max_depth=core_max_depth,
+            max_keys_scanned=core_max_keys,
+        )
+```
+
+**Option 2: Min of core and plugin at each redactor**
+```python
+# In FieldMaskRedactor._apply_mask():
+effective_depth = min(
+    self._max_depth,
+    self._core_max_depth or self._max_depth
+)
+```
+
+---
+
+## Tasks
+
+### Phase 1: Core Implementation
+
+- [ ] Add guardrail parameters to redactor loading in worker.py
+- [ ] Update FieldMaskRedactor to accept and apply core guardrails
+- [ ] Update RegexMaskRedactor to accept and apply core guardrails
+- [ ] Ensure "more restrictive wins" logic
+
+### Phase 2: Testing
+
+- [ ] Test: core guardrail overrides plugin when more restrictive
+- [ ] Test: plugin guardrail applies when more restrictive than core
+- [ ] Test: None core guardrail preserves plugin behavior
+- [ ] Test: both max_depth and max_keys_scanned work
+
+### Phase 3: Cleanup
+
+- [ ] Update CHANGELOG
+- [ ] Verify existing tests still pass
+
+---
+
+## Tests
+
+### Unit Tests
+
+- `tests/unit/plugins/redactors/test_guardrails.py`
+  - `test_core_max_depth_overrides_plugin`
+  - `test_plugin_max_depth_when_more_restrictive`
+  - `test_core_max_keys_overrides_plugin`
+  - `test_none_core_guardrail_uses_plugin_default`
+  - `test_guardrails_emit_warning_when_exceeded`
+
+---
+
+## Definition of Done
+
+### Code Complete
+
+- [ ] All acceptance criteria implemented
+- [ ] Code follows project patterns
+- [ ] No new linting errors
+
+### Quality Assurance
+
+- [ ] Unit tests written and passing
+- [ ] `ruff check` passes
+- [ ] `mypy` passes
+- [ ] No regression in existing tests
+
+### Documentation
+
+- [ ] Code has docstrings where needed
+- [ ] CHANGELOG updated
+
+---
+
+## Risks / Rollback
+
+### Risks
+
+1. **Risk:** Breaking change if users relied on core guardrails being ignored
+   - **Mitigation:** This is a bug fix - settings should work as documented
+
+2. **Risk:** Performance impact from additional checks
+   - **Mitigation:** Single comparison per redactor init, negligible
+
+### Rollback Plan
+
+If issues occur:
+1. Set core guardrails to None to restore current behavior
+
+---
+
+## Related Stories
+
+- **Enables:** Story 4.60 - Document guardrails and precedence
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-01-28 | Initial draft from GPT-5.2 audit | Claude |
+| 2026-01-28 | Revised: split from docs-only to code story after finding core guardrails non-functional | Claude |

--- a/src/fapilog/core/config_builders.py
+++ b/src/fapilog/core/config_builders.py
@@ -193,11 +193,30 @@ def _redactor_configs(settings: _Settings) -> dict[str, dict[str, _Any]]:
 
     Returns:
         Dictionary mapping redactor names to their configuration dictionaries.
+
+    Note:
+        Core guardrails (redaction_max_depth, redaction_max_keys_scanned) are
+        passed to redactors that support them. These act as outer limits that
+        override per-redactor settings when more restrictive.
     """
     rcfg = settings.redactor_config
+    core = settings.core
+
+    # Core guardrails to pass to redactors (None means no core override)
+    core_max_depth = core.redaction_max_depth
+    core_max_keys = core.redaction_max_keys_scanned
+
     cfg: dict[str, dict[str, _Any]] = {
-        "field_mask": {"config": _FieldMaskConfig(**rcfg.field_mask.model_dump())},
-        "regex_mask": {"config": _RegexMaskConfig(**rcfg.regex_mask.model_dump())},
+        "field_mask": {
+            "config": _FieldMaskConfig(**rcfg.field_mask.model_dump()),
+            "core_max_depth": core_max_depth,
+            "core_max_keys_scanned": core_max_keys,
+        },
+        "regex_mask": {
+            "config": _RegexMaskConfig(**rcfg.regex_mask.model_dump()),
+            "core_max_depth": core_max_depth,
+            "core_max_keys_scanned": core_max_keys,
+        },
         "url_credentials": {
             "config": _UrlCredentialsConfig(**rcfg.url_credentials.model_dump())
         },

--- a/tests/unit/plugins/redactors/test_guardrails.py
+++ b/tests/unit/plugins/redactors/test_guardrails.py
@@ -1,0 +1,302 @@
+"""Tests for core redaction guardrails overriding per-redactor settings.
+
+Story 4.57: Make Core Redaction Guardrails Functional
+
+The core guardrails (redaction_max_depth, redaction_max_keys_scanned) in CoreSettings
+should act as outer limits that override per-redactor settings when more restrictive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fapilog.plugins.redactors.field_mask import FieldMaskConfig, FieldMaskRedactor
+from fapilog.plugins.redactors.regex_mask import RegexMaskConfig, RegexMaskRedactor
+
+pytestmark = pytest.mark.security
+
+
+class TestFieldMaskGuardrails:
+    """Tests for FieldMaskRedactor core guardrail behavior."""
+
+    @pytest.mark.asyncio
+    async def test_core_max_depth_overrides_plugin_when_more_restrictive(self) -> None:
+        """Core max_depth=3 should override plugin default of 16."""
+        # Plugin default is max_depth=16, but core says max_depth=3
+        redactor = FieldMaskRedactor(
+            config=FieldMaskConfig(
+                fields_to_mask=["level1.level2.level3.level4.secret"],
+                max_depth=16,  # Plugin setting
+            ),
+            core_max_depth=3,  # Core override - more restrictive
+        )
+
+        # depth 0: root, depth 1: level1, depth 2: level2, depth 3: level3
+        # depth 4: level4 - exceeds max_depth=3, should NOT be redacted
+        event = {
+            "level1": {"level2": {"level3": {"level4": {"secret": "sensitive_data"}}}}
+        }
+
+        result = await redactor.redact(event)
+
+        # Secret at depth 4 should NOT be redacted because core limit of 3 is exceeded
+        assert (
+            result["level1"]["level2"]["level3"]["level4"]["secret"] == "sensitive_data"
+        )
+
+    @pytest.mark.asyncio
+    async def test_plugin_max_depth_applies_when_more_restrictive_than_core(
+        self,
+    ) -> None:
+        """Plugin max_depth=2 should apply when core allows max_depth=20."""
+        redactor = FieldMaskRedactor(
+            config=FieldMaskConfig(
+                fields_to_mask=["level1.level2.level3.secret"],
+                max_depth=2,  # Plugin setting - more restrictive
+            ),
+            core_max_depth=20,  # Core allows more depth
+        )
+
+        event = {"level1": {"level2": {"level3": {"secret": "sensitive_data"}}}}
+
+        result = await redactor.redact(event)
+
+        # Secret at depth 3 should NOT be redacted because plugin limit of 2 is exceeded
+        assert result["level1"]["level2"]["level3"]["secret"] == "sensitive_data"
+
+    @pytest.mark.asyncio
+    async def test_core_max_keys_overrides_plugin_when_more_restrictive(self) -> None:
+        """Core max_keys_scanned=5 should override plugin default of 1000."""
+        redactor = FieldMaskRedactor(
+            config=FieldMaskConfig(
+                fields_to_mask=["data.*.secret"],
+                max_keys_scanned=1000,  # Plugin setting
+            ),
+            core_max_keys_scanned=5,  # Core override - more restrictive
+        )
+
+        # Create event with many keys - should hit limit before finding all secrets
+        event = {"data": {f"item{i}": {"secret": f"secret{i}"} for i in range(20)}}
+
+        result = await redactor.redact(event)
+
+        # Count how many secrets were actually redacted
+        redacted_count = sum(
+            1 for k, v in result["data"].items() if v.get("secret") == "***"
+        )
+
+        # Should have stopped before redacting all 20 (hit the scan limit)
+        assert redacted_count < 20
+
+    @pytest.mark.asyncio
+    async def test_none_core_guardrail_uses_plugin_default(self) -> None:
+        """When core guardrail is None, plugin default applies."""
+        redactor = FieldMaskRedactor(
+            config=FieldMaskConfig(
+                fields_to_mask=["deep.nested.secret"],
+                max_depth=16,  # Plugin default
+            ),
+            core_max_depth=None,  # No core override
+        )
+
+        # Create a structure that fits within plugin's default of 16
+        event = {"deep": {"nested": {"secret": "sensitive_data"}}}
+
+        result = await redactor.redact(event)
+
+        # Should be redacted since depth 2 < plugin max_depth 16
+        assert result["deep"]["nested"]["secret"] == "***"
+
+    @pytest.mark.asyncio
+    async def test_both_guardrails_respect_core_limits(self) -> None:
+        """Both max_depth and max_keys_scanned honor core limits."""
+        redactor = FieldMaskRedactor(
+            config=FieldMaskConfig(
+                fields_to_mask=["a.b.c.d.e.secret"],
+                max_depth=20,
+                max_keys_scanned=10000,
+            ),
+            core_max_depth=4,
+            core_max_keys_scanned=10,
+        )
+
+        # depth 4 puts us at 'e', depth 5 is 'secret' - exceeds limit
+        event = {"a": {"b": {"c": {"d": {"e": {"secret": "value"}}}}}}
+
+        result = await redactor.redact(event)
+
+        # Should NOT be redacted - depth exceeded
+        assert result["a"]["b"]["c"]["d"]["e"]["secret"] == "value"
+
+
+class TestRegexMaskGuardrails:
+    """Tests for RegexMaskRedactor core guardrail behavior."""
+
+    @pytest.mark.asyncio
+    async def test_core_max_depth_overrides_plugin_when_more_restrictive(self) -> None:
+        """Core max_depth=2 should override plugin default of 16."""
+        redactor = RegexMaskRedactor(
+            config=RegexMaskConfig(
+                patterns=[r"level1\.level2\.level3\.secret"],
+                max_depth=16,
+            ),
+            core_max_depth=2,
+        )
+
+        event = {"level1": {"level2": {"level3": {"secret": "sensitive_data"}}}}
+
+        result = await redactor.redact(event)
+
+        # Secret at depth 3 should NOT be redacted because core limit of 2 is exceeded
+        assert result["level1"]["level2"]["level3"]["secret"] == "sensitive_data"
+
+    @pytest.mark.asyncio
+    async def test_plugin_max_depth_applies_when_more_restrictive_than_core(
+        self,
+    ) -> None:
+        """Plugin max_depth=2 should apply when core allows max_depth=20."""
+        redactor = RegexMaskRedactor(
+            config=RegexMaskConfig(
+                patterns=[r"level1\.level2\.level3\.secret"],
+                max_depth=2,
+            ),
+            core_max_depth=20,
+        )
+
+        event = {"level1": {"level2": {"level3": {"secret": "sensitive_data"}}}}
+
+        result = await redactor.redact(event)
+
+        # Secret at depth 3 should NOT be redacted because plugin limit of 2 is exceeded
+        assert result["level1"]["level2"]["level3"]["secret"] == "sensitive_data"
+
+    @pytest.mark.asyncio
+    async def test_core_max_keys_overrides_plugin_when_more_restrictive(self) -> None:
+        """Core max_keys_scanned=5 should override plugin default of 1000."""
+        redactor = RegexMaskRedactor(
+            config=RegexMaskConfig(
+                patterns=[r"data\.item\d+\.secret"],
+                max_keys_scanned=1000,
+            ),
+            core_max_keys_scanned=5,
+        )
+
+        # Create event with many keys
+        event = {"data": {f"item{i}": {"secret": f"secret{i}"} for i in range(20)}}
+
+        result = await redactor.redact(event)
+
+        # Count how many secrets were actually redacted
+        redacted_count = sum(
+            1 for k, v in result["data"].items() if v.get("secret") == "***"
+        )
+
+        # Should have stopped before redacting all 20
+        assert redacted_count < 20
+
+    @pytest.mark.asyncio
+    async def test_none_core_guardrail_uses_plugin_default(self) -> None:
+        """When core guardrail is None, plugin default applies."""
+        redactor = RegexMaskRedactor(
+            config=RegexMaskConfig(
+                patterns=[r"nested\.secret"],
+                max_depth=16,
+            ),
+            core_max_depth=None,
+        )
+
+        event = {"nested": {"secret": "sensitive_data"}}
+
+        result = await redactor.redact(event)
+
+        # Should be redacted since within plugin max_depth
+        assert result["nested"]["secret"] == "***"
+
+
+class TestGuardrailsIntegration:
+    """Integration tests for guardrails being passed through the pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_effective_depth_is_min_of_core_and_plugin(self) -> None:
+        """Effective max_depth should be min(core, plugin)."""
+        # Test case where core is more restrictive
+        redactor1 = FieldMaskRedactor(
+            config=FieldMaskConfig(fields_to_mask=["a.b.c"], max_depth=10),
+            core_max_depth=5,
+        )
+        assert redactor1._max_depth == 5
+
+        # Test case where plugin is more restrictive
+        redactor2 = FieldMaskRedactor(
+            config=FieldMaskConfig(fields_to_mask=["a.b.c"], max_depth=3),
+            core_max_depth=10,
+        )
+        assert redactor2._max_depth == 3
+
+        # Test case where they're equal
+        redactor3 = FieldMaskRedactor(
+            config=FieldMaskConfig(fields_to_mask=["a.b.c"], max_depth=5),
+            core_max_depth=5,
+        )
+        assert redactor3._max_depth == 5
+
+    @pytest.mark.asyncio
+    async def test_effective_keys_scanned_is_min_of_core_and_plugin(self) -> None:
+        """Effective max_keys_scanned should be min(core, plugin)."""
+        # Test case where core is more restrictive
+        redactor1 = FieldMaskRedactor(
+            config=FieldMaskConfig(fields_to_mask=["a"], max_keys_scanned=1000),
+            core_max_keys_scanned=100,
+        )
+        assert redactor1._max_scanned == 100
+
+        # Test case where plugin is more restrictive
+        redactor2 = FieldMaskRedactor(
+            config=FieldMaskConfig(fields_to_mask=["a"], max_keys_scanned=50),
+            core_max_keys_scanned=1000,
+        )
+        assert redactor2._max_scanned == 50
+
+
+class TestConfigBuildersPassGuardrails:
+    """Tests that config builders pass core guardrails to redactors."""
+
+    def test_redactor_configs_includes_core_guardrails(self) -> None:
+        """_redactor_configs should include core guardrails for field_mask/regex_mask."""
+        from fapilog.core.config_builders import _redactor_configs
+        from fapilog.core.settings import Settings
+
+        # Create settings with custom core guardrails
+        settings = Settings()
+        settings.core.redaction_max_depth = 4
+        settings.core.redaction_max_keys_scanned = 100
+
+        configs = _redactor_configs(settings)
+
+        # Verify field_mask gets core guardrails
+        assert "core_max_depth" in configs["field_mask"]
+        assert configs["field_mask"]["core_max_depth"] == 4
+        assert "core_max_keys_scanned" in configs["field_mask"]
+        assert configs["field_mask"]["core_max_keys_scanned"] == 100
+
+        # Verify regex_mask gets core guardrails
+        assert "core_max_depth" in configs["regex_mask"]
+        assert configs["regex_mask"]["core_max_depth"] == 4
+        assert "core_max_keys_scanned" in configs["regex_mask"]
+        assert configs["regex_mask"]["core_max_keys_scanned"] == 100
+
+    def test_redactor_configs_passes_none_when_guardrails_disabled(self) -> None:
+        """_redactor_configs should pass None when core guardrails are None."""
+        from fapilog.core.config_builders import _redactor_configs
+        from fapilog.core.settings import Settings
+
+        settings = Settings()
+        settings.core.redaction_max_depth = None
+        settings.core.redaction_max_keys_scanned = None
+
+        configs = _redactor_configs(settings)
+
+        assert configs["field_mask"]["core_max_depth"] is None
+        assert configs["field_mask"]["core_max_keys_scanned"] is None
+        assert configs["regex_mask"]["core_max_depth"] is None
+        assert configs["regex_mask"]["core_max_keys_scanned"] is None


### PR DESCRIPTION
## Summary

Makes core redaction guardrails (`redaction_max_depth`, `redaction_max_keys_scanned`) functional. These settings were previously defined in `CoreSettings` but never applied - they were dead code. Users configuring these guardrails expected them to work, but they didn't.

The implementation passes core guardrails to `FieldMaskRedactor` and `RegexMaskRedactor` during initialization, applying "more restrictive wins" logic: `effective_limit = min(core, plugin)`.

## Changes

- `CHANGELOG.md` (modified)
- `src/fapilog/core/config_builders.py` (modified)
- `src/fapilog/plugins/redactors/field_mask.py` (modified)
- `src/fapilog/plugins/redactors/regex_mask.py` (modified)
- `tests/unit/plugins/redactors/test_guardrails.py` (new)

## Acceptance Criteria

- [x] AC1: Core guardrails override per-redactor settings when more restrictive
- [x] AC2: Per-redactor settings apply when more restrictive than core
- [x] AC3: Core guardrails passed to redactors at init
- [x] AC4: None core guardrail preserves plugin default behavior

## Test Plan

- [x] Unit tests pass
- [x] Coverage >= 90% on changed lines (100%)
- [x] mypy passes
- [x] ruff check/format passes
- [x] No weak assertions

## Story

[4.57 - Make Core Redaction Guardrails Functional](docs/stories/4.57.redaction-guardrail-documentation.md)