### PR TITLE
feat(core): add reuse parameter to LoggerBuilder

### DIFF
--- a/tests/unit/test_builder_reuse.py
+++ b/tests/unit/test_builder_reuse.py
@@ -1,0 +1,112 @@
+"""Tests for LoggerBuilder.reuse() method (Story 10.41)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from fapilog import AsyncLoggerBuilder, LoggerBuilder
+
+
+class TestReuseMethodReturns:
+    """Test that reuse() returns self for chaining."""
+
+    def test_reuse_method_returns_self(self) -> None:
+        """reuse() should return self for method chaining."""
+        builder = LoggerBuilder()
+        result = builder.reuse(False)
+        assert result is builder
+
+    def test_reuse_method_returns_self_async_builder(self) -> None:
+        """reuse() should return self for AsyncLoggerBuilder too."""
+        builder = AsyncLoggerBuilder()
+        result = builder.reuse(False)
+        assert result is builder
+
+
+class TestReuseInternalState:
+    """Test that reuse() sets internal state correctly."""
+
+    def test_reuse_false_sets_internal_flag(self) -> None:
+        """reuse(False) should set _reuse to False."""
+        builder = LoggerBuilder()
+        builder.reuse(False)
+        assert builder._reuse is False
+
+    def test_reuse_true_sets_internal_flag(self) -> None:
+        """reuse(True) should set _reuse to True."""
+        builder = LoggerBuilder()
+        builder.reuse(False)  # First set to False
+        builder.reuse(True)  # Then back to True
+        assert builder._reuse is True
+
+    def test_default_reuse_is_true(self) -> None:
+        """Default _reuse should be True."""
+        builder = LoggerBuilder()
+        assert builder._reuse is True
+
+
+class TestReuseChaining:
+    """Test that reuse() can be chained anywhere in builder chain."""
+
+    def test_reuse_at_start_of_chain(self) -> None:
+        """reuse() can be called at the start of the chain."""
+        builder = AsyncLoggerBuilder().reuse(False).add_stdout()
+        assert builder._reuse is False
+
+    def test_reuse_at_end_of_chain(self) -> None:
+        """reuse() can be called at the end of the chain."""
+        builder = AsyncLoggerBuilder().add_stdout().reuse(False)
+        assert builder._reuse is False
+
+    def test_reuse_in_middle_of_chain(self) -> None:
+        """reuse() can be called in the middle of the chain."""
+        builder = AsyncLoggerBuilder().reuse(False).with_level("DEBUG").add_stdout()
+        assert builder._reuse is False
+
+
+class TestBuildPassesReuse:
+    """Test that build() passes reuse parameter to get_logger()."""
+
+    def test_build_passes_reuse_false_to_get_logger(self) -> None:
+        """build() should pass reuse=False to get_logger when configured."""
+        with patch("fapilog.get_logger") as mock_get_logger:
+            mock_get_logger.return_value = "fake_logger"
+            LoggerBuilder().add_stdout().reuse(False).build()
+            mock_get_logger.assert_called_once()
+            call_kwargs = mock_get_logger.call_args.kwargs
+            assert call_kwargs["reuse"] is False
+
+    def test_build_passes_reuse_true_by_default(self) -> None:
+        """build() should pass reuse=True by default."""
+        with patch("fapilog.get_logger") as mock_get_logger:
+            mock_get_logger.return_value = "fake_logger"
+            LoggerBuilder().add_stdout().build()
+            mock_get_logger.assert_called_once()
+            call_kwargs = mock_get_logger.call_args.kwargs
+            assert call_kwargs["reuse"] is True
+
+
+class TestBuildAsyncPassesReuse:
+    """Test that build_async() passes reuse parameter to get_async_logger()."""
+
+    @pytest.mark.asyncio
+    async def test_build_async_passes_reuse_false(self) -> None:
+        """build_async() should pass reuse=False to get_async_logger."""
+        with patch("fapilog.get_async_logger", new_callable=AsyncMock) as mock:
+            mock.return_value = "fake_logger"
+            await AsyncLoggerBuilder().add_stdout().reuse(False).build_async()
+            mock.assert_called_once()
+            call_kwargs = mock.call_args.kwargs
+            assert call_kwargs["reuse"] is False
+
+    @pytest.mark.asyncio
+    async def test_build_async_passes_reuse_true_by_default(self) -> None:
+        """build_async() should pass reuse=True by default."""
+        with patch("fapilog.get_async_logger", new_callable=AsyncMock) as mock:
+            mock.return_value = "fake_logger"
+            await AsyncLoggerBuilder().add_stdout().build_async()
+            mock.assert_called_once()
+            call_kwargs = mock.call_args.kwargs
+            assert call_kwargs["reuse"] is True


### PR DESCRIPTION
## Summary

Adds a `reuse(enabled: bool)` method to `LoggerBuilder` that controls whether built loggers are cached. When `reuse(False)` is called, the logger is not added to the cache and can be garbage collected after `stop_and_drain()`.

This enables test isolation without needing to call `clear_logger_cache()` or use context managers.

## Changes

- `src/fapilog/builder.py` (modified)
- `tests/unit/test_builder_reuse.py` (new)

## Acceptance Criteria

- [x] Builder exposes `reuse()` method that returns self for chaining
- [x] `build_async()` passes `reuse` to `get_async_logger()`
- [x] `build()` passes `reuse` to `get_logger()`
- [x] Default behavior unchanged (loggers cached by default)
- [x] Method can be chained anywhere in builder chain

## Test Plan

- [x] Unit tests pass
- [x] Coverage >= 90% on changed lines

## Story

[10.41 - Add reuse parameter to LoggerBuilder](docs/stories/10.41.builder-reuse-parameter.md)