### PR TITLE
feat(redactors): honor core guardrails in UrlCredentialsRedactor

### DIFF
--- a/src/fapilog/core/config_builders.py
+++ b/src/fapilog/core/config_builders.py
@@ -221,7 +221,9 @@ def _redactor_configs(settings: _Settings) -> dict[str, dict[str, _Any]]:
             "core_max_keys_scanned": core_max_keys,
         },
         "url_credentials": {
-            "config": _UrlCredentialsConfig(**rcfg.url_credentials.model_dump())
+            "config": _UrlCredentialsConfig(**rcfg.url_credentials.model_dump()),
+            "core_max_depth": core_max_depth,
+            "core_max_keys_scanned": core_max_keys,
         },
         "field_blocker": {
             "config": _FieldBlockerConfig(**rcfg.field_blocker.model_dump()),

--- a/tests/unit/core/test_config_builders.py
+++ b/tests/unit/core/test_config_builders.py
@@ -142,6 +142,21 @@ class TestRedactorConfigs:
 
         assert "config" in result["field_mask"]
 
+    def test_url_credentials_receives_core_guardrails(self) -> None:
+        """url_credentials config includes core_max_depth and core_max_keys_scanned."""
+        from fapilog.core.config_builders import _redactor_configs
+
+        settings = Settings()
+        result = _redactor_configs(settings)
+
+        url_cfg = result["url_credentials"]
+        assert "core_max_depth" in url_cfg
+        assert "core_max_keys_scanned" in url_cfg
+        assert url_cfg["core_max_depth"] == settings.core.redaction_max_depth
+        assert (
+            url_cfg["core_max_keys_scanned"] == settings.core.redaction_max_keys_scanned
+        )
+
 
 class TestFilterConfigs:
     """Test _filter_configs returns expected structure."""


### PR DESCRIPTION
## Summary

`UrlCredentialsRedactor` hardcoded `depth > 16` and `scanned > 1000` guardrails, ignoring `CoreSettings.redaction_max_depth` and `redaction_max_keys_scanned`. This made it inconsistent with `FieldMaskRedactor` and `RegexMaskRedactor`, which both apply "more restrictive wins" logic. This PR adds the same core guardrail parameters and wires them through the config builder.

## Changes

- `src/fapilog/plugins/redactors/url_credentials.py` (modified) — add `core_max_depth` and `core_max_keys_scanned` params with "more restrictive wins" logic; replace hardcoded limits with instance attributes
- `src/fapilog/core/config_builders.py` (modified) — pass core guardrails to `url_credentials` config entry
- `tests/unit/test_url_credentials_redactor.py` (modified) — add `TestCoreGuardrails` class with 6 tests
- `tests/unit/core/test_config_builders.py` (modified) — add config builder contract test

## Acceptance Criteria

- [x] Core guardrails override hardcoded defaults when more restrictive
- [x] Plugin defaults (depth 16, scanned 1000) preserved without core override
- [x] Config builder passes core guardrails to url_credentials
- [x] Contract test verifies builder pipeline applies core depth

## Test Plan

- [x] Unit tests pass (54 related, 3310 full suite)
- [x] Coverage >= 90% on changed lines (100%)
- [x] ruff check + format pass
- [x] mypy passes
- [x] No regressions

## Story

[4.65 - UrlCredentialsRedactor Should Honor Core Guardrails](docs/stories/4.65.url-credentials-honor-core-guardrails.md)