### PR TITLE
feat(core): add critical() log level method

### DIFF
--- a/docs/api-reference/logger-methods.md
+++ b/docs/api-reference/logger-methods.md
@@ -73,6 +73,22 @@ except Exception:
     logger.error("Work failed", exc_info=True)
 ```
 
+## critical {#critical}
+
+```python
+logger.critical(message: str, *, exc: BaseException | None = None, exc_info: Any | None = None, **metadata) -> None
+await async_logger.critical(message: str, *, exc: BaseException | None = None, exc_info: Any | None = None, **metadata) -> None
+```
+
+Log critical errors. CRITICAL indicates a severe error that may cause the application to abort. Use for unrecoverable failures requiring immediate attention.
+
+### Example
+
+```python
+logger.critical("Database connection lost", db_host="prod-db", retry_count=3)
+await async_logger.critical("System failure", component="auth", error_code="AUTH_001")
+```
+
 ## exception {#exception}
 
 ```python

--- a/src/fapilog/core/logger.py
+++ b/src/fapilog/core/logger.py
@@ -1238,6 +1238,30 @@ class SyncLoggerFacade(_LoggerMixin):
         """
         self._enqueue("ERROR", message, exc_info=True, **metadata)
 
+    def critical(
+        self,
+        message: str,
+        *,
+        exc: BaseException | None = None,
+        exc_info: Any | None = None,
+        **metadata: Any,
+    ) -> None:
+        """Log a message at CRITICAL level.
+
+        CRITICAL indicates a severe error that may cause the application to
+        abort. Use for unrecoverable failures requiring immediate attention.
+
+        Args:
+            message: The log message.
+            exc: Exception instance to include in the log event.
+            exc_info: Exception info tuple or True to capture current exception.
+            **metadata: Additional fields to include in the log event.
+
+        Example:
+            logger.critical("Database connection lost", db_host="prod-db")
+        """
+        self._enqueue("CRITICAL", message, exc=exc, exc_info=exc_info, **metadata)
+
     # Context binding API
     def bind(self, **context: Any) -> SyncLoggerFacade:
         """Return a child logger with additional bound context for
@@ -1486,6 +1510,30 @@ class AsyncLoggerFacade(_LoggerMixin):
         Equivalent to error(message, exc_info=True, **metadata) inside except.
         """
         await self._enqueue("ERROR", message, exc_info=True, **metadata)
+
+    async def critical(
+        self,
+        message: str,
+        *,
+        exc: BaseException | None = None,
+        exc_info: Any | None = None,
+        **metadata: Any,
+    ) -> None:
+        """Log a message at CRITICAL level.
+
+        CRITICAL indicates a severe error that may cause the application to
+        abort. Use for unrecoverable failures requiring immediate attention.
+
+        Args:
+            message: The log message.
+            exc: Exception instance to include in the log event.
+            exc_info: Exception info tuple or True to capture current exception.
+            **metadata: Additional fields to include in the log event.
+
+        Example:
+            await logger.critical("Database connection lost", db_host="prod-db")
+        """
+        await self._enqueue("CRITICAL", message, exc=exc, exc_info=exc_info, **metadata)
 
     # Context binding API
     def bind(self, **context: Any) -> AsyncLoggerFacade:

--- a/src/fapilog/core/stdlib_bridge.py
+++ b/src/fapilog/core/stdlib_bridge.py
@@ -203,10 +203,10 @@ class StdlibBridgeHandler(logging.Handler):
             # Level mapping
             lvl = record.levelno
             method = self._fl.debug
-            if lvl >= logging.ERROR:
+            if lvl >= logging.CRITICAL:
+                method = self._fl.critical
+            elif lvl >= logging.ERROR:
                 method = self._fl.error
-                if lvl >= logging.CRITICAL:
-                    extras.setdefault("critical", True)
             elif lvl >= logging.WARNING:
                 method = self._fl.warning
             elif lvl >= logging.INFO:

--- a/tests/unit/test_logger_critical.py
+++ b/tests/unit/test_logger_critical.py
@@ -1,0 +1,237 @@
+"""
+Test critical() log level method for both SyncLoggerFacade and AsyncLoggerFacade.
+
+Scope:
+- critical() method exists on both facades
+- critical() logs with level="CRITICAL" in envelope
+- Signature matches error() method
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from fapilog.core.logger import AsyncLoggerFacade, SyncLoggerFacade
+
+
+async def _collecting_sink(
+    collected: list[dict[str, Any]], entry: dict[str, Any]
+) -> None:
+    collected.append(dict(entry))
+
+
+class TestSyncLoggerCritical:
+    """Tests for SyncLoggerFacade.critical() method."""
+
+    @pytest.mark.asyncio
+    async def test_sync_logger_has_critical_method(self) -> None:
+        """AC1: SyncLoggerFacade exposes a critical() method."""
+        collected: list[dict[str, Any]] = []
+        logger = SyncLoggerFacade(
+            name="test",
+            queue_capacity=16,
+            batch_max_size=8,
+            batch_timeout_seconds=0.05,
+            backpressure_wait_ms=10,
+            drop_on_full=True,
+            sink_write=lambda e: _collecting_sink(collected, e),
+        )
+        logger.start()
+
+        # Should not raise AttributeError
+        logger.critical("System failure imminent")
+
+        await asyncio.sleep(0.1)
+        res = await logger.stop_and_drain()
+        assert res.submitted == 1
+        assert res.processed == 1
+
+    @pytest.mark.asyncio
+    async def test_sync_critical_logs_include_correct_level(self) -> None:
+        """AC3: CRITICAL logs include level='CRITICAL' in envelope."""
+        collected: list[dict[str, Any]] = []
+        logger = SyncLoggerFacade(
+            name="test",
+            queue_capacity=16,
+            batch_max_size=8,
+            batch_timeout_seconds=0.05,
+            backpressure_wait_ms=10,
+            drop_on_full=True,
+            sink_write=lambda e: _collecting_sink(collected, e),
+        )
+        logger.start()
+
+        logger.critical("Test critical message")
+
+        await asyncio.sleep(0.1)
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        assert collected[0]["level"] == "CRITICAL"
+        assert collected[0]["message"] == "Test critical message"
+
+    @pytest.mark.asyncio
+    async def test_sync_critical_accepts_metadata(self) -> None:
+        """critical() accepts arbitrary metadata like error()."""
+        collected: list[dict[str, Any]] = []
+        logger = SyncLoggerFacade(
+            name="test",
+            queue_capacity=16,
+            batch_max_size=8,
+            batch_timeout_seconds=0.05,
+            backpressure_wait_ms=10,
+            drop_on_full=True,
+            sink_write=lambda e: _collecting_sink(collected, e),
+        )
+        logger.start()
+
+        logger.critical("System down", service="api", code=500)
+
+        await asyncio.sleep(0.1)
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        # Metadata goes into data field (v1.1 envelope schema)
+        data = collected[0].get("data", {})
+        assert data.get("service") == "api"
+        assert data.get("code") == 500
+
+    @pytest.mark.asyncio
+    async def test_sync_critical_accepts_exc_info(self) -> None:
+        """critical() accepts exc_info parameter like error()."""
+        collected: list[dict[str, Any]] = []
+        logger = SyncLoggerFacade(
+            name="test",
+            queue_capacity=16,
+            batch_max_size=8,
+            batch_timeout_seconds=0.05,
+            backpressure_wait_ms=10,
+            drop_on_full=True,
+            sink_write=lambda e: _collecting_sink(collected, e),
+        )
+        logger.start()
+
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            logger.critical("Fatal error", exc_info=True)
+
+        await asyncio.sleep(0.1)
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        # Exception info goes in diagnostics.exception (v1.1 envelope schema)
+        diagnostics = collected[0].get("diagnostics", {})
+        exception = diagnostics.get("exception", {})
+        assert exception.get("error.type") == "ValueError"
+        assert exception.get("error.message") == "boom"
+
+
+class TestAsyncLoggerCritical:
+    """Tests for AsyncLoggerFacade.critical() method."""
+
+    @pytest.mark.asyncio
+    async def test_async_logger_has_critical_method(self) -> None:
+        """AC2: AsyncLoggerFacade exposes an async critical() method."""
+        collected: list[dict[str, Any]] = []
+        logger = AsyncLoggerFacade(
+            name="test",
+            queue_capacity=16,
+            batch_max_size=8,
+            batch_timeout_seconds=0.05,
+            backpressure_wait_ms=10,
+            drop_on_full=True,
+            sink_write=lambda e: _collecting_sink(collected, e),
+        )
+        await logger.start_async()
+
+        # Should not raise AttributeError and should be awaitable
+        await logger.critical("System failure imminent")
+
+        await asyncio.sleep(0.1)
+        res = await logger.drain()
+        assert res.submitted == 1
+        assert res.processed == 1
+
+    @pytest.mark.asyncio
+    async def test_async_critical_logs_include_correct_level(self) -> None:
+        """AC3: CRITICAL logs include level='CRITICAL' in envelope."""
+        collected: list[dict[str, Any]] = []
+        logger = AsyncLoggerFacade(
+            name="test",
+            queue_capacity=16,
+            batch_max_size=8,
+            batch_timeout_seconds=0.05,
+            backpressure_wait_ms=10,
+            drop_on_full=True,
+            sink_write=lambda e: _collecting_sink(collected, e),
+        )
+        await logger.start_async()
+
+        await logger.critical("Test critical message")
+
+        await asyncio.sleep(0.1)
+        await logger.drain()
+
+        assert len(collected) == 1
+        assert collected[0]["level"] == "CRITICAL"
+        assert collected[0]["message"] == "Test critical message"
+
+    @pytest.mark.asyncio
+    async def test_async_critical_accepts_metadata(self) -> None:
+        """critical() accepts arbitrary metadata like error()."""
+        collected: list[dict[str, Any]] = []
+        logger = AsyncLoggerFacade(
+            name="test",
+            queue_capacity=16,
+            batch_max_size=8,
+            batch_timeout_seconds=0.05,
+            backpressure_wait_ms=10,
+            drop_on_full=True,
+            sink_write=lambda e: _collecting_sink(collected, e),
+        )
+        await logger.start_async()
+
+        await logger.critical("System down", service="api", code=500)
+
+        await asyncio.sleep(0.1)
+        await logger.drain()
+
+        assert len(collected) == 1
+        # Metadata goes into data field (v1.1 envelope schema)
+        data = collected[0].get("data", {})
+        assert data.get("service") == "api"
+        assert data.get("code") == 500
+
+    @pytest.mark.asyncio
+    async def test_async_critical_accepts_exc_info(self) -> None:
+        """critical() accepts exc_info parameter like error()."""
+        collected: list[dict[str, Any]] = []
+        logger = AsyncLoggerFacade(
+            name="test",
+            queue_capacity=16,
+            batch_max_size=8,
+            batch_timeout_seconds=0.05,
+            backpressure_wait_ms=10,
+            drop_on_full=True,
+            sink_write=lambda e: _collecting_sink(collected, e),
+        )
+        await logger.start_async()
+
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            await logger.critical("Fatal error", exc_info=True)
+
+        await asyncio.sleep(0.1)
+        await logger.drain()
+
+        assert len(collected) == 1
+        # Exception info goes in diagnostics.exception (v1.1 envelope schema)
+        diagnostics = collected[0].get("diagnostics", {})
+        exception = diagnostics.get("exception", {})
+        assert exception.get("error.type") == "ValueError"
+        assert exception.get("error.message") == "boom"


### PR DESCRIPTION
## Summary

Add `critical()` method to both `SyncLoggerFacade` and `AsyncLoggerFacade`, providing parity with Python's stdlib logging CRITICAL level. The stdlib bridge now calls `critical()` directly instead of using `error()` with an extras flag.

## Changes

- `src/fapilog/core/logger.py` (modified) - Add critical() to SyncLoggerFacade and AsyncLoggerFacade
- `src/fapilog/core/stdlib_bridge.py` (modified) - Call critical() directly for CRITICAL level
- `docs/api-reference/logger-methods.md` (modified) - Document critical() method
- `tests/unit/test_logger_critical.py` (new) - Tests for critical() method
- `tests/unit/test_stdlib_bridge.py` (modified) - Update CRITICAL level test

## Acceptance Criteria

- [x] SyncLoggerFacade exposes critical() method with same signature as error()
- [x] AsyncLoggerFacade exposes async critical() method with same signature as error()
- [x] CRITICAL logs include level="CRITICAL" in the log envelope
- [x] Stdlib bridge calls critical() directly instead of error() with extras flag
- [x] API reference documentation updated

## Test Plan

- [x] Unit tests pass
- [x] Coverage >= 90% on changed lines
- [x] mypy passes
- [x] ruff check passes

## Story

[1.33 - Add critical() Log Level Method](docs/stories/1.33.add-critical-log-level.md)