### PR TITLE
docs(security): update supported versions to 0.11.x/0.10.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,19 @@
 # Security Policy
 
-> **Your sinks can be slow. Your app shouldn't be.**
->
-> Async-first structured logging for FastAPI and modern Python applications.
-
----
-
 ## Supported Versions
 
 The following versions of fapilog are currently supported with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.7.x   | :white_check_mark: |
-| 0.6.x   | :white_check_mark: |
-| < 0.6   | :x:                |
+| 0.11.x  | :white_check_mark: |
+| 0.10.x  | :white_check_mark: |
+| < 0.10  | :x:                |
 
 ## Version Support Policy
 
-- **Current release (0.7.x)**: Full security support
-- **Previous minor (0.6.x)**: Security fixes only, 6 months after next minor release
+- **Current release (0.11.x)**: Full security support
+- **Previous minor (0.10.x)**: Security fixes only, 6 months after next minor release
 - **Older versions**: No support, upgrade recommended
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
## Summary

Updates SECURITY.md to reflect current supported versions.

## Changes

- `SECURITY.md` (modified)
  - Remove marketing tagline (not appropriate for security policy)
  - Update version table from 0.7.x/0.6.x to 0.11.x/0.10.x

## Test Plan

- [x] Visual inspection of rendered markdown