### PR TITLE
feat(core): add custom sink names to builder API

### DIFF
--- a/docs/user-guide/sink-routing.md
+++ b/docs/user-guide/sink-routing.md
@@ -64,6 +64,40 @@ settings.sink_routing.fallback_sinks = ["rotating_file"]
 logger = get_logger(settings=settings)
 ```
 
+### Builder API with custom sink names
+
+Use the `name` parameter to create multiple sinks of the same type with unique names for routing:
+
+```python
+from fapilog import LoggerBuilder
+
+logger = (
+    LoggerBuilder()
+    .add_file("/logs/errors", name="error_file")
+    .add_file("/logs/info", name="info_file")
+    .with_routing([
+        {"levels": ["ERROR", "CRITICAL"], "sinks": ["error_file"]},
+        {"levels": ["DEBUG", "INFO", "WARNING"], "sinks": ["info_file"]},
+    ])
+    .build()
+)
+
+logger.error("Goes to /logs/errors")
+logger.info("Goes to /logs/info")
+```
+
+All `add_*` sink methods support the `name` parameter:
+
+- `add_file(directory, name="rotating_file")`
+- `add_stdout(name="stdout_json")`
+- `add_http(endpoint, name="http")`
+- `add_webhook(endpoint, name="webhook")`
+- `add_cloudwatch(log_group, name="cloudwatch")`
+- `add_loki(url, name="loki")`
+- `add_postgres(dsn, name="postgres")`
+
+Duplicate sink names raise `ValueError` at build time.
+
 ## RoutingSink plugin
 
 For manual composition without touching global settings:

--- a/tests/unit/test_builder_cloud_sinks.py
+++ b/tests/unit/test_builder_cloud_sinks.py
@@ -300,3 +300,61 @@ class TestMultipleCloudSinks:
         config = builder._sinks[0]["config"]
         assert config["circuit_breaker_enabled"] is True
         assert config["circuit_breaker_threshold"] == 3
+
+
+class TestCloudSinkCustomNames:
+    """Tests for custom sink names on cloud sinks (Story 10.46)."""
+
+    def test_add_cloudwatch_accepts_name_parameter(self) -> None:
+        """AC4: add_cloudwatch() accepts name parameter."""
+        builder = LoggerBuilder()
+        builder.add_cloudwatch(log_group="/myapp/prod", name="custom_cloudwatch")
+
+        assert builder._sinks[0]["name"] == "custom_cloudwatch"
+
+    def test_add_cloudwatch_default_name_unchanged(self) -> None:
+        """AC2: add_cloudwatch() defaults to 'cloudwatch'."""
+        builder = LoggerBuilder()
+        builder.add_cloudwatch(log_group="/myapp/prod")
+
+        assert builder._sinks[0]["name"] == "cloudwatch"
+
+    def test_add_loki_accepts_name_parameter(self) -> None:
+        """AC4: add_loki() accepts name parameter."""
+        builder = LoggerBuilder()
+        builder.add_loki(name="custom_loki")
+
+        assert builder._sinks[0]["name"] == "custom_loki"
+
+    def test_add_loki_default_name_unchanged(self) -> None:
+        """AC2: add_loki() defaults to 'loki'."""
+        builder = LoggerBuilder()
+        builder.add_loki()
+
+        assert builder._sinks[0]["name"] == "loki"
+
+    def test_add_postgres_accepts_name_parameter(self) -> None:
+        """AC4: add_postgres() accepts name parameter."""
+        builder = LoggerBuilder()
+        builder.add_postgres(
+            dsn="postgresql://user:pass@host/db", name="custom_postgres"
+        )
+
+        assert builder._sinks[0]["name"] == "custom_postgres"
+
+    def test_add_postgres_default_name_unchanged(self) -> None:
+        """AC2: add_postgres() defaults to 'postgres'."""
+        builder = LoggerBuilder()
+        builder.add_postgres(dsn="postgresql://user:pass@host/db")
+
+        assert builder._sinks[0]["name"] == "postgres"
+
+    def test_multiple_cloudwatch_sinks_with_custom_names(self) -> None:
+        """AC1: Custom names enable multiple CloudWatch sinks."""
+        builder = LoggerBuilder()
+        builder.add_cloudwatch(log_group="/errors", name="cw_errors")
+        builder.add_cloudwatch(log_group="/info", name="cw_info")
+
+        assert len(builder._sinks) == 2
+        assert builder._sinks[0]["name"] == "cw_errors"
+        assert builder._sinks[1]["name"] == "cw_info"


### PR DESCRIPTION
## Summary

Add optional `name` parameter to all `add_*` sink methods, enabling multiple sinks of the same type with unique names for level-based routing. Duplicate names raise `ValueError` at build time.

## Changes

- `src/fapilog/builder.py` (modified)
- `docs/user-guide/sink-routing.md` (modified)
- `tests/unit/test_builder_api.py` (modified)
- `tests/unit/test_builder_cloud_sinks.py` (modified)

## Acceptance Criteria

- [x] Custom sink names enable routing between multiple sinks of same type
- [x] Backwards compatible defaults (existing code unchanged)
- [x] Duplicate name validation raises ValueError at build time
- [x] All sink methods support custom names (add_file, add_stdout, add_http, add_webhook, add_cloudwatch, add_loki, add_postgres)

## Test Plan

- [x] Unit tests for custom names on all sink methods
- [x] Unit tests for default name preservation
- [x] Unit tests for duplicate name validation
- [x] Async builder validation test
- [x] Coverage >= 90%