### PR TITLE
fix(core): enable serialize_in_flush for size_guard processor

### DIFF
--- a/tests/integration/test_size_guard_builder.py
+++ b/tests/integration/test_size_guard_builder.py
@@ -1,0 +1,116 @@
+"""Integration tests for size_guard through builder API (Story 12.26).
+
+These tests verify that `with_size_guard()` actually truncates payloads
+when used via the builder, ensuring the `serialize_in_flush` fix works.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fapilog.builder import AsyncLoggerBuilder
+
+
+@pytest.mark.asyncio
+async def test_size_guard_truncates_via_builder() -> None:
+    """with_size_guard() truncates oversized payloads when building logger."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logger = await (
+            AsyncLoggerBuilder()
+            .with_size_guard(max_bytes="1 KB", action="truncate")
+            .add_file(directory=tmpdir)
+            .reuse(False)
+            .build_async()
+        )
+
+        # Log a large payload that exceeds 1 KB
+        await logger.info("test", data={"huge": "x" * 10000})
+        await logger.drain()
+
+        files = list(Path(tmpdir).glob("*.jsonl"))
+        assert len(files) == 1, "Expected one log file"
+
+        content = files[0].read_text()
+        # Allow overhead for JSON structure + truncation markers
+        assert len(content) <= 1500, f"Content too large: {len(content)} bytes"
+        assert "_truncated" in content, "Expected _truncated marker"
+
+
+@pytest.mark.asyncio
+async def test_size_guard_drop_action_via_builder() -> None:
+    """with_size_guard(action='drop') replaces oversized payloads."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logger = await (
+            AsyncLoggerBuilder()
+            .with_size_guard(max_bytes=500, action="drop")
+            .add_file(directory=tmpdir)
+            .reuse(False)
+            .build_async()
+        )
+
+        await logger.info("test", data={"huge": "x" * 5000})
+        await logger.drain()
+
+        files = list(Path(tmpdir).glob("*.jsonl"))
+        content = files[0].read_text()
+        data = json.loads(content.strip())
+
+        assert data.get("_dropped") is True
+        assert "_original_size" in data
+
+
+@pytest.mark.asyncio
+async def test_size_guard_preserves_fields_via_builder() -> None:
+    """with_size_guard() preserves specified fields during truncation."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logger = await (
+            AsyncLoggerBuilder()
+            .with_size_guard(
+                max_bytes=300,
+                preserve_fields=["level", "timestamp", "custom_id"],
+            )
+            .add_file(directory=tmpdir)
+            .reuse(False)
+            .build_async()
+        )
+
+        await logger.info("test", data={"custom_id": "keep-me", "huge": "x" * 5000})
+        await logger.drain()
+
+        files = list(Path(tmpdir).glob("*.jsonl"))
+        content = files[0].read_text()
+        envelope = json.loads(content.strip())
+
+        # Envelope may be heavily truncated; check markers
+        assert envelope.get("_truncated") is True or envelope.get("_dropped") is True
+
+
+@pytest.mark.asyncio
+async def test_small_payload_passes_through_unchanged() -> None:
+    """Small payloads pass through size_guard unchanged."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        logger = await (
+            AsyncLoggerBuilder()
+            .with_size_guard(max_bytes="10 KB")
+            .add_file(directory=tmpdir)
+            .reuse(False)
+            .build_async()
+        )
+
+        await logger.info("hello", data={"small": "value"})
+        await logger.drain()
+
+        files = list(Path(tmpdir).glob("*.jsonl"))
+        content = files[0].read_text()
+        envelope = json.loads(content.strip())
+
+        # No truncation markers at envelope level
+        assert "_truncated" not in envelope
+        assert "_dropped" not in envelope
+        # Envelope structure preserved with nested log object
+        assert envelope["log"]["message"] == "hello"
+        assert envelope["log"]["data"]["small"] == "value"

--- a/tests/unit/test_builder_processors.py
+++ b/tests/unit/test_builder_processors.py
@@ -96,3 +96,31 @@ class TestWithSizeGuard:
             "correlation_id",
             "request_id",
         ]
+
+    def test_with_size_guard_enables_serialize_in_flush(self) -> None:
+        """with_size_guard() automatically enables serialize_in_flush."""
+        builder = LoggerBuilder()
+        builder.with_size_guard(max_bytes="1 KB")
+
+        core = builder._config.get("core", {})
+        assert core.get("serialize_in_flush") is True
+
+    def test_with_size_guard_respects_explicit_serialize_in_flush_false(self) -> None:
+        """with_size_guard() respects pre-set serialize_in_flush=False."""
+        builder = LoggerBuilder()
+        # User explicitly disables serialize_in_flush first
+        builder._config.setdefault("core", {})["serialize_in_flush"] = False
+        builder.with_size_guard(max_bytes="1 KB")
+
+        # Should stay False - user knows what they're doing
+        assert builder._config["core"]["serialize_in_flush"] is False
+
+    def test_with_size_guard_does_not_override_explicit_true(self) -> None:
+        """with_size_guard() does not change pre-set serialize_in_flush=True."""
+        builder = LoggerBuilder()
+        # User explicitly enables serialize_in_flush first
+        builder._config.setdefault("core", {})["serialize_in_flush"] = True
+        builder.with_size_guard(max_bytes="1 KB")
+
+        # Should remain True
+        assert builder._config["core"]["serialize_in_flush"] is True


### PR DESCRIPTION
## Summary

The `with_size_guard()` builder method configures a size guard processor but doesn't enable `serialize_in_flush`, causing the processor to be loaded but never executed. This fix automatically enables `serialize_in_flush=True` when `with_size_guard()` is called.

## Changes

- `src/fapilog/builder.py` (modified)
- `tests/integration/test_size_guard_builder.py` (new)
- `tests/unit/test_builder_processors.py` (modified)

## Acceptance Criteria

- [x] size_guard truncates payloads via builder
- [x] serialize_in_flush enabled automatically
- [x] Existing explicit serialize_in_flush not overwritten

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Coverage >= 90%