### PR TITLE
feat(core): add unsafe_debug escape hatch for raw diagnostic logging

### DIFF
--- a/src/fapilog/core/worker.py
+++ b/src/fapilog/core/worker.py
@@ -439,11 +439,18 @@ class LoggerWorker:
         both original fields AND enriched fields (e.g., request context
         that may contain PII).
 
+        Events tagged with ``_fapilog_unsafe`` bypass redaction entirely
+        (Story 4.70 - unsafe_debug escape hatch).
+
         Behavior on error depends on redaction_fail_mode:
         - "open": Returns original entry unchanged (fail-safe, default)
         - "closed": Returns None to signal event should be dropped
         - "warn": Returns original entry but emits diagnostic warning
         """
+        # Skip redaction for unsafe_debug events (Story 4.70)
+        if entry.get("data", {}).get("_fapilog_unsafe") is True:
+            return entry
+
         redactors = self._redactors_getter()
         if not redactors:
             return entry

--- a/tests/unit/test_unsafe_debug.py
+++ b/tests/unit/test_unsafe_debug.py
@@ -1,0 +1,226 @@
+"""Tests for unsafe_debug escape hatch (Story 4.70).
+
+Covers:
+- AC1: unsafe_debug emits at DEBUG level
+- AC2: Event tagged with _fapilog_unsafe marker
+- AC3: Redaction pipeline skipped for unsafe_debug events
+- AC4: Regular debug() still redacts
+- AC5: Async facade support
+- AC6: User-supplied _fapilog_unsafe kwarg does not bypass redaction
+- Exception forwarding via exc/exc_info
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fapilog.core.logger import AsyncLoggerFacade, SyncLoggerFacade
+
+
+class _FieldRedactor:
+    """Test redactor that replaces 'password' values with '***'."""
+
+    name = "field_mask"
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def redact(self, event: dict[str, Any]) -> dict[str, Any]:
+        e = dict(event)
+        data = e.get("data")
+        if isinstance(data, dict) and "password" in data:
+            data = dict(data)
+            data["password"] = "***"
+            e["data"] = data
+        return e
+
+
+def _make_sync_logger(
+    collected: list[dict[str, Any]],
+    *,
+    with_redactor: bool = False,
+) -> SyncLoggerFacade:
+    """Create a SyncLoggerFacade that collects events into a list."""
+
+    async def sink(event: dict[str, Any]) -> None:
+        collected.append(dict(event))
+
+    logger = SyncLoggerFacade(
+        name="unsafe-debug-test",
+        queue_capacity=16,
+        batch_max_size=8,
+        batch_timeout_seconds=0.05,
+        backpressure_wait_ms=10,
+        drop_on_full=True,
+        sink_write=sink,
+    )
+    if with_redactor:
+        logger._redactors = [_FieldRedactor()]  # type: ignore[attr-defined]
+        logger._invalidate_redactors_cache()  # type: ignore[attr-defined]
+    return logger
+
+
+def _make_async_logger(
+    collected: list[dict[str, Any]],
+    *,
+    with_redactor: bool = False,
+) -> AsyncLoggerFacade:
+    """Create an AsyncLoggerFacade that collects events into a list."""
+
+    async def sink(event: dict[str, Any]) -> None:
+        collected.append(dict(event))
+
+    logger = AsyncLoggerFacade(
+        name="unsafe-debug-async-test",
+        queue_capacity=16,
+        batch_max_size=8,
+        batch_timeout_seconds=0.05,
+        backpressure_wait_ms=10,
+        drop_on_full=True,
+        sink_write=sink,
+    )
+    if with_redactor:
+        logger._redactors = [_FieldRedactor()]  # type: ignore[attr-defined]
+        logger._invalidate_redactors_cache()  # type: ignore[attr-defined]
+    return logger
+
+
+class TestUnsafeDebug:
+    """Tests for SyncLoggerFacade.unsafe_debug()."""
+
+    @pytest.mark.asyncio
+    async def test_unsafe_debug_emits_debug_level(self) -> None:
+        """AC1: unsafe_debug() always produces a DEBUG-level event."""
+        collected: list[dict[str, Any]] = []
+        logger = _make_sync_logger(collected)
+        logger.start()
+
+        logger.unsafe_debug("raw data", payload="sensitive")
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        assert collected[0]["level"] == "DEBUG"
+
+    @pytest.mark.asyncio
+    async def test_unsafe_debug_tags_fapilog_unsafe_marker(self) -> None:
+        """AC2: Event has data._fapilog_unsafe = True."""
+        collected: list[dict[str, Any]] = []
+        logger = _make_sync_logger(collected)
+        logger.start()
+
+        logger.unsafe_debug("raw data", payload="x")
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        assert collected[0]["data"]["_fapilog_unsafe"] is True
+
+    @pytest.mark.asyncio
+    async def test_unsafe_debug_skips_redaction(self) -> None:
+        """AC3: Events from unsafe_debug bypass the redaction pipeline."""
+        collected: list[dict[str, Any]] = []
+        logger = _make_sync_logger(collected, with_redactor=True)
+        logger.start()
+
+        logger.unsafe_debug("debug", password="secret123", api_key="sk-abc")
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        data = collected[0]["data"]
+        assert data["password"] == "secret123"
+        assert data["api_key"] == "sk-abc"
+
+    @pytest.mark.asyncio
+    async def test_regular_debug_still_redacts(self) -> None:
+        """AC4: Regular debug() continues to apply redaction."""
+        collected: list[dict[str, Any]] = []
+        logger = _make_sync_logger(collected, with_redactor=True)
+        logger.start()
+
+        logger.debug("debug", password="secret123")
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        assert collected[0]["data"]["password"] == "***"
+
+    @pytest.mark.asyncio
+    async def test_user_kwarg_fapilog_unsafe_does_not_bypass_redaction(self) -> None:
+        """AC6: User-supplied _fapilog_unsafe=True via normal log methods is stripped."""
+        collected: list[dict[str, Any]] = []
+        logger = _make_sync_logger(collected, with_redactor=True)
+        logger.start()
+
+        logger.info("sneaky", password="secret123", _fapilog_unsafe=True)
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        assert collected[0]["data"]["password"] == "***"
+
+    @pytest.mark.asyncio
+    async def test_unsafe_debug_with_exception(self) -> None:
+        """unsafe_debug forwards exc/exc_info to the envelope."""
+        collected: list[dict[str, Any]] = []
+        logger = _make_sync_logger(collected)
+        logger.start()
+
+        err = ValueError("test error")
+        logger.unsafe_debug("error dump", exc=err, detail="raw")
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        assert collected[0]["level"] == "DEBUG"
+        assert collected[0]["data"]["detail"] == "raw"
+        # Exception info should be captured in diagnostics.exception
+        exc_info = collected[0].get("diagnostics", {}).get("exception", {})
+        assert exc_info.get("error.type") == "ValueError"
+        assert exc_info.get("error.message") == "test error"
+
+
+class TestAsyncUnsafeDebug:
+    """Tests for AsyncLoggerFacade.unsafe_debug() (AC5)."""
+
+    @pytest.mark.asyncio
+    async def test_async_unsafe_debug_emits_debug_level(self) -> None:
+        """AC5: Async facade unsafe_debug produces DEBUG-level event."""
+        collected: list[dict[str, Any]] = []
+        logger = _make_async_logger(collected)
+        logger.start()
+
+        await logger.unsafe_debug("raw data", payload="sensitive")
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        assert collected[0]["level"] == "DEBUG"
+
+    @pytest.mark.asyncio
+    async def test_async_unsafe_debug_skips_redaction(self) -> None:
+        """AC5+AC3: Async unsafe_debug also bypasses redaction."""
+        collected: list[dict[str, Any]] = []
+        logger = _make_async_logger(collected, with_redactor=True)
+        logger.start()
+
+        await logger.unsafe_debug("debug", password="secret123")
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        assert collected[0]["data"]["password"] == "secret123"
+
+    @pytest.mark.asyncio
+    async def test_async_user_kwarg_fapilog_unsafe_stripped(self) -> None:
+        """AC6: Async facade also strips _fapilog_unsafe from user kwargs."""
+        collected: list[dict[str, Any]] = []
+        logger = _make_async_logger(collected, with_redactor=True)
+        logger.start()
+
+        await logger.info("sneaky", password="secret123", _fapilog_unsafe=True)
+        await logger.stop_and_drain()
+
+        assert len(collected) == 1
+        assert collected[0]["data"]["password"] == "***"


### PR DESCRIPTION
## Summary

Developers need to log raw, unredacted data during debugging. Without a sanctioned path, they resort to `print()`, `logging.debug()`, or bypassing fapilog entirely — making it impossible to track or audit what sensitive data was exposed.

`unsafe_debug()` provides a controlled escape hatch that emits at DEBUG level, tags the event with a reserved internal marker (`_fapilog_unsafe`), and bypasses the redaction pipeline. The method name is deliberately alarming to discourage casual use and is easy to grep in code review.

## Changes

- `src/fapilog/core/logger.py` (modified) — add `unsafe_debug()` to `SyncLoggerFacade` and `AsyncLoggerFacade`; sentinel-based marker extraction in `_prepare_payload`
- `src/fapilog/core/worker.py` (modified) — early return in `_apply_redactors` for `_fapilog_unsafe`-tagged events
- `tests/unit/test_unsafe_debug.py` (new) — 9 tests covering all acceptance criteria

## Acceptance Criteria

- [x] `unsafe_debug()` always produces a DEBUG-level event
- [x] Event tagged with `_fapilog_unsafe` reserved internal marker
- [x] Redaction pipeline skipped for unsafe_debug events
- [x] Regular `debug()` still applies redaction
- [x] `AsyncLoggerFacade` also has `unsafe_debug()`
- [x] User-supplied `_fapilog_unsafe` kwarg via normal log methods does not bypass redaction

## Test Plan

- [x] Unit tests pass (9/9)
- [x] Full suite regression pass (3248 passed)
- [x] Coverage >= 90% on changed lines (93%)
- [x] ruff check + format pass
- [x] mypy passes
- [x] No weak assertions
- [x] No dead code

## Story

[4.70 - unsafe_debug Escape Hatch for Raw Diagnostic Logging](docs/stories/4.70.unsafe-debug-escape-hatch.md)