### PR TITLE
fix(tests): use CI timeout multiplier for backpressure timing test

### DIFF
--- a/tests/benchmark/test_perf_benchmarks.py
+++ b/tests/benchmark/test_perf_benchmarks.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+from conftest import get_test_timeout
 from fapilog.core.concurrency import NonBlockingRingQueue
 from fapilog.core.serialization import (
     convert_json_bytes_to_jsonl,
@@ -213,8 +214,10 @@ async def test_backpressure_event_signaling_low_cpu() -> None:
     assert completed == 0, "No enqueue should have succeeded"
 
     # Elapsed time should be reasonable (not spinning)
-    # Allow some overhead but should complete within 2x the wait duration
-    assert elapsed < wait_duration * 3, (
-        f"Elapsed {elapsed:.3f}s >> expected ~{wait_duration}s. "
+    # Allow some overhead but should complete within 3x the wait duration
+    # Use get_test_timeout() to scale for CI environments
+    max_elapsed = get_test_timeout(wait_duration * 3)
+    assert elapsed < max_elapsed, (
+        f"Elapsed {elapsed:.3f}s >> expected <{max_elapsed:.3f}s. "
         "Event signaling may not be working correctly."
     )


### PR DESCRIPTION
## Summary

Fix flaky test that was failing in CI due to tight timing tolerance.

## Changes

- `tests/benchmark/test_perf_benchmarks.py` (modified)

## Problem

`test_backpressure_event_signaling_low_cpu` was failing with:
```
AssertionError: Elapsed 0.303s >> expected ~0.1s
assert 0.303 < (0.1 * 3)  # 0.3s threshold
```

The test was only 1% over the threshold - normal CI timing variance.

## Fix

Apply `get_test_timeout()` to scale the timing threshold for CI environments, matching the pattern used by other timing-sensitive tests.

## Test Plan

- [x] Test passes locally (ran 3x)
- [x] Linting passes