### PR TITLE
docs(redactors): add prominent PII f-string warning

### DIFF
--- a/docs/api-reference/plugins/redactors.md
+++ b/docs/api-reference/plugins/redactors.md
@@ -2,6 +2,22 @@
 
 Plugins that mask or remove sensitive data.
 
+!!! warning "PII in Message Strings Is Not Redacted"
+
+    Redactors only process **structured fields** in the log envelope.
+    PII embedded in the message string will pass through unchanged.
+
+    ```python
+    # UNSAFE - email will NOT be redacted
+    logger.info(f"User {email} logged in")
+
+    # SAFE - email field will be redacted
+    logger.info("User logged in", email=email)
+    ```
+
+    See [PII Showing Despite Redaction](../../troubleshooting/pii-showing-despite-redaction.md)
+    for more details.
+
 ## Contract
 
 Implement `BaseRedactor.redact(entry: dict) -> dict` (async). Return the updated entry; contain errors so the pipeline continues.

--- a/docs/plugins/redactors.md
+++ b/docs/plugins/redactors.md
@@ -2,6 +2,24 @@
 
 Redactors transform structured log events to remove or mask sensitive data before serialization and sink emission. The Redactors stage executes after Enrichers and before Sinks, preserving the async-first, non-blocking guarantees of the runtime pipeline.
 
+!!! warning "PII in Message Strings Is Not Redacted"
+
+    Redactors only process **structured fields** in the log envelope.
+    PII embedded in the message string will pass through unchanged.
+
+    ```python
+    # UNSAFE - email will NOT be redacted
+    logger.info(f"User {email} logged in")
+    logger.info("User " + email + " logged in")
+
+    # SAFE - email field will be redacted
+    logger.info("User logged in", email=email)
+    logger.info("User logged in", user={"email": email})
+    ```
+
+    See [PII Showing Despite Redaction](../troubleshooting/pii-showing-despite-redaction.md)
+    for more details.
+
 ## Stage Placement and Lifecycle
 
 - Runs in the logger worker loop; no new threads or loops are created

--- a/docs/troubleshooting/pii-showing-despite-redaction.md
+++ b/docs/troubleshooting/pii-showing-despite-redaction.md
@@ -4,7 +4,25 @@
 - Passwords, tokens, or emails appear in logs
 - URL credentials (`user:pass@`) still visible
 
-## Causes
+## Most Common Cause: PII in Message Strings
+
+Redactors only process **structured fields** in the log envelope. PII embedded directly in the message string bypasses redaction entirely:
+
+```python
+# UNSAFE - these will NOT be redacted
+logger.info(f"User {email} logged in")           # f-string
+logger.info("User " + email + " logged in")      # concatenation
+logger.info("User %s logged in", email)          # %-formatting
+logger.info("User {} logged in".format(email))   # .format()
+
+# SAFE - structured fields ARE redacted
+logger.info("User logged in", email=email)
+logger.info("User logged in", user={"email": email})
+```
+
+**Fix:** Always pass sensitive data as structured keyword arguments, not in the message string.
+
+## Other Causes
 - Redactors disabled or order overridden
 - Sensitive fields not included in policy
 - Guardrails too restrictive for nested data


### PR DESCRIPTION
## Summary

Add prominent warning callouts to redaction documentation explaining that PII embedded in message strings (f-strings, concatenation, etc.) bypasses redaction entirely. Users often discover this limitation after PII has already been logged.

## Changes

- `docs/plugins/redactors.md` (modified)
- `docs/api-reference/plugins/redactors.md` (modified)
- `docs/troubleshooting/pii-showing-despite-redaction.md` (modified)

## Acceptance Criteria

- [x] Main redaction guide has prominent warning callout after introduction
- [x] API reference has warning with link to troubleshooting guide
- [x] Warning content is actionable (shows unsafe/safe patterns, links to docs)

## Test Plan

- [x] Docs build without errors
- [x] Links verified working
- [x] Warning placement prominent and visible

## Story

[12.23 - Add Prominent PII F-String Warning to Redaction Docs](docs/stories/12.23.redaction-pii-fstring-warning.md)