### PR TITLE
fix(docs): use correct logo green and make logo clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 <p align="center">
-  <img src="https://fapilog.dev/fapilog-logo.png" alt="Fapilog Logo" width="200">
+  <a href="https://fapilog.dev">
+    <img src="https://fapilog.dev/fapilog-logo.png" alt="Fapilog Logo" width="200">
+  </a>
 </p>
 
 # Fapilog - Batteries-included, async-first logging for Python services
 
-![Async-first](https://img.shields.io/badge/async-first-84CC16?style=flat-square&logo=python&logoColor=white)
-![JSON Ready](https://img.shields.io/badge/json-ready-84CC16?style=flat-square&logo=json&logoColor=white)
-![Enterprise Ready](https://img.shields.io/badge/enterprise-ready-84CC16?style=flat-square&logo=shield&logoColor=white)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.100+-84CC16?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
-[![Coverage](https://img.shields.io/badge/coverage-90%25-84CC16?style=flat-square)](docs/quality-signals.md)
-![Pydantic v2](https://img.shields.io/badge/Pydantic-v2-84CC16?style=flat-square&logo=pydantic&logoColor=white)
+![Async-first](https://img.shields.io/badge/async-first-9FE17B?style=flat-square&logo=python&logoColor=white)
+![JSON Ready](https://img.shields.io/badge/json-ready-9FE17B?style=flat-square&logo=json&logoColor=white)
+![Enterprise Ready](https://img.shields.io/badge/enterprise-ready-9FE17B?style=flat-square&logo=shield&logoColor=white)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.100+-9FE17B?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
+[![Coverage](https://img.shields.io/badge/coverage-90%25-9FE17B?style=flat-square)](docs/quality-signals.md)
+![Pydantic v2](https://img.shields.io/badge/Pydantic-v2-9FE17B?style=flat-square&logo=pydantic&logoColor=white)
 
-[![Python 3.10+](https://img.shields.io/badge/python-3.10+-84CC16?style=flat-square&logo=python&logoColor=white)](https://pypi.org/project/fapilog/)
-[![PyPI Version](https://img.shields.io/pypi/v/fapilog.svg?style=flat-square&color=84CC16&logo=pypi&logoColor=white)](https://pypi.org/project/fapilog/)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-84CC16?style=flat-square&logo=apache&logoColor=white)](https://opensource.org/licenses/Apache-2.0)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-9FE17B?style=flat-square&logo=python&logoColor=white)](https://pypi.org/project/fapilog/)
+[![PyPI Version](https://img.shields.io/pypi/v/fapilog.svg?style=flat-square&color=9FE17B&logo=pypi&logoColor=white)](https://pypi.org/project/fapilog/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-9FE17B?style=flat-square&logo=apache&logoColor=white)](https://opensource.org/licenses/Apache-2.0)
 
 **fapilog** delivers production-ready logging for the modern Python stack—async-first, structured, and optimized for FastAPI and cloud-native apps. It's equally suitable for **on-prem**, **desktop**, or **embedded** projects where structured, JSON-ready, and pluggable logging is required.
 


### PR DESCRIPTION
## Summary

- Update badge color from #84CC16 to #9FE17B to match the actual fapilog logo green
- Make the logo clickable, linking to https://fapilog.dev

## Changes

- `README.md` (modified)

## Test Plan

- [x] Badge colors match logo branding
- [x] Logo links to fapilog.dev