### PR TITLE
docs(fapilog): document context field routing in with_context() docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Documentation
+
+- **with_context() docstring documents field routing:** The `with_context()` builder method docstring now explains that known context fields (`request_id`, `user_id`, `tenant_id`, `trace_id`, `span_id`) are routed to `log.context` while custom fields go to `log.data`.
+
 ## [0.8.1] - 2026-01-29
 
 ### Added

--- a/src/fapilog/builder.py
+++ b/src/fapilog/builder.py
@@ -395,10 +395,28 @@ class LoggerBuilder:
         return self
 
     def with_context(self, **kwargs: object) -> LoggerBuilder:
-        """Set default bound context.
+        """Set default bound context fields for all log entries.
+
+        Context fields are automatically included in every log entry from this
+        logger. Fields are routed to different sections based on their names:
+
+        **Known context fields** (go to ``log.context``):
+            request_id, user_id, tenant_id, trace_id, span_id
+
+        **Custom fields** (go to ``log.data``):
+            All other field names
 
         Args:
-            **kwargs: Context key-value pairs
+            **kwargs: Context key-value pairs to bind to the logger.
+
+        Returns:
+            Self for method chaining.
+
+        Example:
+            >>> logger = LoggerBuilder().with_context(
+            ...     request_id="req-123",  # -> log.context.request_id
+            ...     custom="value"         # -> log.data.custom
+            ... ).build()
         """
         self._config.setdefault("core", {})["default_bound_context"] = kwargs
         return self

--- a/tests/unit/test_builder_api.py
+++ b/tests/unit/test_builder_api.py
@@ -707,3 +707,33 @@ class TestRedactionBranches:
         patterns = builder._config["redactor_config"]["regex_mask"]["patterns"]
         assert patterns == ["password.*"]
         assert "secret.*" not in patterns
+
+
+class TestWithContextDocstring:
+    """Test with_context() docstring documents field routing (Story 10.42)."""
+
+    def test_docstring_explains_field_routing(self):
+        """AC1: Docstring explains that known fields go to context, custom to data."""
+        from fapilog import LoggerBuilder
+
+        docstring = LoggerBuilder.with_context.__doc__
+        assert docstring is not None  # noqa: WA003 - guard before behavioral checks
+        assert "context" in docstring.lower()
+        assert "data" in docstring.lower()
+        assert "request_id" in docstring
+
+    def test_docstring_lists_known_context_fields(self):
+        """AC2: Docstring lists all 5 known context fields."""
+        from fapilog import LoggerBuilder
+
+        docstring = LoggerBuilder.with_context.__doc__
+        known_fields = ["request_id", "user_id", "tenant_id", "trace_id", "span_id"]
+        for field in known_fields:
+            assert field in docstring, f"Missing known context field: {field}"
+
+    def test_docstring_includes_example(self):
+        """AC3: Docstring includes an example showing field destinations."""
+        from fapilog import LoggerBuilder
+
+        docstring = LoggerBuilder.with_context.__doc__
+        assert "Example:" in docstring or ">>>" in docstring


### PR DESCRIPTION
## Summary

The `with_context()` builder method routes fields to different sections of the log envelope based on field name, but this behavior was not documented. This PR enhances the docstring to explain:

- **Known context fields** (`request_id`, `user_id`, `tenant_id`, `trace_id`, `span_id`) → `log.context`
- **Custom fields** → `log.data`

## Changes

- `src/fapilog/builder.py` (modified) - Enhanced `with_context()` docstring
- `tests/unit/test_builder_api.py` (modified) - Added docstring validation tests
- `CHANGELOG.md` (modified) - Added Documentation entry

## Acceptance Criteria

- [x] Docstring explains that known fields go to `context` and custom fields go to `data`
- [x] All 5 known context fields are listed: `request_id`, `user_id`, `tenant_id`, `trace_id`, `span_id`
- [x] Example shows where fields end up in the output structure

## Test Plan

- [x] Unit tests validate docstring content against all acceptance criteria
- [x] All 70 builder API tests pass (no regression)
- [x] ruff check passes
- [x] mypy passes

## Story

[10.42 - Document context field routing in with_context() docstring](docs/stories/10.42.with-context-docstring-field-routing.md)