### PR TITLE
fix(core): fix first_occurrence filter parameter name mismatch

### DIFF
--- a/src/fapilog/builder.py
+++ b/src/fapilog/builder.py
@@ -591,19 +591,35 @@ class LoggerBuilder:
         self,
         window_seconds: float = 300.0,
         *,
-        max_entries: int = 10000,
+        max_keys: int | None = None,
+        max_entries: int | None = None,
         key_fields: list[str] | None = None,
     ) -> Self:
         """Configure first-occurrence deduplication filter.
 
         Args:
             window_seconds: Deduplication window (default: 300 = 5 minutes)
-            max_entries: Maximum tracked messages (default: 10000)
+            max_keys: Maximum tracked messages (default: 10000)
+            max_entries: Deprecated alias for max_keys
             key_fields: Fields to use as dedup key (default: message only)
 
         Example:
             >>> builder.with_first_occurrence(window_seconds=60)
         """
+        import warnings
+
+        if max_entries is not None:
+            warnings.warn(
+                "max_entries is deprecated, use max_keys instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if max_keys is None:
+                max_keys = max_entries
+
+        if max_keys is None:
+            max_keys = 10000
+
         filters = self._config.setdefault("core", {}).setdefault("filters", [])
         if "first_occurrence" not in filters:
             filters.append("first_occurrence")
@@ -611,7 +627,7 @@ class LoggerBuilder:
         filter_config = self._config.setdefault("filter_config", {})
         first_occurrence_config: dict[str, Any] = {
             "window_seconds": window_seconds,
-            "max_entries": max_entries,
+            "max_keys": max_keys,
         }
         if key_fields is not None:
             first_occurrence_config["key_fields"] = key_fields

--- a/tests/integration/test_first_occurrence_builder.py
+++ b/tests/integration/test_first_occurrence_builder.py
@@ -1,0 +1,100 @@
+"""Integration tests for first_occurrence filter via builder (Story 12.27).
+
+These tests verify that the first_occurrence filter actually deduplicates
+messages when configured through the builder API.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fapilog import _build_pipeline
+from fapilog.builder import AsyncLoggerBuilder
+from fapilog.core.settings import Settings
+
+pytestmark = pytest.mark.integration
+
+
+class TestFirstOccurrenceDeduplication:
+    """Tests for AC1: first_occurrence deduplicates via builder."""
+
+    @pytest.mark.asyncio
+    async def test_first_occurrence_deduplicates_via_builder(self) -> None:
+        """Duplicate messages are filtered when using with_first_occurrence()."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = await (
+                AsyncLoggerBuilder()
+                .with_first_occurrence(window_seconds=60.0, max_keys=1000)
+                .add_file(directory=tmpdir)
+                .reuse(False)
+                .build_async()
+            )
+
+            for _ in range(10):
+                await logger.info("Duplicate message")
+            await logger.drain()
+
+            files = list(Path(tmpdir).glob("*.jsonl"))
+            assert len(files) == 1
+            content = files[0].read_text()
+            lines = [line for line in content.strip().split("\n") if line]
+            duplicate_count = sum(1 for line in lines if "Duplicate message" in line)
+            assert duplicate_count == 1
+
+    @pytest.mark.asyncio
+    async def test_first_occurrence_unique_messages_pass(self) -> None:
+        """Unique messages all pass through the filter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = await (
+                AsyncLoggerBuilder()
+                .with_first_occurrence(window_seconds=60.0, max_keys=1000)
+                .add_file(directory=tmpdir)
+                .reuse(False)
+                .build_async()
+            )
+
+            for i in range(5):
+                await logger.info(f"Unique message {i}")
+            await logger.drain()
+
+            files = list(Path(tmpdir).glob("*.jsonl"))
+            content = files[0].read_text()
+            lines = [line for line in content.strip().split("\n") if line]
+            assert len(lines) == 5
+
+
+class TestFirstOccurrenceFilterLoads:
+    """Tests for AC4: filter actually loads in the pipeline."""
+
+    def test_first_occurrence_filter_loads_with_max_keys(self) -> None:
+        """Filter loads when config uses max_keys."""
+        settings = Settings(
+            core={"filters": ["first_occurrence"]},
+            filter_config={
+                "first_occurrence": {"window_seconds": 60.0, "max_keys": 1000}
+            },
+        )
+
+        _, _, _, _, filters, _ = _build_pipeline(settings)
+
+        assert len(filters) == 1
+        assert filters[0].__class__.__name__ == "FirstOccurrenceFilter"
+
+    def test_first_occurrence_filter_loads_via_builder_config(self) -> None:
+        """Filter loads when configured via builder."""
+        builder = AsyncLoggerBuilder().with_first_occurrence(
+            window_seconds=60.0, max_keys=1000
+        )
+
+        settings = Settings(
+            core=builder._config.get("core"),
+            filter_config=builder._config.get("filter_config"),
+        )
+
+        _, _, _, _, filters, _ = _build_pipeline(settings)
+
+        assert len(filters) == 1
+        assert filters[0].__class__.__name__ == "FirstOccurrenceFilter"


### PR DESCRIPTION
## Summary

Fix parameter name mismatch in `with_first_occurrence()` builder method where it used `max_entries` but the plugin config expected `max_keys`, causing silent filter loading failure.

## Changes

- `src/fapilog/builder.py` (modified)
- `tests/integration/test_first_occurrence_builder.py` (new)
- `tests/unit/test_builder_filters.py` (modified)

## Acceptance Criteria

- [x] first_occurrence deduplicates via builder
- [x] Correct config key (`max_keys`) generated
- [x] Backward compatibility with `max_entries` (deprecation warning)
- [x] Filter actually loads in pipeline

## Test Plan

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Coverage >= 90% on changed lines

## Story

[12.27 - Fix first_occurrence Filter Parameter Name Mismatch](docs/stories/12.27.fix-first-occurrence-param-name.md)