### PR TITLE
fix(redactors): align block_on_unredactable defaults across config layers

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -102,7 +102,7 @@
 | `FAPILOG_PROCESSOR_CONFIG__SIZE_GUARD__PRESERVE_FIELDS` | list | PydanticUndefined | Fields that should never be removed during truncation |
 | `FAPILOG_PROCESSOR_CONFIG__ZERO_COPY` | dict | PydanticUndefined | Configuration for zero_copy processor (reserved for future options) |
 | `FAPILOG_REDACTOR_CONFIG__EXTRA` | dict | PydanticUndefined | Configuration for third-party redactors by name |
-| `FAPILOG_REDACTOR_CONFIG__FIELD_MASK__BLOCK_ON_UNREDACTABLE` | bool | False | Block log entry if redaction fails |
+| `FAPILOG_REDACTOR_CONFIG__FIELD_MASK__BLOCK_ON_UNREDACTABLE` | bool | True | Emit diagnostic warning when a field path cannot be redacted |
 | `FAPILOG_REDACTOR_CONFIG__FIELD_MASK__FIELDS_TO_MASK` | list | PydanticUndefined | Field names to mask (case-insensitive) |
 | `FAPILOG_REDACTOR_CONFIG__FIELD_MASK__MASK_STRING` | str | *** | Replacement mask string |
 | `FAPILOG_REDACTOR_CONFIG__FIELD_MASK__MAX_DEPTH` | int | 16 | Max nested depth to scan |

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -493,7 +493,8 @@ class RedactorFieldMaskSettings(BaseModel):
     )
     mask_string: str = Field(default="***", description="Replacement mask string")
     block_on_unredactable: bool = Field(
-        default=False, description="Block log entry if redaction fails"
+        default=True,
+        description="Emit diagnostic warning when a field path cannot be redacted",
     )
     max_depth: int = Field(default=16, ge=1, description="Max nested depth to scan")
     max_keys_scanned: int = Field(

--- a/tests/unit/test_redaction_defaults.py
+++ b/tests/unit/test_redaction_defaults.py
@@ -238,6 +238,31 @@ class TestPresetConsistency:
         )
 
 
+class TestBlockOnUnredactableConsistency:
+    """Verify block_on_unredactable defaults are consistent across config layers.
+
+    Story 4.67: FieldMaskConfig and RedactorFieldMaskSettings must agree.
+    """
+
+    def test_block_on_unredactable_consistent_across_config_layers(self) -> None:
+        """AC1: Plugin-level and settings-level defaults must match."""
+        from fapilog.core.settings import RedactorFieldMaskSettings
+        from fapilog.plugins.redactors.field_mask import FieldMaskConfig
+
+        assert (
+            FieldMaskConfig().block_on_unredactable
+            == RedactorFieldMaskSettings().block_on_unredactable
+        )
+
+    def test_both_defaults_are_true(self) -> None:
+        """AC2: Chosen default is True (security-forward)."""
+        from fapilog.core.settings import RedactorFieldMaskSettings
+        from fapilog.plugins.redactors.field_mask import FieldMaskConfig
+
+        assert FieldMaskConfig().block_on_unredactable is True
+        assert RedactorFieldMaskSettings().block_on_unredactable is True
+
+
 class TestFailClosedDefaults:
     """Verify fail-closed defaults for redaction security.
 


### PR DESCRIPTION
## Summary

`RedactorFieldMaskSettings.block_on_unredactable` defaulted to `False` while `FieldMaskConfig.block_on_unredactable` defaulted to `True`, causing diagnostic warnings for unredactable fields to appear during development/testing but silently disappear in production. Aligned both to `True` (security-forward) so behavior is consistent regardless of construction path.

## Changes

- `src/fapilog/core/settings.py` (modified)
- `tests/unit/test_redaction_defaults.py` (modified)
- `docs/env-vars.md` (modified)

## Acceptance Criteria

- [x] Consistent default across both config paths — `FieldMaskConfig` and `RedactorFieldMaskSettings` both default to `True`
- [x] Chosen default is security-forward (`True`) and pinned by tests
- [x] No behavioral regression — 52 related tests pass

## Test Plan

- [x] Unit tests pass (`pytest tests/unit/test_redaction_defaults.py` — 22/22)
- [x] All redactor edge case tests pass (52/52 total)
- [x] mypy passes on changed files
- [x] Builder parity check passes
- [x] Settings descriptions check passes

## Story

[4.67 - Align block_on_unredactable Defaults Across Config Layers](docs/stories/4.67.align-block-on-unredactable-defaults.md)