### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2026-01-28
 
 ### Breaking Changes
 


### PR DESCRIPTION
## Summary

Release v0.8.0 with breaking changes to redaction defaults (fail-closed behavior).

## Changes

- `CHANGELOG.md` (modified) - Move Unreleased section to v0.8.0

## Highlights

### Breaking Changes
- Redaction defaults changed to fail-closed to prevent PII leakage

### Changed
- Production preset disables Postgres auto-DDL
- Worker and backpressure now use event-based signaling

### Added
- FastAPI middleware `require_logger` parameter
- Fallback sink raw output hardening

### Fixed
- Core redaction guardrails now functional
- Silent data loss in `write_serialized`

## Post-merge

After merging, create and push the tag:
```bash
git checkout main && git pull
git tag v0.8.0
git push origin v0.8.0
```