### PR TITLE
feat(core): always emit correlation_id in envelope for stable schema

### DIFF
--- a/docs/architecture/built-in-core-features.md
+++ b/docs/architecture/built-in-core-features.md
@@ -11,7 +11,7 @@ Fapilog v3 includes essential features **out of the box** to ensure immediate pr
   - Uses zero-copy serialization helpers
   - Non-blocking writes using `asyncio.to_thread(...)` to avoid event loop stalls
   - Intended as a dev/default sink; production deployments typically add file/HTTP/cloud sinks via plugins
-  - Includes `correlation_id` (when present in context) in the emitted JSON
+  - Includes `correlation_id` in the emitted JSON (always present; `null` when no correlation context is active)
   - Errors are contained and never crash the app; see Internal Diagnostics below
 
 ## Internal Diagnostics (Optional)

--- a/docs/architecture/coding-standards.md
+++ b/docs/architecture/coding-standards.md
@@ -25,8 +25,8 @@ These standards are **MANDATORY for AI agents** and critical for maintaining cod
 - **Container Isolation:** Never use global state - all state must be container-scoped
 - **Zero-Copy Operations:** Pass LogEvent by reference, never copy event data unnecessarily
 - **Correlation ID Propagation:** All async operations must propagate correlation_id for tracing
-  - The default pipeline reads `request_id` from the async context and assigns it to `LogEvent.correlation_id`, defaulting to a UUID if none exists
-  - Sinks should include `correlation_id` in emitted records when present
+  - The default pipeline reads `request_id` from the async context and assigns it to `context.correlation_id`; the field is always present in the envelope (`null` when no correlation context is active)
+  - Sinks should always include `correlation_id` in emitted records
 - **Enrichment Order:** Default enrichers run before serialization/sinks
   - `runtime_info` provides service/env/version/host/pid/python
   - `context_vars` provides request_id/user_id and optional trace/span IDs

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -797,11 +797,14 @@
       "properties": {
         "context": {
           "additionalProperties": true,
-          "description": "Request/trace context - identifies WHO and WHAT request. message_id uniquely identifies each log entry; correlation_id is shared across related entries when set via context.",
+          "description": "Request/trace context - identifies WHO and WHAT request. message_id uniquely identifies each log entry; correlation_id is always present (null when no correlation context is active).",
           "properties": {
             "correlation_id": {
-              "description": "Shared identifier across related log entries (only when set via context)",
-              "type": "string"
+              "description": "Shared identifier across related log entries. Always present; null when no correlation context is active.",
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "message_id": {
               "description": "Unique identifier for each log entry (always present)",
@@ -824,7 +827,8 @@
             }
           },
           "required": [
-            "message_id"
+            "message_id",
+            "correlation_id"
           ],
           "type": "object"
         },

--- a/docs/schema-migration-v1.0-to-v1.1.md
+++ b/docs/schema-migration-v1.0-to-v1.1.md
@@ -28,7 +28,8 @@ v1.1 organizes fields into three semantic groups:
     "message": str,        # Human-readable log message
     "logger": str,         # Logger name
     "context": {           # Request/trace identifiers (WHO/WHAT)
-        "correlation_id": str,
+        "message_id": str,             # Always present - unique per log entry
+        "correlation_id": str | None,  # Always present; None when unset
         "request_id": str | None,
         "user_id": str | None,
         "tenant_id": str | None,

--- a/schemas/log_envelope_v1.json
+++ b/schemas/log_envelope_v1.json
@@ -35,11 +35,11 @@
         },
         "context": {
           "type": "object",
-          "description": "Request/trace context - identifies WHO and WHAT request. message_id uniquely identifies each log entry; correlation_id is shared across related entries when set via context.",
-          "required": ["message_id"],
+          "description": "Request/trace context - identifies WHO and WHAT request. message_id uniquely identifies each log entry; correlation_id is always present (null when no correlation context is active).",
+          "required": ["message_id", "correlation_id"],
           "properties": {
             "message_id": { "type": "string", "description": "Unique identifier for each log entry (always present)" },
-            "correlation_id": { "type": "string", "description": "Shared identifier across related log entries (only when set via context)" },
+            "correlation_id": { "type": ["string", "null"], "description": "Shared identifier across related log entries. Always present; null when no correlation context is active." },
             "request_id": { "type": "string" },
             "user_id": { "type": "string" },
             "tenant_id": { "type": "string" },

--- a/src/fapilog/core/envelope.py
+++ b/src/fapilog/core/envelope.py
@@ -89,8 +89,8 @@ def build_envelope(
         exceptions_max_frames: Maximum traceback frames to include.
         exceptions_max_stack_chars: Maximum characters for stack trace.
         logger_name: Name of the logger.
-        correlation_id: Correlation ID for request tracing. Only included in
-            envelope when explicitly provided (not auto-generated).
+        correlation_id: Correlation ID for request tracing. Always included in
+            envelope; None when no correlation context is active.
         origin: Source of the log entry. One of 'native' (direct fapilog calls),
             'stdlib' (routed through stdlib bridge), or 'third_party' (from
             external libraries or explicit override). Defaults to 'native'.
@@ -113,9 +113,8 @@ def build_envelope(
     # message_id: Always generate a unique ID per log entry (Story 1.34)
     context["message_id"] = str(uuid4())
 
-    # correlation_id: Only include when explicitly set (not auto-generated)
-    if correlation_id is not None:
-        context["correlation_id"] = correlation_id
+    # correlation_id: Always present; None when no correlation context is active
+    context["correlation_id"] = correlation_id
 
     # Extract trace context fields from bound_context (first)
     if bound_context:

--- a/tests/unit/envelope/test_envelope_v1_1.py
+++ b/tests/unit/envelope/test_envelope_v1_1.py
@@ -85,16 +85,15 @@ class TestContextFieldSemantics:
         # NOT at top level
         assert "correlation_id" not in envelope
 
-    def test_correlation_id_absent_when_not_provided(self) -> None:
-        """correlation_id should NOT be present when not explicitly set (Story 1.34).
+    def test_correlation_id_null_when_not_provided(self) -> None:
+        """correlation_id should be None when not explicitly set (Story 10.55).
 
-        The new semantics: message_id is always generated (unique per entry),
-        correlation_id only appears when explicitly set via context variable.
+        The v1.1+ schema always includes correlation_id for stable schema shape.
+        It is None when no correlation context is active, present when explicitly set.
         """
         envelope = build_envelope(level="INFO", message="Test")
 
-        # correlation_id NOT present when not explicitly set
-        assert "correlation_id" not in envelope["context"]
+        assert envelope["context"]["correlation_id"] is None
 
     def test_message_id_always_present(self) -> None:
         """message_id should always be present as a valid UUID (Story 1.34)."""

--- a/tests/unit/test_envelope.py
+++ b/tests/unit/test_envelope.py
@@ -244,20 +244,18 @@ class TestBuildEnvelopeCorrelation:
 
         assert envelope["context"]["correlation_id"] == "corr-789"
 
-    def test_correlation_id_absent_when_not_provided(self) -> None:
-        """Correlation ID is NOT present when not explicitly provided (Story 1.34).
+    def test_correlation_id_null_when_not_provided(self) -> None:
+        """Correlation ID is None when not explicitly provided (Story 10.55).
 
-        The old behavior auto-generated a UUID for correlation_id. The new behavior
-        only includes correlation_id when explicitly set via context variable.
-        message_id is now used for unique per-message identification.
+        The schema always includes correlation_id for stability. It is None
+        when no correlation context is active.
         """
         envelope = build_envelope(
             level="INFO",
             message="test",
         )
 
-        # correlation_id should NOT be present when not explicitly set
-        assert "correlation_id" not in envelope["context"]
+        assert envelope["context"]["correlation_id"] is None
         # message_id should always be present
         assert "message_id" in envelope["context"]
 

--- a/tests/unit/test_logger_core.py
+++ b/tests/unit/test_logger_core.py
@@ -165,7 +165,7 @@ class TestCorrelationId:
     """Tests for correlation ID generation."""
 
     @pytest.mark.asyncio
-    async def test_correlation_id_absent_when_not_set(self) -> None:
+    async def test_correlation_id_null_when_not_set(self) -> None:
         captured: list[dict[str, Any]] = []
 
         logger = get_logger(name="test")
@@ -181,12 +181,12 @@ class TestCorrelationId:
 
         assert captured, "Expected at least one emitted entry"
         event = captured[0]
-        # Story 1.34: correlation_id only present when explicitly set
+        # Story 10.55: correlation_id always present, None when unset
         assert "context" in event
-        assert "correlation_id" not in event["context"]
+        assert event["context"]["correlation_id"] is None
 
     @pytest.mark.asyncio
-    async def test_context_propagation_and_absent_without(self) -> None:
+    async def test_context_propagation_and_null_without(self) -> None:
         captured: list[dict[str, Any]] = []
         logger = get_logger(name="ctx-test")
 
@@ -202,7 +202,7 @@ class TestCorrelationId:
         finally:
             request_id_var.reset(token)
 
-        # No request id -> correlation_id absent (Story 1.34)
+        # No request id -> correlation_id is None (Story 10.55)
         logger.info("b")
 
         await logger.stop_and_drain()
@@ -210,7 +210,7 @@ class TestCorrelationId:
         assert len(captured) >= 2
         a, b = captured[0], captured[1]
         assert a["context"]["correlation_id"] == "req-123"
-        assert "correlation_id" not in b["context"]
+        assert b["context"]["correlation_id"] is None
 
 
 class TestBatchAndDrain:

--- a/tests/unit/test_message_id.py
+++ b/tests/unit/test_message_id.py
@@ -47,11 +47,11 @@ class TestMessageIdAlwaysPresent:
 class TestCorrelationIdOnlyWhenExplicitlySet:
     """AC2: correlation_id only appears when explicitly set."""
 
-    def test_correlation_id_absent_without_context(self) -> None:
-        """correlation_id is NOT present when not explicitly set."""
+    def test_correlation_id_null_without_context(self) -> None:
+        """correlation_id is None when not explicitly set (Story 10.55)."""
         envelope = build_envelope(level="INFO", message="test")
 
-        assert "correlation_id" not in envelope["context"]
+        assert envelope["context"]["correlation_id"] is None
 
     def test_correlation_id_present_when_explicitly_set(self) -> None:
         """correlation_id appears when explicitly provided."""

--- a/tests/unit/test_public_api_runtime.py
+++ b/tests/unit/test_public_api_runtime.py
@@ -40,7 +40,7 @@ def test_get_logger_basic_enqueue_and_stdout_json():
         sys.stdout = orig  # type: ignore[assignment]
 
 
-def test_get_logger_omits_correlation_id_when_unset():
+def test_get_logger_has_null_correlation_id_when_unset():
     # Capture stdout
     buf = io.BytesIO()
     orig = sys.stdout
@@ -66,8 +66,8 @@ def test_get_logger_omits_correlation_id_when_unset():
         assert js["message"] == "hello"
         assert js["level"] == "INFO"
         assert js["logger"] == "corr-test"
-        # Story 1.34: correlation_id is absent when not explicitly set
-        assert "correlation_id" not in js.get("context", {})
+        # Story 10.55: correlation_id always present, null when unset
+        assert js.get("context", {}).get("correlation_id") is None
     finally:
         sys.stdout = orig  # type: ignore[assignment]
 


### PR DESCRIPTION
## Summary

The envelope previously omitted `correlation_id` entirely when no correlation context was set, creating schema instability for downstream consumers. This change makes `correlation_id` always present in the `context` dict — set to `null` when no correlation context is active, and populated with the context value when set.

## Changes

- `src/fapilog/core/envelope.py` (modified) — remove conditional guard; always assign `correlation_id`
- `schemas/log_envelope_v1.json` (modified) — type `"string"` → `["string", "null"]`, added to `required`
- `docs/schema-guide.md` (modified) — auto-regenerated from schema
- `docs/core-concepts/envelope.md` (modified) — describe field as always present (nullable)
- `docs/schema-migration-v1.0-to-v1.1.md` (modified) — add `message_id`/`correlation_id` to context schema
- `docs/architecture/built-in-core-features.md` (modified) — update correlation_id description
- `docs/architecture/coding-standards.md` (modified) — update propagation guidance
- `tests/unit/envelope/test_envelope_v1_1.py` (modified) — absence check → null assertion
- `tests/unit/test_envelope.py` (modified) — absence check → null assertion
- `tests/unit/test_message_id.py` (modified) — absence check → null assertion
- `tests/unit/test_logger_core.py` (modified) — absence checks → null assertions
- `tests/unit/test_public_api_runtime.py` (modified) — absence check → null assertion

## Acceptance Criteria

- [x] The `context` dict always contains `correlation_id`, set to `null` when no correlation context is active
- [x] When correlation context is set, `correlation_id` contains the context value
- [x] Envelopes with `correlation_id: null` serialize and deserialize correctly through all sinks
- [x] Existing downstream code using `.get("correlation_id")` continues to work
- [x] Every test that previously checked `"correlation_id" not in context` now asserts `context["correlation_id"] is None`
- [x] Envelope docs, schema guide, and architecture docs describe `correlation_id` as always present (nullable). JSON schema changes type from `"string"` to `["string", "null"]`

## Test Plan

- [x] Unit tests pass (2981 passed)
- [x] Contract tests pass (schema validation + type contract)
- [x] diff-cover 100% on changed production code
- [x] `grep -rn '"correlation_id" not in.*\["context"\]' tests/` returns 0 matches
- [x] ruff, mypy, vulture all pass

## Story

[10.55 - Always Emit correlation_id in Envelope for Stable Schema](docs/stories/10.55.stable-correlation-id-field.md)