### PR TITLE
fix(sinks): fix Postgres sink field extraction for v1.1 schema

### DIFF
--- a/docs/plugins/sinks/postgres.md
+++ b/docs/plugins/sinks/postgres.md
@@ -107,11 +107,13 @@ CREATE TABLE IF NOT EXISTS public.logs (
 );
 ```
 
+The `correlation_id` column is extracted from `entry["context"]["correlation_id"]` (v1.1 schema). When no correlation context is active, the column is `NULL`.
+
 Indexes:
 
 - `timestamp DESC` for time range queries
 - `level` for severity filters
-- `correlation_id` for tracing
+- `correlation_id` for tracing (partial index, excludes NULLs)
 - `event` GIN index when `use_jsonb=True`
 
 ## Query examples

--- a/src/fapilog/plugins/sinks/contrib/postgres.py
+++ b/src/fapilog/plugins/sinks/contrib/postgres.py
@@ -260,6 +260,8 @@ class PostgresSink(BatchingMixin):
                 values.append(entry.get("logger", "root"))
             elif column == "message":
                 values.append(entry.get("message", ""))
+            elif column == "correlation_id":
+                values.append(entry.get("context", {}).get("correlation_id"))
             elif column == "event":
                 # asyncpg requires JSON string for JSONB columns, not Python dict
                 values.append(json.dumps(event_payload, default=str))

--- a/tests/integration/test_postgres_sink.py
+++ b/tests/integration/test_postgres_sink.py
@@ -111,7 +111,7 @@ class TestPostgresSinkIntegration:
         await sink.start()
         await sink.write_serialized(
             SerializedView(
-                data=b'{"level":"ERROR","message":"serialized","correlation_id":"abc-1"}'
+                data=b'{"level":"ERROR","message":"serialized","context":{"correlation_id":"abc-1"}}'
             )
         )
         await sink.stop()


### PR DESCRIPTION
## Summary

The Postgres sink extracted `correlation_id` from the envelope root (`entry.get("correlation_id")`), which was correct under the v1.0 schema. After the v1.1 schema migration, `correlation_id` moved to `entry["context"]["correlation_id"]`, causing the column to always be `NULL`. This fixes the extraction path and updates all tests to use v1.1-shaped data.

## Changes

- `src/fapilog/plugins/sinks/contrib/postgres.py` (modified) — add `correlation_id` case to `_prepare_row()` reading from `entry["context"]`
- `tests/unit/test_postgres_sink_unit.py` (modified) — update existing test to v1.1 shape, add contract test with `build_envelope()`, add null correlation_id test
- `tests/integration/test_postgres_sink.py` (modified) — update hand-crafted JSON to v1.1 shape
- `docs/plugins/sinks/postgres.md` (modified) — document correlation_id extraction from context

## Acceptance Criteria

- [x] `_prepare_row()` reads `correlation_id` from `entry["context"]["correlation_id"]`
- [x] Column receives `None` when no correlation context is set
- [x] Contract test feeds real `build_envelope()` output through the sink
- [x] Unit and integration tests use v1.1-shaped data

## Test Plan

- [x] Unit tests pass (36/36)
- [x] Contract test validates all 5 extracted columns against `build_envelope()` output
- [x] diff-cover 100% on changed lines
- [x] ruff, mypy, vulture all pass

## Story

[1.42 - Fix Postgres Sink Field Extraction for v1.1 Schema](docs/stories/1.42.postgres-sink-v1.1-field-extraction.md)