### PR TITLE
docs(stdlib-bridge): fix CRITICAL level mapping

### DIFF
--- a/docs/user-guide/stdlib-bridge.md
+++ b/docs/user-guide/stdlib-bridge.md
@@ -154,7 +154,7 @@ def setup_logging(**kwargs):
 
 | stdlib Level | fapilog Method |
 |--------------|----------------|
-| `CRITICAL` | `error()` with `critical=True` |
+| `CRITICAL` | `critical()` |
 | `ERROR` | `error()` |
 | `WARNING` | `warning()` |
 | `INFO` | `info()` |


### PR DESCRIPTION
## Summary

Audit of stdlib bridge documentation accuracy. Found and fixed an error in the level mapping table.

## Changes

- `docs/user-guide/stdlib-bridge.md` (modified)

## Acceptance Criteria

- [x] No incorrect API references (`with_stdlib_bridge`, `logger.stdlib`, `.enable_bridge(`)
- [x] Documentation matches implementation (signature, parameters, defaults)
- [x] Code examples are runnable

## Test Plan

- [x] Grep searches return no incorrect references
- [x] Function signature verified against `stdlib_bridge.py:245-256`
- [x] Quick Start example tested successfully

## Story

[12.24 - Audit stdlib Bridge Documentation Accuracy](docs/stories/12.24.fix-stdlib-bridge-documentation.md)