### PR TITLE
feat(fallback): add raw output hardening with keyword scrubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to this project will be documented in this file. This change
 - **Worker event-based wakeup:** The background worker loop now uses `asyncio.Event` signaling instead of fixed 1ms polling when an enqueue event is provided, reducing CPU wakeups when the queue is empty (Story 10.32).
 - **Doc accuracy CI now fails on missing critical files:** The `scripts/check_doc_accuracy.py` script now fails when required documentation files are missing, instead of silently skipping them. This prevents security-sensitive documentation from drifting without CI catching it.
 
+### Added
+
+- **Fallback sink raw output hardening:** When JSON parsing fails for serialized payloads on the fallback path, fapilog now applies keyword scrubbing to mask common secret patterns (`password=`, `token=`, `api_key=`, `authorization:`) before writing to stderr. Optional truncation via `core.fallback_raw_max_bytes` limits output size. Scrubbing is enabled by default; set `FAPILOG_CORE__FALLBACK_SCRUB_RAW=false` to disable for debugging (Story 4.59).
+
 ### Fixed
 
 - **Core redaction guardrails now functional:** The `redaction_max_depth` and `redaction_max_keys_scanned` settings in `CoreSettings` were previously defined but never applied (dead code). They are now passed to `FieldMaskRedactor` and `RegexMaskRedactor` during initialization and act as outer limits that override per-redactor settings when more restrictive (Story 4.57).

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -24,7 +24,9 @@
 | `FAPILOG_CORE__EXCEPTIONS_ENABLED` | bool | True | Enable structured exception serialization for log calls |
 | `FAPILOG_CORE__EXCEPTIONS_MAX_FRAMES` | int | 10 | Maximum number of stack frames to capture for exceptions |
 | `FAPILOG_CORE__EXCEPTIONS_MAX_STACK_CHARS` | int | 20000 | Maximum total characters for serialized stack string |
+| `FAPILOG_CORE__FALLBACK_RAW_MAX_BYTES` | int | None | — | Optional limit for raw fallback output bytes; payloads exceeding this are truncated with '[truncated]' marker |
 | `FAPILOG_CORE__FALLBACK_REDACT_MODE` | Literal | minimal | Redaction mode for fallback stderr output: 'inherit' uses pipeline redactors, 'minimal' applies built-in sensitive field masking, 'none' writes unredacted (opt-in to legacy behavior) |
+| `FAPILOG_CORE__FALLBACK_SCRUB_RAW` | bool | True | Apply keyword scrubbing to raw (non-JSON) fallback output; set to False for debugging when raw output is needed |
 | `FAPILOG_CORE__FILTERS` | list | PydanticUndefined | Filter plugins to apply before enrichment (by name) |
 | `FAPILOG_CORE__FLUSH_ON_CRITICAL` | bool | False | Immediately flush ERROR and CRITICAL logs (bypass batching) to reduce log loss on abrupt shutdown |
 | `FAPILOG_CORE__INTERNAL_LOGGING_ENABLED` | bool | False | Emit DEBUG/WARN diagnostics for internal errors |

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -156,6 +156,20 @@
       "title": "Exceptions Max Stack Chars",
       "type": "integer"
     },
+    "fallback_raw_max_bytes": {
+      "anyOf": [
+        {
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional limit for raw fallback output bytes; payloads exceeding this are truncated with '[truncated]' marker",
+      "title": "Fallback Raw Max Bytes"
+    },
     "fallback_redact_mode": {
       "default": "minimal",
       "description": "Redaction mode for fallback stderr output: 'inherit' uses pipeline redactors, 'minimal' applies built-in sensitive field masking, 'none' writes unredacted (opt-in to legacy behavior)",
@@ -166,6 +180,12 @@
       ],
       "title": "Fallback Redact Mode",
       "type": "string"
+    },
+    "fallback_scrub_raw": {
+      "default": true,
+      "description": "Apply keyword scrubbing to raw (non-JSON) fallback output; set to False for debugging when raw output is needed",
+      "title": "Fallback Scrub Raw",
+      "type": "boolean"
     },
     "filters": {
       "description": "Filter plugins to apply before enrichment (by name)",

--- a/docs/settings-guide.md
+++ b/docs/settings-guide.md
@@ -52,6 +52,8 @@ This guide documents Settings groups and fields.
 | `core.flush_on_critical` | bool | False | Immediately flush ERROR and CRITICAL logs (bypass batching) to reduce log loss on abrupt shutdown |
 | `core.emit_drop_summary` | bool | False | Emit summary log events when events are dropped due to backpressure or deduplicated due to error dedupe window |
 | `core.drop_summary_window_seconds` | float | 60.0 | Window in seconds for aggregating drop/dedupe summary events. Summaries are emitted at most once per window. |
+| `core.fallback_scrub_raw` | bool | True | Apply keyword scrubbing to raw (non-JSON) fallback output; set to False for debugging when raw output is needed |
+| `core.fallback_raw_max_bytes` | int | None | — | Optional limit for raw fallback output bytes; payloads exceeding this are truncated with '[truncated]' marker |
 | `core.benchmark_file_path` | str | None | — | Optional path used by performance benchmarks |
 
 ## security

--- a/scripts/builder_param_mappings.py
+++ b/scripts/builder_param_mappings.py
@@ -70,7 +70,12 @@ CORE_COVERAGE: dict[str, list[str]] = {
         "redaction_max_depth",
         "redaction_max_keys_scanned",
     ],
-    "with_fallback_redaction": ["fallback_redact_mode", "redaction_fail_mode"],
+    "with_fallback_redaction": [
+        "fallback_redact_mode",
+        "redaction_fail_mode",
+        "fallback_scrub_raw",
+        "fallback_raw_max_bytes",
+    ],
     # Graceful shutdown (Story 6.13)
     "with_atexit_drain": ["atexit_drain_enabled", "atexit_drain_timeout_seconds"],
     "with_signal_handlers": ["signal_handler_enabled"],

--- a/src/fapilog/builder.py
+++ b/src/fapilog/builder.py
@@ -928,6 +928,8 @@ class LoggerBuilder:
         *,
         fallback_mode: Literal["inherit", "minimal", "none"] = "minimal",
         fail_mode: Literal["open", "closed", "warn"] = "open",
+        scrub_raw: bool = True,
+        raw_max_bytes: int | None = None,
     ) -> LoggerBuilder:
         """Configure redaction behavior for fallback and failure scenarios.
 
@@ -940,16 +942,25 @@ class LoggerBuilder:
                 - "open": Pass original event through (default)
                 - "closed": Drop event entirely
                 - "warn": Pass event through but emit diagnostic warning
+            scrub_raw: Apply keyword scrubbing to raw (non-JSON) fallback output.
+                Masks patterns like password=, token=, api_key= (default: True).
+            raw_max_bytes: Optional byte limit for raw fallback output. Payloads
+                exceeding this are truncated with '[truncated]' marker.
 
         Example:
             >>> builder.with_fallback_redaction(
             ...     fallback_mode="minimal",
             ...     fail_mode="warn",
+            ...     scrub_raw=True,
+            ...     raw_max_bytes=1000,
             ... )
         """
         core = self._config.setdefault("core", {})
         core["fallback_redact_mode"] = fallback_mode
         core["redaction_fail_mode"] = fail_mode
+        core["fallback_scrub_raw"] = scrub_raw
+        if raw_max_bytes is not None:
+            core["fallback_raw_max_bytes"] = raw_max_bytes
         return self
 
     def with_routing(

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -838,6 +838,22 @@ class CoreSettings(BaseModel):
             "Summaries are emitted at most once per window."
         ),
     )
+    # Fallback raw output hardening (Story 4.59)
+    fallback_scrub_raw: bool = Field(
+        default=True,
+        description=(
+            "Apply keyword scrubbing to raw (non-JSON) fallback output; "
+            "set to False for debugging when raw output is needed"
+        ),
+    )
+    fallback_raw_max_bytes: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Optional limit for raw fallback output bytes; "
+            "payloads exceeding this are truncated with '[truncated]' marker"
+        ),
+    )
 
     # Example of a field requiring async validation
     benchmark_file_path: str | None = Field(

--- a/tests/test_builder_parity.py
+++ b/tests/test_builder_parity.py
@@ -86,8 +86,13 @@ BUILDER_TO_CORE_FIELDS: dict[str, list[str]] = {
     "with_atexit_drain": ["atexit_drain_enabled", "atexit_drain_timeout_seconds"],
     "with_signal_handlers": ["signal_handler_enabled"],
     "with_flush_on_critical": ["flush_on_critical"],
-    # Story 4.54: Redaction fail mode
-    "with_fallback_redaction": ["fallback_redact_mode", "redaction_fail_mode"],
+    # Story 4.54: Redaction fail mode, Story 4.59: Raw output hardening
+    "with_fallback_redaction": [
+        "fallback_redact_mode",
+        "redaction_fail_mode",
+        "fallback_scrub_raw",
+        "fallback_raw_max_bytes",
+    ],
 }
 
 # Mapping of add_* methods to sink types they cover

--- a/tests/unit/test_worker_redaction_fail_modes.py
+++ b/tests/unit/test_worker_redaction_fail_modes.py
@@ -41,6 +41,26 @@ class TestRedactionFailModeSetting:
         assert builder._config["core"]["fallback_redact_mode"] == "none"
         assert builder._config["core"]["redaction_fail_mode"] == "warn"
 
+    def test_builder_with_fallback_redaction_sets_raw_hardening(self) -> None:
+        """Builder with_fallback_redaction sets raw output hardening params (Story 4.59)."""
+        from fapilog.builder import LoggerBuilder
+
+        builder = LoggerBuilder()
+        builder.with_fallback_redaction(scrub_raw=False, raw_max_bytes=1000)
+
+        assert builder._config["core"]["fallback_scrub_raw"] is False
+        assert builder._config["core"]["fallback_raw_max_bytes"] == 1000
+
+    def test_builder_with_fallback_redaction_raw_max_bytes_omitted(self) -> None:
+        """raw_max_bytes not set when None (default)."""
+        from fapilog.builder import LoggerBuilder
+
+        builder = LoggerBuilder()
+        builder.with_fallback_redaction()
+
+        assert builder._config["core"]["fallback_scrub_raw"] is True
+        assert "fallback_raw_max_bytes" not in builder._config["core"]
+
     def test_explicit_closed(self) -> None:
         """Can set redaction_fail_mode to 'closed'."""
         settings = CoreSettings(redaction_fail_mode="closed")


### PR DESCRIPTION
## Summary

When the fallback sink cannot parse a serialized payload as JSON, it writes raw bytes to stderr. This safety-net path can leak secrets if the payload contains credentials in a non-JSON format. This PR adds keyword scrubbing and optional truncation to harden this fallback path.

## Changes

- `src/fapilog/core/defaults.py` (modified) - Add FALLBACK_SCRUB_PATTERNS regex for password/token/auth patterns
- `src/fapilog/core/settings.py` (modified) - Add fallback_scrub_raw and fallback_raw_max_bytes to CoreSettings
- `src/fapilog/plugins/sinks/fallback.py` (modified) - Implement _scrub_raw() and apply to raw fallback path
- `src/fapilog/builder.py` (modified) - Extend with_fallback_redaction() with scrub_raw and raw_max_bytes params
- `scripts/builder_param_mappings.py` (modified) - Update CORE_COVERAGE for new settings
- `tests/unit/test_fallback_serialized_redaction.py` (modified) - Add raw output scrubbing tests
- `tests/unit/test_worker_redaction_fail_modes.py` (modified) - Add builder integration tests
- `tests/test_builder_parity.py` (modified) - Update parity mappings
- `docs/user-guide/reliability-defaults.md` (modified) - Document fallback raw hardening
- `CHANGELOG.md` (modified) - Add changelog entry
- `docs/env-vars.md` (modified) - Auto-generated env vars doc
- `docs/schema-guide.md` (modified) - Auto-generated schema doc
- `docs/settings-guide.md` (modified) - Auto-generated settings doc

## Acceptance Criteria

- [x] AC1: When JSON parsing fails, apply regex scrub for common secret patterns before output
- [x] AC2: Optionally truncate unparseable payloads to limit exposure
- [x] AC3: Default behavior applies keyword scrub (opt-out available)
- [x] AC4: Can disable scrubbing for debugging scenarios
- [x] AC5: Diagnostic warning includes scrubbed/truncated/original_size info

## Test Plan

- [x] Unit test: keyword patterns scrubbed (password, token, api_key, auth)
- [x] Unit test: truncation applied at limit with [truncated] marker
- [x] Unit test: opt-out disables scrubbing
- [x] Unit test: diagnostic includes scrub/truncate info
- [x] Unit test: builder params set config correctly
- [x] ruff check and format pass
- [x] mypy passes
- [x] diff-cover >= 90% (100% on changed lines)

## Story

[4.59 - Fallback Sink Raw Output Hardening](docs/stories/4.59.fallback-sink-raw-output-hardening.md)