### PR TITLE
feat(core): replace backpressure spin-wait with event signaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file. This change
 
 - **Production preset disables Postgres auto-DDL:** The `production` preset now sets `create_table=False` for Postgres sink configuration, requiring explicit table provisioning via migrations. This prevents unexpected DDL execution in regulated environments (Story 10.32).
 - **Worker event-based wakeup:** The background worker loop now uses `asyncio.Event` signaling instead of fixed 1ms polling when an enqueue event is provided, reducing CPU wakeups when the queue is empty (Story 10.32).
+- **Backpressure event-based signaling:** `NonBlockingRingQueue.await_enqueue()` and `await_dequeue()` now use `asyncio.Event` signaling instead of spin-wait loops, reducing CPU usage under sustained backpressure. The `yield_every` parameter has been removed (Story 12.23).
 - **Doc accuracy CI now fails on missing critical files:** The `scripts/check_doc_accuracy.py` script now fails when required documentation files are missing, instead of silently skipping them. This prevents security-sensitive documentation from drifting without CI catching it.
 
 ### Added

--- a/tests/unit/test_concurrency_more.py
+++ b/tests/unit/test_concurrency_more.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from fapilog.core.concurrency import NonBlockingRingQueue
@@ -36,3 +38,201 @@ async def test_ring_queue_dequeue_timeout() -> None:
     q: NonBlockingRingQueue[int] = NonBlockingRingQueue(capacity=1)
     with pytest.raises(TimeoutError):
         await q.await_dequeue(timeout=0.01)
+
+
+# Story 12.23: Event signaling tests
+
+
+@pytest.mark.asyncio
+async def test_await_enqueue_uses_event_not_spin() -> None:
+    """await_enqueue should use event signaling, not spin-wait.
+
+    Verifies that the queue has _space_available Event attribute,
+    indicating event-based signaling is implemented.
+    """
+    q: NonBlockingRingQueue[int] = NonBlockingRingQueue(capacity=1)
+
+    # Queue should have event attributes for signaling
+    assert hasattr(q, "_space_available"), "Queue should have _space_available event"
+    assert isinstance(q._space_available, asyncio.Event), (
+        "_space_available should be an asyncio.Event"
+    )
+
+
+@pytest.mark.asyncio
+async def test_await_dequeue_uses_event_not_spin() -> None:
+    """await_dequeue should use event signaling, not spin-wait.
+
+    Verifies that the queue has _data_available Event attribute,
+    indicating event-based signaling is implemented.
+    """
+    q: NonBlockingRingQueue[int] = NonBlockingRingQueue(capacity=1)
+
+    # Queue should have event attributes for signaling
+    assert hasattr(q, "_data_available"), "Queue should have _data_available event"
+    assert isinstance(q._data_available, asyncio.Event), (
+        "_data_available should be an asyncio.Event"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dequeue_signals_waiting_enqueuer() -> None:
+    """Dequeue should wake up a waiting enqueuer via event signaling."""
+    q: NonBlockingRingQueue[int] = NonBlockingRingQueue(capacity=1)
+    # Fill the queue
+    assert q.try_enqueue(1) is True
+
+    enqueue_completed = False
+
+    async def enqueue_waiter() -> None:
+        nonlocal enqueue_completed
+        await q.await_enqueue(2, timeout=1.0)
+        enqueue_completed = True
+
+    # Start waiting enqueuer
+    task = asyncio.create_task(enqueue_waiter())
+    # Give it time to start waiting
+    await asyncio.sleep(0.01)
+
+    # Dequeue should signal the waiter
+    ok, item = q.try_dequeue()
+    assert ok is True
+    assert item == 1
+
+    # Wait for enqueue to complete
+    await asyncio.wait_for(task, timeout=0.5)
+    assert enqueue_completed is True
+
+    # Verify item was enqueued
+    ok, item = q.try_dequeue()
+    assert ok is True
+    assert item == 2
+
+
+@pytest.mark.asyncio
+async def test_enqueue_signals_waiting_dequeuer() -> None:
+    """Enqueue should wake up a waiting dequeuer via event signaling."""
+    q: NonBlockingRingQueue[int] = NonBlockingRingQueue(capacity=1)
+    # Queue is empty
+
+    dequeue_result: int | None = None
+
+    async def dequeue_waiter() -> None:
+        nonlocal dequeue_result
+        dequeue_result = await q.await_dequeue(timeout=1.0)
+
+    # Start waiting dequeuer
+    task = asyncio.create_task(dequeue_waiter())
+    # Give it time to start waiting
+    await asyncio.sleep(0.01)
+
+    # Enqueue should signal the waiter
+    assert q.try_enqueue(42) is True
+
+    # Wait for dequeue to complete
+    await asyncio.wait_for(task, timeout=0.5)
+    assert dequeue_result == 42
+
+
+@pytest.mark.asyncio
+async def test_multiple_enqueuers_wake_correctly() -> None:
+    """Multiple waiting enqueuers should be awakened as space becomes available."""
+    q: NonBlockingRingQueue[int] = NonBlockingRingQueue(capacity=1)
+    # Fill the queue
+    assert q.try_enqueue(0) is True
+
+    results: list[int] = []
+
+    async def enqueue_waiter(value: int) -> None:
+        await q.await_enqueue(value, timeout=2.0)
+        results.append(value)
+
+    # Start multiple waiting enqueuers
+    tasks = [asyncio.create_task(enqueue_waiter(i)) for i in range(1, 4)]
+    # Give them time to start waiting
+    await asyncio.sleep(0.01)
+
+    # Dequeue repeatedly to make space and wake waiters
+    for _ in range(3):
+        q.try_dequeue()
+        await asyncio.sleep(0.01)  # Let awakened task run
+
+    # Wait for all tasks
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+    # All should have completed
+    assert len(results) == 3
+    assert set(results) == {1, 2, 3}
+
+
+@pytest.mark.asyncio
+async def test_multiple_dequeuers_wake_correctly() -> None:
+    """Multiple waiting dequeuers should be awakened as data becomes available."""
+    q: NonBlockingRingQueue[int] = NonBlockingRingQueue(capacity=3)
+    # Queue is empty
+
+    results: list[int] = []
+
+    async def dequeue_waiter() -> None:
+        item = await q.await_dequeue(timeout=2.0)
+        results.append(item)
+
+    # Start multiple waiting dequeuers
+    tasks = [asyncio.create_task(dequeue_waiter()) for _ in range(3)]
+    # Give them time to start waiting
+    await asyncio.sleep(0.01)
+
+    # Enqueue items to wake waiters
+    for i in range(3):
+        q.try_enqueue(i + 1)
+        await asyncio.sleep(0.01)  # Let awakened task run
+
+    # Wait for all tasks
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+    # All should have completed
+    assert len(results) == 3
+    assert set(results) == {1, 2, 3}
+
+
+@pytest.mark.asyncio
+async def test_timeout_during_retry_loop_enqueue() -> None:
+    """Timeout should be checked during retry loop, not just on wait."""
+    q: NonBlockingRingQueue[int] = NonBlockingRingQueue(capacity=1)
+    assert q.try_enqueue(0) is True  # Fill queue
+
+    # Create a situation where waiter wakes but can't enqueue, times out on retry
+    async def slow_consumer() -> None:
+        await asyncio.sleep(0.05)  # Let enqueuer start waiting
+        q.try_dequeue()  # Wake enqueuer
+        # Immediately fill queue again before enqueuer can act
+        q.try_enqueue(99)
+
+    task = asyncio.create_task(slow_consumer())
+
+    # Very short timeout - should timeout during retry check
+    with pytest.raises(TimeoutError):
+        await q.await_enqueue(1, timeout=0.06)
+
+    await task
+
+
+@pytest.mark.asyncio
+async def test_timeout_during_retry_loop_dequeue() -> None:
+    """Timeout should be checked during retry loop for dequeue."""
+    q: NonBlockingRingQueue[int] = NonBlockingRingQueue(capacity=1)
+    # Queue is empty
+
+    async def tease_dequeuer() -> None:
+        await asyncio.sleep(0.05)  # Let dequeuer start waiting
+        q.try_enqueue(1)  # Wake dequeuer
+        # Immediately empty queue again before dequeuer can act
+        q.try_dequeue()
+
+    task = asyncio.create_task(tease_dequeuer())
+
+    # Very short timeout - should timeout during retry check
+    with pytest.raises(TimeoutError):
+        await q.await_dequeue(timeout=0.06)
+
+    await task


### PR DESCRIPTION
## Summary

Replace spin-wait loops in `NonBlockingRingQueue.await_enqueue()` and `await_dequeue()` with `asyncio.Event` signaling to reduce CPU usage under sustained backpressure conditions.

## Changes

- `CHANGELOG.md` (modified)
- `src/fapilog/core/concurrency.py` (modified)
- `tests/benchmark/test_perf_benchmarks.py` (modified)
- `tests/unit/test_concurrency_more.py` (modified)

## Acceptance Criteria

- [x] AC1: Event-Based Waiting - `await_enqueue()` uses `asyncio.Event` instead of spin loop
- [x] AC2: Signal on Dequeue - `try_dequeue()` signals the event when space becomes available
- [x] AC3: Timeout Preserved - Timeout behavior works correctly with event wait
- [x] AC4: CPU Usage Reduced - Benchmark shows reduced CPU under sustained full-queue
- [x] AC5: Backward Compatible API - Core API preserved; `yield_every` parameter removed (breaking change, user approved)

## Test Plan

- [x] Unit tests for event signaling behavior
- [x] Tests for multi-waiter wake-up scenarios
- [x] Timeout tests preserved and passing
- [x] CPU efficiency benchmark test

## Story

[12.23 - Replace Backpressure Spin-Wait with Event Signaling](docs/stories/12.23.backpressure-event-signaling.md)