### PR TITLE
fix(ci): make fapilog.dev link clickable in Discord embed

### DIFF
--- a/scripts/format_discord_release.py
+++ b/scripts/format_discord_release.py
@@ -65,10 +65,7 @@ def build_embed(version: str, release_url: str, sections: dict[str, list[str]]) 
         "title": f"\U0001f680 Fapilog v{version} Released",
         "url": release_url,
         "color": EMBED_COLOR,
-        "author": {
-            "name": "fapilog.dev",
-            "url": LANDING_PAGE_URL,
-        },
+        "description": f"[fapilog.dev]({LANDING_PAGE_URL})",
         "fields": [],
     }
 


### PR DESCRIPTION
## Summary

Use markdown link in embed description instead of author field to make fapilog.dev clickable.

## Changes

- `scripts/format_discord_release.py` (modified)