### PR TITLE
feat(core): add security-hardened preset for regulated environments

### DIFF
--- a/docs/redaction/presets.md
+++ b/docs/redaction/presets.md
@@ -88,7 +88,14 @@ from fapilog import get_logger
 logger = get_logger(preset="production")
 ```
 
-To add compliance presets:
+The `hardened` preset applies comprehensive redaction from HIPAA_PHI, PCI_DSS, and CREDENTIALS presets:
+
+```python
+# Maximum security for regulated environments
+logger = get_logger(preset="hardened")
+```
+
+To add compliance presets to other environment presets:
 
 ```python
 logger = (

--- a/src/fapilog/builder.py
+++ b/src/fapilog/builder.py
@@ -98,8 +98,11 @@ class LoggerBuilder:
         For production, fastapi, and serverless presets, the CREDENTIALS
         redaction preset is automatically applied for secure defaults.
 
+        For the hardened preset, HIPAA_PHI, PCI_DSS, and CREDENTIALS redaction
+        presets are applied for maximum security coverage.
+
         Args:
-            preset: Preset name (dev, production, fastapi, minimal, serverless)
+            preset: Preset name (dev, production, fastapi, minimal, serverless, hardened)
 
         Raises:
             ValueError: If a preset is already set
@@ -113,6 +116,10 @@ class LoggerBuilder:
         # Apply CREDENTIALS redaction preset for security-focused presets
         if preset in ("production", "fastapi", "serverless"):
             self.with_redaction(preset="CREDENTIALS")
+
+        # Apply comprehensive redaction presets for hardened mode
+        if preset == "hardened":
+            self.with_redaction(preset=["HIPAA_PHI", "PCI_DSS", "CREDENTIALS"])
 
         return self
 

--- a/src/fapilog/core/presets.py
+++ b/src/fapilog/core/presets.py
@@ -108,6 +108,45 @@ PRESETS: dict[str, dict[str, Any]] = {
         },
         "_apply_credentials_preset": True,
     },
+    "hardened": {
+        "core": {
+            "log_level": "INFO",
+            "batch_max_size": 100,
+            "drop_on_full": False,  # Never lose logs
+            "redaction_fail_mode": "closed",  # Drop event if redaction fails
+            "strict_envelope_mode": True,  # Reject malformed envelopes
+            "fallback_redact_mode": "inherit",  # Full redaction on fallback
+            "fallback_scrub_raw": True,  # Scrub raw output
+            "sinks": ["stdout_json", "rotating_file"],
+            "enrichers": ["runtime_info", "context_vars"],
+            "redactors": ["field_mask", "regex_mask", "url_credentials"],
+        },
+        "sink_config": {
+            "rotating_file": {
+                "directory": "./logs",
+                "filename_prefix": "fapilog",
+                "max_bytes": 52_428_800,  # 50 MB
+                "max_files": 10,
+                "compress_rotated": True,
+            },
+            "postgres": {
+                "create_table": False,  # Require explicit provisioning
+            },
+        },
+        "enricher_config": {
+            "runtime_info": {},
+            "context_vars": {},
+        },
+        "redactor_config": {
+            "field_mask": {},
+            "regex_mask": {},
+            "url_credentials": {},
+        },
+        # Marker for automatic CREDENTIALS preset application
+        "_apply_credentials_preset": True,
+        # Additional presets for hardened mode (HIPAA + PCI-DSS)
+        "_apply_redaction_presets": ["HIPAA_PHI", "PCI_DSS"],
+    },
 }
 
 

--- a/tests/integration/test_hardened_preset.py
+++ b/tests/integration/test_hardened_preset.py
@@ -1,0 +1,196 @@
+"""Integration tests for hardened preset.
+
+Story 3.10: Security-Hardened Preset
+
+Tests verify that the hardened preset:
+- Applies comprehensive redaction from HIPAA, PCI-DSS, and CREDENTIALS presets (AC6)
+- Creates a working logger with all security settings enabled (AC1)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from fapilog import get_logger, list_presets
+from fapilog.core.presets import get_preset
+from fapilog.core.settings import Settings
+
+pytestmark = [pytest.mark.integration, pytest.mark.security]
+
+
+async def _collecting_sink(
+    collected: list[dict[str, Any]], entry: dict[str, Any]
+) -> None:
+    """Helper sink that collects events for inspection."""
+    collected.append(dict(entry))
+
+
+class TestHardenedPresetDiscovery:
+    """Test that hardened preset is discoverable."""
+
+    def test_hardened_preset_in_list(self):
+        """AC1: Hardened preset is discoverable via list_presets."""
+        presets = list_presets()
+        assert "hardened" in presets
+
+    def test_hardened_preset_returns_config(self):
+        """AC1: get_preset returns valid config for hardened."""
+        config = get_preset("hardened")
+        assert "core" in config
+        assert config["core"]["redaction_fail_mode"] == "closed"
+
+
+class TestHardenedPresetRedactionFields:
+    """Test comprehensive redaction preset application (AC6)."""
+
+    def test_hardened_preset_applies_hipaa_fields(self):
+        """AC6: Hardened preset applies HIPAA_PHI redaction fields."""
+        config = get_preset("hardened")
+        # Verify Settings creation works (fields applied at logger creation)
+        Settings(**config)
+
+        # HIPAA fields (via resolve in get_logger)
+        # These are applied at logger creation time, so we verify
+        # the preset has the marker for application
+        redaction_presets = config.get("_apply_redaction_presets", [])
+        assert "HIPAA_PHI" in redaction_presets
+
+    def test_hardened_preset_applies_pci_dss_fields(self):
+        """AC6: Hardened preset applies PCI_DSS redaction fields."""
+        config = get_preset("hardened")
+
+        redaction_presets = config.get("_apply_redaction_presets", [])
+        assert "PCI_DSS" in redaction_presets
+
+    def test_hardened_preset_applies_credentials_fields(self):
+        """AC6: Hardened preset applies CREDENTIALS redaction fields."""
+        config = get_preset("hardened")
+
+        # Legacy marker for CREDENTIALS
+        assert config.get("_apply_credentials_preset") is True
+
+
+@pytest.mark.asyncio
+async def test_hardened_preset_creates_working_logger():
+    """AC1: Logger can be created with hardened preset and logs work."""
+    collected: list[dict[str, Any]] = []
+
+    logger = get_logger(name="test-hardened", preset="hardened")
+
+    async def sink(entry: dict[str, Any]) -> None:
+        await _collecting_sink(collected, entry)
+
+    logger._sink_write = sink  # type: ignore[attr-defined]
+
+    # Log a test message
+    logger.info("test message", user_id="12345")
+    await asyncio.sleep(0)
+    await logger.stop_and_drain()
+
+    assert collected, "Expected at least one emitted entry"
+    event = collected[0]
+    assert event["message"] == "test message"
+
+
+@pytest.mark.asyncio
+async def test_hardened_preset_redacts_credentials():
+    """Hardened preset redacts credential fields."""
+    collected: list[dict[str, Any]] = []
+
+    logger = get_logger(name="test-hardened-creds", preset="hardened")
+
+    async def sink(entry: dict[str, Any]) -> None:
+        await _collecting_sink(collected, entry)
+
+    logger._sink_write = sink  # type: ignore[attr-defined]
+
+    # Log with sensitive credential data
+    logger.info(
+        "auth attempt",
+        password="secret123",
+        api_key="sk-1234567890",
+    )
+    await asyncio.sleep(0)
+    await logger.stop_and_drain()
+
+    assert collected, "Expected at least one emitted entry"
+    event = collected[0]
+    data = event.get("data", {})
+
+    # Credentials should be redacted
+    password = data.get("password", "")
+    api_key = data.get("api_key", "")
+
+    assert "secret123" not in password, f"Password should be redacted, got: {password}"
+    assert "sk-1234567890" not in api_key, f"API key should be redacted, got: {api_key}"
+
+
+@pytest.mark.asyncio
+async def test_hardened_preset_redacts_pci_fields():
+    """Hardened preset redacts PCI-DSS fields."""
+    collected: list[dict[str, Any]] = []
+
+    logger = get_logger(name="test-hardened-pci", preset="hardened")
+
+    async def sink(entry: dict[str, Any]) -> None:
+        await _collecting_sink(collected, entry)
+
+    logger._sink_write = sink  # type: ignore[attr-defined]
+
+    # Log with PCI-DSS sensitive data
+    logger.info(
+        "payment",
+        card_number="4111111111111111",
+        cvv="123",
+    )
+    await asyncio.sleep(0)
+    await logger.stop_and_drain()
+
+    assert collected, "Expected at least one emitted entry"
+    event = collected[0]
+    data = event.get("data", {})
+
+    # PCI fields should be redacted
+    card = data.get("card_number", "")
+    cvv = data.get("cvv", "")
+
+    assert "4111111111111111" not in card, (
+        f"Card number should be redacted, got: {card}"
+    )
+    assert "123" not in cvv, f"CVV should be redacted, got: {cvv}"
+
+
+@pytest.mark.asyncio
+async def test_hardened_preset_redacts_hipaa_fields():
+    """Hardened preset redacts HIPAA PHI fields."""
+    collected: list[dict[str, Any]] = []
+
+    logger = get_logger(name="test-hardened-hipaa", preset="hardened")
+
+    async def sink(entry: dict[str, Any]) -> None:
+        await _collecting_sink(collected, entry)
+
+    logger._sink_write = sink  # type: ignore[attr-defined]
+
+    # Log with HIPAA PHI data
+    logger.info(
+        "patient record",
+        ssn="123-45-6789",
+        mrn="MRN-001234",
+    )
+    await asyncio.sleep(0)
+    await logger.stop_and_drain()
+
+    assert collected, "Expected at least one emitted entry"
+    event = collected[0]
+    data = event.get("data", {})
+
+    # HIPAA fields should be redacted
+    ssn = data.get("ssn", "")
+    mrn = data.get("mrn", "")
+
+    assert "123-45-6789" not in ssn, f"SSN should be redacted, got: {ssn}"
+    assert "MRN-001234" not in mrn, f"MRN should be redacted, got: {mrn}"

--- a/tests/unit/test_redaction_defaults.py
+++ b/tests/unit/test_redaction_defaults.py
@@ -220,7 +220,14 @@ class TestPresetConsistency:
 
         This test ensures new presets get documented.
         """
-        expected_presets = {"dev", "production", "fastapi", "minimal", "serverless"}
+        expected_presets = {
+            "dev",
+            "production",
+            "fastapi",
+            "minimal",
+            "serverless",
+            "hardened",
+        }
         actual_presets = set(PRESETS.keys())
 
         assert actual_presets == expected_presets, (


### PR DESCRIPTION
## Summary

Add new `hardened` preset for regulated environments (HIPAA, PCI-DSS, financial services) that enables all strict security options in a single configuration. This addresses audit findings recommending a "security-hardened preset or checklist" for compliance teams.

The hardened preset enables:
- `redaction_fail_mode="closed"` - drops events if redaction fails
- `strict_envelope_mode=True` - rejects malformed envelopes
- `fallback_redact_mode="inherit"` - full redaction on fallback output
- `drop_on_full=False` - never drops logs under queue pressure
- Comprehensive redaction from HIPAA_PHI, PCI_DSS, and CREDENTIALS presets

## Changes

- `src/fapilog/core/presets.py` (modified) - add hardened preset definition
- `src/fapilog/__init__.py` (modified) - extend to handle `_apply_redaction_presets` list pattern
- `src/fapilog/builder.py` (modified) - extend `with_preset()` for hardened mode
- `docs/user-guide/configuration.md` (modified) - add hardened to preset comparison table
- `docs/redaction/presets.md` (modified) - reference hardened preset
- `tests/unit/test_presets.py` (modified) - add hardened preset tests
- `tests/unit/test_builder_api.py` (modified) - add builder tests for hardened
- `tests/unit/test_redaction_defaults.py` (modified) - update preset consistency test
- `tests/integration/test_hardened_preset.py` (new) - integration tests for redaction behavior

## Acceptance Criteria

- [x] AC1: Hardened preset exists and is discoverable via `list_presets()`
- [x] AC2: Fail-closed redaction mode (`redaction_fail_mode="closed"`)
- [x] AC3: Strict envelope mode enabled (`strict_envelope_mode=True`)
- [x] AC4: Full fallback redaction (`fallback_redact_mode="inherit"`)
- [x] AC5: No log loss under pressure (`drop_on_full=False`)
- [x] AC6: Comprehensive redaction presets (HIPAA_PHI + PCI_DSS + CREDENTIALS)
- [x] AC7: Documentation updated with preset comparison and trade-offs

## Test Plan

- [x] Unit tests for preset structure (12 tests)
- [x] Integration tests for redaction behavior (9 tests)
- [x] All 2714 existing tests pass (no regressions)
- [x] 100% diff coverage on changed lines

## Story

[3.10 - Security-Hardened Preset](docs/stories/3.10.security-hardened-preset.md)