### PR TITLE
fix(core): add contract tests and parity check for filter/processor configs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,3 +149,12 @@ repos:
         files: ^(src/fapilog/redaction/presets\.py|docs/redaction/presets\.md)$
         stages: [pre-commit]
         description: "Ensure redaction preset docs match source definitions"
+
+      - id: check-filter-config-parity
+        name: Check Filter Config Parity
+        entry: python scripts/check_filter_config_parity.py
+        language: system
+        pass_filenames: false
+        files: ^src/fapilog/(builder\.py|plugins/(filters|processors)/)
+        stages: [pre-commit]
+        description: "Ensure builder filter/processor config keys match plugin config fields"

--- a/scripts/builder_param_mappings.py
+++ b/scripts/builder_param_mappings.py
@@ -156,6 +156,42 @@ FILTER_COVERAGE: dict[str, str] = {
 }
 
 
+# === FILTER PARAMETER MAPPINGS ===
+# Maps builder param name -> plugin config field name
+# Story 12.28: Added to document param-to-field translations
+
+FILTER_PARAM_MAPPINGS: dict[str, dict[str, str]] = {
+    "with_sampling": {
+        "rate": "sample_rate",
+        "seed": "seed",
+    },
+    "with_adaptive_sampling": {
+        # Builder uses human-friendly names, plugin uses abbreviated field names
+        "min_rate": "min_sample_rate",
+        "max_rate": "max_sample_rate",
+        "target_events_per_sec": "target_eps",
+        "window_seconds": "window_seconds",
+    },
+    "with_trace_sampling": {
+        # Builder param 'default_rate' maps to plugin field 'sample_rate'
+        "default_rate": "sample_rate",
+        # Note: honor_upstream was removed (not in TraceSamplingConfig)
+    },
+    "with_rate_limit": {
+        "capacity": "capacity",
+        "refill_rate": "refill_rate_per_sec",
+        "key_field": "key_field",
+        "max_keys": "max_keys",
+        "overflow_action": "overflow_action",
+    },
+    "with_first_occurrence": {
+        "window_seconds": "window_seconds",
+        "max_keys": "max_keys",
+        "key_fields": "key_fields",
+    },
+}
+
+
 # === PROCESSOR COVERAGE ===
 # Maps processor -> param:field mappings
 

--- a/scripts/check_filter_config_parity.py
+++ b/scripts/check_filter_config_parity.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+"""Validate builder filter/processor config keys match plugin config fields.
+
+This script ensures that builder methods generate config dictionaries
+with keys that are accepted by the corresponding plugin config classes
+(which reject unknown fields via Pydantic model_config).
+
+Story 12.28: Add Contract Tests and Parity Check for Filter/Processor Configs
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# Map filter/processor name -> (builder method name, plugin config class path)
+FILTER_MAPPINGS: dict[str, tuple[str, str]] = {
+    "sampling": (
+        "with_sampling",
+        "fapilog.plugins.filters.sampling:SamplingFilterConfig",
+    ),
+    "adaptive_sampling": (
+        "with_adaptive_sampling",
+        "fapilog.plugins.filters.adaptive_sampling:AdaptiveSamplingConfig",
+    ),
+    "trace_sampling": (
+        "with_trace_sampling",
+        "fapilog.plugins.filters.trace_sampling:TraceSamplingConfig",
+    ),
+    "rate_limit": (
+        "with_rate_limit",
+        "fapilog.plugins.filters.rate_limit:RateLimitFilterConfig",
+    ),
+    "first_occurrence": (
+        "with_first_occurrence",
+        "fapilog.plugins.filters.first_occurrence:FirstOccurrenceConfig",
+    ),
+}
+
+PROCESSOR_MAPPINGS: dict[str, tuple[str, str]] = {
+    "size_guard": (
+        "with_size_guard",
+        "fapilog.plugins.processors.size_guard:SizeGuardConfig",
+    ),
+}
+
+
+def get_builder_ast() -> ast.Module:
+    """Parse builder.py AST."""
+    builder_path = Path(__file__).parent.parent / "src" / "fapilog" / "builder.py"
+    return ast.parse(builder_path.read_text())
+
+
+def extract_builder_config_keys(tree: ast.Module, method_name: str) -> set[str]:
+    """Extract config keys set by a builder method from AST.
+
+    Looks for patterns like:
+        filter_config["filter_name"] = {"key1": ..., "key2": ...}
+    or
+        some_config: dict = {"key1": ..., "key2": ...}
+        filter_config["filter_name"] = some_config
+    """
+    keys: set[str] = set()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if node.name != method_name:
+            continue
+
+        # Walk the function body looking for dict assignments
+        for stmt in ast.walk(node):
+            # Look for direct dict literal assignments to filter_config/processor_config
+            if isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    # filter_config["name"] = {...}
+                    if isinstance(target, ast.Subscript) and isinstance(
+                        stmt.value, ast.Dict
+                    ):
+                        for key in stmt.value.keys:
+                            if isinstance(key, ast.Constant) and isinstance(
+                                key.value, str
+                            ):
+                                keys.add(key.value)
+
+    return keys
+
+
+def extract_plugin_config_fields(config_class_path: str) -> set[str]:
+    """Import config class and get field names."""
+    module_path, class_name = config_class_path.rsplit(":", 1)
+
+    import importlib
+
+    module = importlib.import_module(module_path)
+    config_class = getattr(module, class_name)
+
+    # Get fields from Pydantic model or dataclass
+    fields: set[str] = set()
+
+    if hasattr(config_class, "model_fields"):
+        # Pydantic v2
+        fields = set(config_class.model_fields.keys())
+    elif hasattr(config_class, "__dataclass_fields__"):
+        # dataclass
+        fields = set(config_class.__dataclass_fields__.keys())
+    elif hasattr(config_class, "__fields__"):
+        # Pydantic v1
+        fields = set(config_class.__fields__.keys())
+
+    return fields
+
+
+def check_parity(
+    name: str,
+    method_name: str,
+    config_path: str,
+    tree: ast.Module,
+) -> list[str]:
+    """Check parity between builder and plugin config."""
+    errors: list[str] = []
+
+    builder_keys = extract_builder_config_keys(tree, method_name)
+    plugin_fields = extract_plugin_config_fields(config_path)
+
+    if not builder_keys:
+        # Can't extract keys from AST - fall back to runtime check
+        return []
+
+    # Keys in builder but not in plugin (will cause validation error)
+    extra_keys = builder_keys - plugin_fields
+    if extra_keys:
+        errors.append(f"{method_name}(): unknown keys {sorted(extra_keys)}")
+
+    return errors
+
+
+def run_runtime_checks() -> list[str]:
+    """Run runtime checks by actually calling builder methods.
+
+    This catches cases that AST analysis might miss.
+    """
+    from fapilog import Settings, _build_pipeline_impl, _load_plugins
+    from fapilog.builder import LoggerBuilder
+
+    errors: list[str] = []
+
+    # Test each filter builder method
+    filter_tests = [
+        ("with_sampling", lambda b: b.with_sampling(rate=0.5)),
+        (
+            "with_adaptive_sampling",
+            lambda b: b.with_adaptive_sampling(
+                min_rate=0.01, max_rate=1.0, target_events_per_sec=500
+            ),
+        ),
+        ("with_trace_sampling", lambda b: b.with_trace_sampling(default_rate=0.5)),
+        ("with_rate_limit", lambda b: b.with_rate_limit(capacity=100)),
+        ("with_first_occurrence", lambda b: b.with_first_occurrence(window_seconds=60)),
+    ]
+
+    for method_name, builder_call in filter_tests:
+        try:
+            builder = builder_call(LoggerBuilder())
+            settings = Settings(
+                core=builder._config.get("core"),
+                filter_config=builder._config.get("filter_config"),
+            )
+            _, _, _, _, filters, _ = _build_pipeline_impl(settings, _load_plugins)
+            if not filters:
+                errors.append(f"{method_name}(): filter did not load (config rejected)")
+        except Exception as e:
+            errors.append(f"{method_name}(): {e}")
+
+    # Test size_guard processor
+    try:
+        builder = LoggerBuilder().with_size_guard(max_bytes="1 MB")
+        settings = Settings(
+            core=builder._config.get("core"),
+            processor_config=builder._config.get("processor_config"),
+        )
+        _, _, _, processors, _, _ = _build_pipeline_impl(settings, _load_plugins)
+        if not processors:
+            errors.append("with_size_guard(): processor did not load (config rejected)")
+    except Exception as e:
+        errors.append(f"with_size_guard(): {e}")
+
+    return errors
+
+
+def main() -> int:
+    """Run parity checks."""
+    all_errors: list[str] = []
+
+    # Parse builder AST once
+    tree = get_builder_ast()
+
+    # Check filters
+    for name, (method, config_path) in FILTER_MAPPINGS.items():
+        errors = check_parity(name, method, config_path, tree)
+        all_errors.extend(errors)
+
+    # Check processors
+    for name, (method, config_path) in PROCESSOR_MAPPINGS.items():
+        errors = check_parity(name, method, config_path, tree)
+        all_errors.extend(errors)
+
+    # Run runtime checks (most reliable)
+    runtime_errors = run_runtime_checks()
+    all_errors.extend(runtime_errors)
+
+    if all_errors:
+        print("Filter/processor config parity check FAILED:")
+        for error in all_errors:
+            print(f"  - {error}")
+        return 1
+
+    print("Filter/processor config parity check passed ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/fapilog/builder.py
+++ b/src/fapilog/builder.py
@@ -513,10 +513,11 @@ class LoggerBuilder:
             filters.append("adaptive_sampling")
 
         filter_config = self._config.setdefault("filter_config", {})
+        # Config keys must match AdaptiveSamplingConfig field names
         filter_config["adaptive_sampling"] = {
-            "min_rate": min_rate,
-            "max_rate": max_rate,
-            "target_events_per_sec": target_events_per_sec,
+            "min_sample_rate": min_rate,
+            "max_sample_rate": max_rate,
+            "target_eps": target_events_per_sec,
             "window_seconds": window_seconds,
         }
 
@@ -525,14 +526,11 @@ class LoggerBuilder:
     def with_trace_sampling(
         self,
         default_rate: float = 1.0,
-        *,
-        honor_upstream: bool = True,
     ) -> Self:
         """Configure distributed trace-aware sampling.
 
         Args:
             default_rate: Default sample rate when no trace context (default: 1.0)
-            honor_upstream: Honor upstream sampling decisions (default: True)
 
         Example:
             >>> builder.with_trace_sampling(default_rate=0.1)
@@ -542,9 +540,9 @@ class LoggerBuilder:
             filters.append("trace_sampling")
 
         filter_config = self._config.setdefault("filter_config", {})
+        # Config key must match TraceSamplingConfig field name
         filter_config["trace_sampling"] = {
-            "default_rate": default_rate,
-            "honor_upstream": honor_upstream,
+            "sample_rate": default_rate,
         }
 
         return self

--- a/tests/integration/test_filter_contract.py
+++ b/tests/integration/test_filter_contract.py
@@ -1,0 +1,187 @@
+"""Contract tests for filter/processor builder methods (Story 12.28).
+
+These tests verify that builder methods generate config that is accepted
+by the plugin config classes (which reject unknown fields).
+"""
+
+import tempfile
+
+import pytest
+
+from fapilog import Settings, _build_pipeline_impl, _load_plugins
+from fapilog.builder import AsyncLoggerBuilder, LoggerBuilder
+
+
+class TestFilterContractTests:
+    """Contract tests verifying builder output matches plugin config expectations."""
+
+    @pytest.mark.parametrize(
+        "filter_name,builder_call",
+        [
+            ("sampling", lambda b: b.with_sampling(rate=0.5)),
+            (
+                "adaptive_sampling",
+                lambda b: b.with_adaptive_sampling(
+                    min_rate=0.01, max_rate=1.0, target_events_per_sec=500
+                ),
+            ),
+            ("trace_sampling", lambda b: b.with_trace_sampling(default_rate=0.5)),
+            ("rate_limit", lambda b: b.with_rate_limit(capacity=100)),
+            ("first_occurrence", lambda b: b.with_first_occurrence(window_seconds=60)),
+        ],
+    )
+    def test_filter_loads_via_builder(
+        self, filter_name: str, builder_call: callable
+    ) -> None:
+        """Builder-generated config loads successfully via _build_pipeline."""
+        builder = builder_call(LoggerBuilder())
+
+        settings = Settings(
+            core=builder._config.get("core"),
+            filter_config=builder._config.get("filter_config"),
+        )
+
+        _, _, _, _, filters, _ = _build_pipeline_impl(settings, _load_plugins)
+
+        assert len(filters) == 1
+        assert filters[0].name == filter_name
+
+
+class TestProcessorContractTests:
+    """Contract tests for processor builder methods."""
+
+    def test_size_guard_loads_via_builder(self) -> None:
+        """with_size_guard() config loads successfully in pipeline."""
+        builder = LoggerBuilder().with_size_guard(max_bytes="1 MB")
+
+        settings = Settings(
+            core=builder._config.get("core"),
+            processor_config=builder._config.get("processor_config"),
+        )
+
+        _, _, _, processors, _, _ = _build_pipeline_impl(settings, _load_plugins)
+
+        assert len(processors) == 1
+        assert processors[0].name == "size_guard"
+
+
+class TestAdaptiveSamplingConfigContract:
+    """Contract tests for adaptive_sampling config keys matching plugin."""
+
+    def test_adaptive_sampling_config_keys_match_plugin(self) -> None:
+        """with_adaptive_sampling() generates config matching AdaptiveSamplingConfig."""
+        builder = LoggerBuilder().with_adaptive_sampling(
+            min_rate=0.01, max_rate=1.0, target_events_per_sec=500, window_seconds=30
+        )
+        config = builder._config["filter_config"]["adaptive_sampling"]
+
+        # These must match AdaptiveSamplingConfig field names
+        assert "min_sample_rate" in config
+        assert "max_sample_rate" in config
+        assert "target_eps" in config
+        assert "window_seconds" in config
+
+        # Old keys must NOT be present
+        assert "min_rate" not in config
+        assert "max_rate" not in config
+        assert "target_events_per_sec" not in config
+
+
+class TestTraceSamplingConfigContract:
+    """Contract tests for trace_sampling config keys matching plugin."""
+
+    def test_trace_sampling_config_keys_match_plugin(self) -> None:
+        """with_trace_sampling() generates config matching TraceSamplingConfig."""
+        builder = LoggerBuilder().with_trace_sampling(default_rate=0.1)
+        config = builder._config["filter_config"]["trace_sampling"]
+
+        # Must match TraceSamplingConfig field names
+        assert "sample_rate" in config
+
+        # Old/invalid keys must NOT be present
+        assert "default_rate" not in config
+        assert "honor_upstream" not in config
+
+
+class TestAllFiltersSmoke:
+    """Smoke test that exercises all filter methods together."""
+
+    @pytest.mark.asyncio
+    async def test_all_filters_load_when_chained(self) -> None:
+        """All filter methods can be chained and all filters load successfully."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger = await (
+                AsyncLoggerBuilder()
+                .with_sampling(rate=0.9)
+                .with_adaptive_sampling(target_events_per_sec=1000)
+                .with_trace_sampling(default_rate=0.5)
+                .with_rate_limit(capacity=100)
+                .with_first_occurrence(window_seconds=60)
+                .with_size_guard(max_bytes="1 MB")
+                .add_file(directory=tmpdir)
+                .reuse(False)
+                .build_async()
+            )
+
+            # Verify logger works - log a message and drain
+            await logger.info("test message for smoke test")
+            await logger.drain()
+
+            # Verify logger has the expected callable interface
+            assert callable(logger.info)
+            assert callable(logger.debug)
+            assert callable(logger.warning)
+            assert callable(logger.error)
+
+    def test_all_filters_config_generated_correctly(self) -> None:
+        """All filter builder methods generate valid config dictionaries."""
+        builder = (
+            LoggerBuilder()
+            .with_sampling(rate=0.9)
+            .with_adaptive_sampling(
+                min_rate=0.01, max_rate=1.0, target_events_per_sec=1000
+            )
+            .with_trace_sampling(default_rate=0.5)
+            .with_rate_limit(capacity=100, refill_rate=10.0)
+            .with_first_occurrence(window_seconds=60, max_keys=5000)
+            .with_size_guard(max_bytes="1 MB", action="truncate")
+        )
+
+        # Verify all filters are registered
+        filters = builder._config["core"]["filters"]
+        assert "sampling" in filters
+        assert "adaptive_sampling" in filters
+        assert "trace_sampling" in filters
+        assert "rate_limit" in filters
+        assert "first_occurrence" in filters
+
+        # Verify processor is registered
+        processors = builder._config["core"]["processors"]
+        assert "size_guard" in processors
+
+        # Verify all filter configs use correct keys
+        filter_config = builder._config["filter_config"]
+
+        # sampling
+        assert filter_config["sampling"]["sample_rate"] == 0.9
+
+        # adaptive_sampling - uses plugin field names
+        assert filter_config["adaptive_sampling"]["min_sample_rate"] == 0.01
+        assert filter_config["adaptive_sampling"]["max_sample_rate"] == 1.0
+        assert filter_config["adaptive_sampling"]["target_eps"] == 1000
+
+        # trace_sampling - uses plugin field name
+        assert filter_config["trace_sampling"]["sample_rate"] == 0.5
+
+        # rate_limit
+        assert filter_config["rate_limit"]["capacity"] == 100
+        assert filter_config["rate_limit"]["refill_rate_per_sec"] == 10.0
+
+        # first_occurrence
+        assert filter_config["first_occurrence"]["window_seconds"] == 60
+        assert filter_config["first_occurrence"]["max_keys"] == 5000
+
+        # Verify processor config
+        processor_config = builder._config["processor_config"]
+        assert processor_config["size_guard"]["max_bytes"] == "1 MB"
+        assert processor_config["size_guard"]["action"] == "truncate"

--- a/tests/unit/test_builder_filters.py
+++ b/tests/unit/test_builder_filters.py
@@ -84,9 +84,10 @@ class TestWithAdaptiveSampling:
         filter_config = builder._config["filter_config"]["adaptive_sampling"]
 
         assert "adaptive_sampling" in filters
-        assert filter_config["min_rate"] == 0.01
-        assert filter_config["max_rate"] == 1.0
-        assert filter_config["target_events_per_sec"] == 1000.0
+        # Config keys must match AdaptiveSamplingConfig field names
+        assert filter_config["min_sample_rate"] == 0.01
+        assert filter_config["max_sample_rate"] == 1.0
+        assert filter_config["target_eps"] == 1000.0
         assert filter_config["window_seconds"] == 60.0
 
     def test_with_adaptive_sampling_returns_self(self) -> None:
@@ -102,9 +103,10 @@ class TestWithAdaptiveSampling:
 
         filter_config = builder._config["filter_config"]["adaptive_sampling"]
 
-        assert filter_config["min_rate"] == 0.01
-        assert filter_config["max_rate"] == 1.0
-        assert filter_config["target_events_per_sec"] == 1000.0
+        # Config keys must match AdaptiveSamplingConfig field names
+        assert filter_config["min_sample_rate"] == 0.01
+        assert filter_config["max_sample_rate"] == 1.0
+        assert filter_config["target_eps"] == 1000.0
         assert filter_config["window_seconds"] == 60.0
 
     def test_with_adaptive_sampling_does_not_duplicate_filter(self) -> None:
@@ -115,11 +117,9 @@ class TestWithAdaptiveSampling:
 
         filters = builder._config["core"]["filters"]
         assert filters.count("adaptive_sampling") == 1
+        # Config key must match AdaptiveSamplingConfig field name
         assert (
-            builder._config["filter_config"]["adaptive_sampling"][
-                "target_events_per_sec"
-            ]
-            == 1000
+            builder._config["filter_config"]["adaptive_sampling"]["target_eps"] == 1000
         )
 
     def test_with_adaptive_sampling_creates_valid_logger(self) -> None:
@@ -141,14 +141,16 @@ class TestWithTraceSampling:
     def test_with_trace_sampling_adds_filter_and_config(self) -> None:
         """with_trace_sampling() adds filter and sets config fields."""
         builder = LoggerBuilder()
-        builder.with_trace_sampling(default_rate=0.1, honor_upstream=False)
+        builder.with_trace_sampling(default_rate=0.1)
 
         filters = builder._config["core"]["filters"]
         filter_config = builder._config["filter_config"]["trace_sampling"]
 
         assert "trace_sampling" in filters
-        assert filter_config["default_rate"] == 0.1
-        assert filter_config["honor_upstream"] is False
+        # Config key must match TraceSamplingConfig field name
+        assert filter_config["sample_rate"] == 0.1
+        # honor_upstream not in TraceSamplingConfig - should not be in config
+        assert "honor_upstream" not in filter_config
 
     def test_with_trace_sampling_returns_self(self) -> None:
         """with_trace_sampling() returns self for chaining."""
@@ -163,8 +165,10 @@ class TestWithTraceSampling:
 
         filter_config = builder._config["filter_config"]["trace_sampling"]
 
-        assert filter_config["default_rate"] == 1.0
-        assert filter_config["honor_upstream"] is True
+        # Config key must match TraceSamplingConfig field name
+        assert filter_config["sample_rate"] == 1.0
+        # honor_upstream not in TraceSamplingConfig
+        assert "honor_upstream" not in filter_config
 
     def test_with_trace_sampling_does_not_duplicate_filter(self) -> None:
         """Calling with_trace_sampling() twice doesn't duplicate filter."""
@@ -174,7 +178,8 @@ class TestWithTraceSampling:
 
         filters = builder._config["core"]["filters"]
         assert filters.count("trace_sampling") == 1
-        assert builder._config["filter_config"]["trace_sampling"]["default_rate"] == 0.3
+        # Config key must match TraceSamplingConfig field name
+        assert builder._config["filter_config"]["trace_sampling"]["sample_rate"] == 0.3
 
     def test_with_trace_sampling_creates_valid_logger(self) -> None:
         """with_trace_sampling() produces valid logger configuration."""


### PR DESCRIPTION
## Summary

Fix config key mismatches in filter builder methods that caused filters to silently fail to load. Add contract tests and a pre-commit parity check to prevent future regressions.

The builder methods `with_adaptive_sampling()` and `with_trace_sampling()` were generating config dictionaries with keys that didn't match the plugin config field names. Since plugin configs use `extra="forbid"`, the filters would fail validation and silently not load.

## Changes

- `src/fapilog/builder.py` (modified) - Fix config keys in `with_adaptive_sampling()` and `with_trace_sampling()`
- `tests/integration/test_filter_contract.py` (new) - Contract tests verifying builder configs load via pipeline
- `scripts/check_filter_config_parity.py` (new) - Pre-commit parity check script
- `scripts/builder_param_mappings.py` (modified) - Add FILTER_PARAM_MAPPINGS documentation
- `.pre-commit-config.yaml` (modified) - Add check-filter-config-parity hook
- `tests/unit/test_builder_filters.py` (modified) - Update assertions for correct config keys

## Acceptance Criteria

- [x] `with_adaptive_sampling()` generates config matching `AdaptiveSamplingConfig`
- [x] `with_trace_sampling()` generates config matching `TraceSamplingConfig`
- [x] Contract tests for all 5 filter builder methods
- [x] Contract test for `with_size_guard()` processor
- [x] Parity check script validates builder config keys match plugin config fields
- [x] Pre-commit hook runs parity check on relevant file changes
- [x] Smoke test chains all filter methods and verifies all load

## Test Plan

- [x] Unit tests pass (`pytest tests/unit/test_builder_filters.py`)
- [x] Contract tests pass (`pytest tests/integration/test_filter_contract.py`)
- [x] Parity check passes (`python scripts/check_filter_config_parity.py`)
- [x] Pre-commit hooks pass

## Story

[12.28 - Add Contract Tests and Parity Check for Filter/Processor Configs](docs/stories/12.28.filter-config-contract-tests.md)