### PR TITLE
fix(core): align worker redaction_fail_mode default with settings

### DIFF
--- a/docs/redaction/behavior.md
+++ b/docs/redaction/behavior.md
@@ -7,19 +7,19 @@ This page documents exactly what fapilog redacts, how the pipeline works, and kn
 ```{important}
 **Redaction Failure Behavior**
 
-By default (`redaction_fail_mode="open"`), if the redaction pipeline encounters an unexpected error, the original log event passes through **unredacted**. For production systems handling sensitive data, explicitly set the failure mode:
+By default (`redaction_fail_mode="warn"`), if the redaction pipeline encounters an unexpected error, the original log event passes through and a diagnostic warning is emitted. For high-security systems handling sensitive data:
 
-- `"warn"` (recommended for production): Pass event through + emit diagnostic warning
 - `"closed"` (high-security): Drop the event entirely rather than risk data exposure
+- `"open"` (debugging only): Pass event through silently without warning
 
 Configure via builder:
    ```python
-   logger = LoggerBuilder().with_fallback_redaction(fail_mode="warn").build()
+   logger = LoggerBuilder().with_fallback_redaction(fail_mode="closed").build()
    ```
 
 Or via settings:
    ```python
-   Settings(core=CoreSettings(redaction_fail_mode="warn"))
+   Settings(core=CoreSettings(redaction_fail_mode="closed"))
    ```
 
 See [Reliability Defaults](../user-guide/reliability-defaults.md) for related production settings.

--- a/src/fapilog/core/worker.py
+++ b/src/fapilog/core/worker.py
@@ -155,7 +155,7 @@ class LoggerWorker:
         emit_redactor_diagnostics: bool,
         emit_processor_diagnostics: bool = False,
         counters: dict[str, int],
-        redaction_fail_mode: Literal["open", "closed", "warn"] = "open",
+        redaction_fail_mode: Literal["open", "closed", "warn"] = "warn",
         enqueue_event: asyncio.Event | None = None,
     ) -> None:
         self._queue = queue

--- a/tests/unit/test_worker_redaction_fail_modes.py
+++ b/tests/unit/test_worker_redaction_fail_modes.py
@@ -1,6 +1,7 @@
 """Tests for redaction fail mode behavior in LoggerWorker.
 
 Story 4.54: Redaction Fail-Closed Mode and Fallback Hardening
+Story 4.61: Align Worker Redaction Fail Mode Default with Settings
 """
 
 from __future__ import annotations
@@ -11,6 +12,28 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from fapilog.core.settings import CoreSettings
+
+
+class TestRedactionFailModeDefaultAlignment:
+    """Story 4.61: Worker and Settings defaults must be aligned."""
+
+    def test_worker_redaction_fail_mode_matches_settings(self) -> None:
+        """Regression test: LoggerWorker default must match CoreSettings default.
+
+        Story 4.61 AC1/AC3: Prevents silent security regression from default drift.
+        """
+        import inspect
+
+        from fapilog.core.worker import LoggerWorker
+
+        worker_sig = inspect.signature(LoggerWorker.__init__)
+        worker_default = worker_sig.parameters["redaction_fail_mode"].default
+        settings_default = CoreSettings.model_fields["redaction_fail_mode"].default
+
+        assert worker_default == settings_default, (
+            f"LoggerWorker.redaction_fail_mode default ({worker_default}) "
+            f"must match CoreSettings default ({settings_default})"
+        )
 
 
 class TestRedactionFailModeSetting:


### PR DESCRIPTION
## Summary

Fixes P1 security issue from v0.8.0 assessment: `LoggerWorker.__init__` defaulted `redaction_fail_mode="open"` while `CoreSettings` defaults to `"warn"`. This misalignment could cause silent fail-open behavior if construction paths missed passing the Settings-derived value.

Also fixes documentation in `docs/redaction/behavior.md` which incorrectly stated the default was `"open"`.

## Changes

- `src/fapilog/core/worker.py` (modified) - Change default from `"open"` to `"warn"`
- `docs/redaction/behavior.md` (modified) - Update admonition to reflect true default
- `tests/unit/test_worker_redaction_fail_modes.py` (modified) - Add regression test

## Acceptance Criteria

- [x] AC1: Worker default matches Settings default (`"warn"`)
- [x] AC2: Documentation reflects true default
- [x] AC3: Regression test prevents future drift

## Test Plan

- [x] Unit tests pass (21 tests)
- [x] Regression test verifies defaults match via `inspect.signature`
- [x] ruff check passes
- [x] mypy passes
- [x] No weak assertions

## Story

[4.61 - Align Worker Redaction Fail Mode Default with Settings](docs/stories/4.61.align-worker-redaction-fail-mode-default.md)