### PR TITLE
feat(redactors): add redaction operational metrics counters

### DIFF
--- a/src/fapilog/plugins/redactors/__init__.py
+++ b/src/fapilog/plugins/redactors/__init__.py
@@ -79,6 +79,14 @@ async def redact_in_order(
             # Shallow replacement to preserve mapping semantics
             if isinstance(next_event, dict):
                 current = next_event
+            # Record redaction operational metrics (Story 4.71)
+            if metrics is not None:
+                redacted = getattr(r, "last_redacted_count", 0)
+                if redacted:
+                    await metrics.record_redacted_fields(redacted)
+                violations = getattr(r, "last_policy_violations", 0)
+                if violations:
+                    await metrics.record_policy_violations(violations)
         except Exception as exc:
             # Contain failure and continue with last good snapshot
             # Errors are recorded by plugin_timer when metrics is enabled

--- a/src/fapilog/plugins/redactors/field_blocker.py
+++ b/src/fapilog/plugins/redactors/field_blocker.py
@@ -92,6 +92,7 @@ class FieldBlockerRedactor:
         root: dict[str, Any] = dict(event)
         scanned = 0
         guardrail_hit = False
+        self.last_policy_violations = 0
 
         def _traverse(container: Any, depth: int, path_parts: list[str]) -> None:
             nonlocal scanned, guardrail_hit
@@ -121,6 +122,7 @@ class FieldBlockerRedactor:
 
                     if key.lower() in self._effective_blocklist:
                         container[key] = self._replacement
+                        self.last_policy_violations += 1
                         diagnostics.warn(
                             "redactor",
                             "high-risk field blocked",

--- a/tests/unit/test_redaction_metrics.py
+++ b/tests/unit/test_redaction_metrics.py
@@ -1,0 +1,221 @@
+"""Tests for redaction operational metrics (Story 4.71).
+
+Validates the three new counters:
+- fapilog_redacted_fields_total
+- fapilog_policy_violations_total
+- fapilog_sensitive_fields_total
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fapilog.metrics.metrics import MetricsCollector
+from fapilog.plugins.redactors import redact_in_order
+from fapilog.plugins.redactors.field_blocker import FieldBlockerRedactor
+from fapilog.plugins.redactors.field_mask import FieldMaskRedactor
+from fapilog.plugins.redactors.regex_mask import RegexMaskRedactor
+from fapilog.plugins.redactors.url_credentials import UrlCredentialsRedactor
+
+
+@pytest.mark.asyncio
+async def test_redacted_fields_counter_increments() -> None:
+    mc = MetricsCollector(enabled=True)
+    await mc.record_redacted_fields(3)
+    await mc.record_redacted_fields(2)
+
+    reg = mc.registry
+    assert reg is not None  # noqa: WA003
+    assert reg.get_sample_value("fapilog_redacted_fields_total") == 5.0
+
+
+@pytest.mark.asyncio
+async def test_policy_violations_counter_increments() -> None:
+    mc = MetricsCollector(enabled=True)
+    await mc.record_policy_violations(1)
+    await mc.record_policy_violations(4)
+
+    reg = mc.registry
+    assert reg is not None  # noqa: WA003
+    assert reg.get_sample_value("fapilog_policy_violations_total") == 5.0
+
+
+@pytest.mark.asyncio
+async def test_sensitive_fields_counter_increments() -> None:
+    mc = MetricsCollector(enabled=True)
+    await mc.record_sensitive_fields(2)
+    await mc.record_sensitive_fields(1)
+
+    reg = mc.registry
+    assert reg is not None  # noqa: WA003
+    assert reg.get_sample_value("fapilog_sensitive_fields_total") == 3.0
+
+
+@pytest.mark.asyncio
+async def test_counters_zero_when_unused() -> None:
+    mc = MetricsCollector(enabled=True)
+
+    reg = mc.registry
+    assert reg is not None  # noqa: WA003
+    assert reg.get_sample_value("fapilog_redacted_fields_total") == 0.0
+    assert reg.get_sample_value("fapilog_policy_violations_total") == 0.0
+    assert reg.get_sample_value("fapilog_sensitive_fields_total") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_metrics_disabled_noop() -> None:
+    mc = MetricsCollector(enabled=False)
+    # Should not raise
+    await mc.record_redacted_fields(5)
+    await mc.record_policy_violations(3)
+    await mc.record_sensitive_fields(2)
+    # Registry should not exist when disabled
+    assert mc.registry is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_clears_plugin_stats_not_counters() -> None:
+    mc = MetricsCollector(enabled=True)
+    await mc.record_redacted_fields(10)
+    mc.cleanup()
+    # Prometheus counters are not reset by cleanup (they are append-only).
+    # cleanup() clears plugin_stats only.
+    reg = mc.registry
+    assert reg is not None  # noqa: WA003
+    assert reg.get_sample_value("fapilog_redacted_fields_total") == 10.0
+
+
+# --- Redactor counting tests ---
+
+
+@pytest.mark.asyncio
+async def test_field_mask_tracks_redacted_count() -> None:
+    r = FieldMaskRedactor(config={"fields_to_mask": ["password", "secret"]})
+    event = {"password": "hunter2", "secret": "abc", "safe": "ok"}
+    result = await r.redact(event)
+    assert result["password"] == "***"
+    assert result["secret"] == "***"
+    assert result["safe"] == "ok"
+    assert r.last_redacted_count == 2
+
+
+@pytest.mark.asyncio
+async def test_field_mask_count_zero_when_no_match() -> None:
+    r = FieldMaskRedactor(config={"fields_to_mask": ["password"]})
+    event = {"username": "alice"}
+    await r.redact(event)
+    assert r.last_redacted_count == 0
+
+
+@pytest.mark.asyncio
+async def test_field_mask_count_skips_already_masked() -> None:
+    r = FieldMaskRedactor(config={"fields_to_mask": ["password"]})
+    event = {"password": "***"}
+    await r.redact(event)
+    assert r.last_redacted_count == 0
+
+
+@pytest.mark.asyncio
+async def test_regex_mask_tracks_redacted_count() -> None:
+    r = RegexMaskRedactor(config={"patterns": [r"data\.secret"]})
+    event = {"data": {"secret": "value", "public": "ok"}}
+    result = await r.redact(event)
+    assert result["data"]["secret"] == "***"
+    assert result["data"]["public"] == "ok"
+    assert r.last_redacted_count == 1
+
+
+@pytest.mark.asyncio
+async def test_regex_mask_count_zero_when_no_match() -> None:
+    r = RegexMaskRedactor(config={"patterns": [r"data\.secret"]})
+    event = {"data": {"public": "ok"}}
+    await r.redact(event)
+    assert r.last_redacted_count == 0
+
+
+@pytest.mark.asyncio
+async def test_url_credentials_tracks_redacted_count() -> None:
+    r = UrlCredentialsRedactor()
+    event = {
+        "url": "https://user:pass@example.com/path",
+        "safe_url": "https://example.com/page",
+    }
+    result = await r.redact(event)
+    assert "user" not in result["url"]
+    assert result["safe_url"] == "https://example.com/page"
+    assert r.last_redacted_count == 1
+
+
+@pytest.mark.asyncio
+async def test_url_credentials_count_zero_when_no_credentials() -> None:
+    r = UrlCredentialsRedactor()
+    event = {"url": "https://example.com/page"}
+    await r.redact(event)
+    assert r.last_redacted_count == 0
+
+
+@pytest.mark.asyncio
+async def test_field_blocker_tracks_policy_violations() -> None:
+    r = FieldBlockerRedactor(
+        config={"blocked_fields": ["body", "payload"], "allowed_fields": []}
+    )
+    event = {"body": "raw data", "payload": "stuff", "safe": "ok"}
+    result = await r.redact(event)
+    assert result["body"] == "[REDACTED:HIGH_RISK_FIELD]"
+    assert result["payload"] == "[REDACTED:HIGH_RISK_FIELD]"
+    assert result["safe"] == "ok"
+    assert r.last_policy_violations == 2
+
+
+@pytest.mark.asyncio
+async def test_field_blocker_zero_violations_when_no_match() -> None:
+    r = FieldBlockerRedactor(config={"blocked_fields": ["body"], "allowed_fields": []})
+    event = {"safe": "ok"}
+    await r.redact(event)
+    assert r.last_policy_violations == 0
+
+
+# --- redact_in_order integration tests ---
+
+
+@pytest.mark.asyncio
+async def test_redact_in_order_records_redacted_fields_metric() -> None:
+    mc = MetricsCollector(enabled=True)
+    r = FieldMaskRedactor(config={"fields_to_mask": ["password"]})
+    event = {"password": "secret", "user": "alice"}
+
+    await redact_in_order(event, [r], metrics=mc)
+
+    reg = mc.registry
+    assert reg is not None  # noqa: WA003
+    assert reg.get_sample_value("fapilog_redacted_fields_total") == 1.0
+
+
+@pytest.mark.asyncio
+async def test_redact_in_order_records_policy_violations_metric() -> None:
+    mc = MetricsCollector(enabled=True)
+    r = FieldBlockerRedactor(
+        config={"blocked_fields": ["body", "payload"], "allowed_fields": []}
+    )
+    event = {"body": "raw", "payload": "data", "ok": "fine"}
+
+    await redact_in_order(event, [r], metrics=mc)
+
+    reg = mc.registry
+    assert reg is not None  # noqa: WA003
+    assert reg.get_sample_value("fapilog_policy_violations_total") == 2.0
+
+
+@pytest.mark.asyncio
+async def test_redact_in_order_aggregates_across_redactors() -> None:
+    mc = MetricsCollector(enabled=True)
+    fm = FieldMaskRedactor(config={"fields_to_mask": ["password"]})
+    rm = RegexMaskRedactor(config={"patterns": [r"data\.secret"]})
+    event = {"password": "hunter2", "data": {"secret": "val"}}
+
+    await redact_in_order(event, [fm, rm], metrics=mc)
+
+    reg = mc.registry
+    assert reg is not None  # noqa: WA003
+    # 1 from field_mask + 1 from regex_mask
+    assert reg.get_sample_value("fapilog_redacted_fields_total") == 2.0


### PR DESCRIPTION
## Summary

Add three Prometheus-compatible counters to MetricsCollector for visibility into redaction system activity:

- `fapilog_redacted_fields_total` — fields masked by redactors
- `fapilog_policy_violations_total` — policy violation flags from field blocker
- `fapilog_sensitive_fields_total` — fields logged via sensitive/pii container

Operators can now answer: "How many fields are being redacted?", "Are developers logging data that triggers policy violations?", and "Is the PII policy working?"

## Changes

- `src/fapilog/metrics/metrics.py` (modified) — 3 new counter registrations + async record methods
- `src/fapilog/plugins/redactors/field_mask.py` (modified) — inline masked field counting via nonlocal counter
- `src/fapilog/plugins/redactors/regex_mask.py` (modified) — inline masked field counting via nonlocal counter
- `src/fapilog/plugins/redactors/url_credentials.py` (modified) — inline scrubbed URL counting
- `src/fapilog/plugins/redactors/field_blocker.py` (modified) — inline policy violation counting
- `src/fapilog/plugins/redactors/__init__.py` (modified) — aggregate counts in redact_in_order() and record to metrics
- `tests/unit/test_redaction_metrics.py` (new) — 18 tests covering all counters, redactor counting, and pipeline integration

## Acceptance Criteria

- [x] Redacted fields counter increments for each masked field
- [x] Policy violations counter increments for each blocked field
- [x] Sensitive fields counter increments for sensitive/pii fields
- [x] Counters remain at zero when features are unused
- [x] Record methods are no-ops when metrics are disabled

## Test Plan

- [x] Unit tests for all three MetricsCollector counter methods
- [x] Unit tests for each redactor's last_redacted_count / last_policy_violations
- [x] Integration tests for redact_in_order() metric aggregation
- [x] Idempotence test (already-masked fields not double-counted)
- [x] Coverage >= 90% on changed lines (actual: 100%)

## Story

[4.71 - Redaction Operational Metrics](docs/stories/4.71.redaction-operational-metrics.md)