### PR TITLE
docs(redaction): document redaction guardrails and precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. This change
 - **Architecture documentation accuracy:** Removed stale references to non-existent components (`ComplianceEngine`, `UniversalSettings`, `EventCategory`) and deleted outdated monolithic `docs/architecture.md` (Story 12.15).
 - **Production checklist documentation:** Added consolidated pre-deployment checklist covering preset selection, metrics, diagnostics, redaction validation, backpressure tuning, and graceful shutdown (Story 12.16).
 - **stdlib bridge documentation:** Added user guide for `enable_stdlib_bridge()` with API reference, common use cases, Django/Celery integration examples, level mapping, and troubleshooting (Story 12.18).
+- **Redaction guardrails documentation:** Documented two-level guardrail system (core pipeline vs per-redactor), precedence rules ("more restrictive wins"), and added CI validation for per-redactor defaults (Story 4.60).
 
 ## [0.7.0] - 2026-01-27
 

--- a/docs/user-guide/reliability-defaults.md
+++ b/docs/user-guide/reliability-defaults.md
@@ -31,7 +31,7 @@ This is intentional—blocking on the same thread would cause a deadlock since t
 - Order when active: `field-mask` → `regex-mask` → `url-credentials`
 - Guardrails: `core.redaction_max_depth=6`, `core.redaction_max_keys_scanned=5000`
 
-See [Redaction Behavior](../redaction/behavior.md) for complete details on what's redacted, including **failure mode configuration** for production systems.
+See {ref}`guardrails` for complete details on how core and per-redactor guardrails interact, and [Redaction Behavior](../redaction/behavior.md) for what's redacted and **failure mode configuration** for production systems.
 
 ## Exceptions and diagnostics
 - Exceptions serialized by default: `core.exceptions_enabled=True`


### PR DESCRIPTION
## Summary

Document the two-level redaction guardrail system (core pipeline vs per-redactor), precedence rules ("more restrictive wins"), and add CI validation for per-redactor defaults.

## Changes

- `CHANGELOG.md` (modified)
- `docs/redaction/behavior.md` (modified)
- `docs/user-guide/reliability-defaults.md` (modified)
- `scripts/check_doc_accuracy.py` (modified)

## Acceptance Criteria

- [x] AC1: Documentation clearly separates core guardrails from per-redactor guardrails
- [x] AC2: Precedence rules documented with "more restrictive wins" table
- [x] AC3: Cross-link from reliability-defaults.md to guardrails section
- [x] AC4: check_doc_accuracy.py validates per-redactor guardrail defaults

## Test Plan

- [x] `sphinx-build -W` passes with no warnings
- [x] `python scripts/check_doc_accuracy.py` passes (11/11 checks)
- [x] ruff check + format passes
- [x] mypy passes

## Story

[4.60 - Document Redaction Guardrails and Precedence](docs/stories/4.60.redaction-guardrail-docs.md)