### PR TITLE
feat(core): add Literal type hints for preset name parameters

### DIFF
--- a/src/fapilog/__init__.py
+++ b/src/fapilog/__init__.py
@@ -38,6 +38,7 @@ from .core.levels import register_level
 from .core.logger import AsyncLoggerFacade as _AsyncLoggerFacade
 from .core.logger import DrainResult
 from .core.logger import SyncLoggerFacade as _SyncLoggerFacade
+from .core.presets import PresetName as PresetName
 from .core.presets import list_presets
 from .core.settings import Settings as _Settings
 from .core.shutdown import install_shutdown_handlers
@@ -48,6 +49,7 @@ from .plugins.filters.level import LEVEL_PRIORITY as _LEVEL_PRIORITY
 from .plugins.processors import BaseProcessor as _BaseProcessor
 from .plugins.redactors import BaseRedactor as _BaseRedactor
 from .plugins.sinks.stdout_json import StdoutJsonSink as _StdoutJsonSink
+from .redaction.presets import RedactionPresetName as RedactionPresetName
 
 # Public exports
 Settings = _Settings
@@ -63,6 +65,8 @@ __all__ = [
     "list_presets",
     "LoggerBuilder",
     "AsyncLoggerBuilder",
+    "PresetName",
+    "RedactionPresetName",
     "sinks",
     "get_cached_loggers",
     "clear_logger_cache",
@@ -122,7 +126,7 @@ def _apply_plugin_settings(settings: _Settings) -> None:
 def _apply_default_log_level(
     settings: _Settings,
     *,
-    preset: str | None,
+    preset: PresetName | None,
 ) -> _Settings:
     if preset is not None:
         return settings
@@ -569,7 +573,7 @@ def _apply_logger_extras(
 def _prepare_logger(
     name: str | None,
     *,
-    preset: str | None,
+    preset: PresetName | None,
     format: _Literal["json", "pretty", "auto"] | None,
     settings: _Settings | None,
     sinks: list[object] | None,
@@ -817,7 +821,7 @@ def _create_and_start_facade(
 def get_logger(
     name: str | None = None,
     *,
-    preset: str | None = None,
+    preset: PresetName | None = None,
     format: _Literal["json", "pretty", "auto"] | None = None,
     settings: _Settings | None = None,
     sinks: list[object] | None = None,
@@ -904,7 +908,7 @@ def get_logger(
 async def get_async_logger(
     name: str | None = None,
     *,
-    preset: str | None = None,
+    preset: PresetName | None = None,
     format: _Literal["json", "pretty", "auto"] | None = None,
     settings: _Settings | None = None,
     sinks: list[object] | None = None,

--- a/src/fapilog/builder.py
+++ b/src/fapilog/builder.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from typing_extensions import Self
 
+from .core.presets import PresetName
+from .redaction.presets import RedactionPresetName
+
 if TYPE_CHECKING:
     from .core.logger import AsyncLoggerFacade, SyncLoggerFacade
 
@@ -34,7 +37,7 @@ class LoggerBuilder:
         return list_redaction_presets()
 
     @staticmethod
-    def get_redaction_preset_info(name: str) -> dict[str, Any]:
+    def get_redaction_preset_info(name: RedactionPresetName) -> dict[str, Any]:
         """Get detailed information about a redaction preset.
 
         Args:
@@ -78,7 +81,7 @@ class LoggerBuilder:
     def __init__(self) -> None:
         self._config: dict[str, Any] = {}
         self._name: str | None = None
-        self._preset: str | None = None
+        self._preset: PresetName | None = None
         self._sinks: list[dict[str, Any]] = []
         self._reuse: bool = True
 
@@ -112,7 +115,7 @@ class LoggerBuilder:
         self._config.setdefault("core", {})["log_level"] = level.upper()
         return self
 
-    def with_preset(self, preset: str) -> Self:
+    def with_preset(self, preset: PresetName) -> Self:
         """Apply preset configuration.
 
         Preset is applied first, then subsequent methods override.
@@ -296,7 +299,7 @@ class LoggerBuilder:
     def with_redaction(
         self,
         *,
-        preset: str | list[str] | None = None,
+        preset: RedactionPresetName | list[RedactionPresetName] | None = None,
         fields: list[str] | None = None,
         patterns: list[str] | None = None,
         mask: str = "***",

--- a/src/fapilog/core/presets.py
+++ b/src/fapilog/core/presets.py
@@ -3,7 +3,18 @@
 from __future__ import annotations
 
 import copy
-from typing import Any
+from typing import Any, Literal
+
+PresetName = Literal[
+    "dev",
+    "fastapi",
+    "hardened",
+    "high-volume",
+    "minimal",
+    "production",
+    "production-latency",
+    "serverless",
+]
 
 PRESETS: dict[str, dict[str, Any]] = {
     "dev": {
@@ -206,7 +217,7 @@ PRESETS: dict[str, dict[str, Any]] = {
 }
 
 
-def validate_preset(name: str) -> None:
+def validate_preset(name: PresetName) -> None:
     """Validate preset name.
 
     Args:
@@ -220,7 +231,7 @@ def validate_preset(name: str) -> None:
         raise ValueError(f"Invalid preset '{name}'. Valid presets: {valid}")
 
 
-def get_preset(name: str) -> dict[str, Any]:
+def get_preset(name: PresetName) -> dict[str, Any]:
     """Get preset configuration by name.
 
     Args:

--- a/src/fapilog/fastapi/setup.py
+++ b/src/fapilog/fastapi/setup.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncContextManager, AsyncIterator, Callable
 
 from ..core.diagnostics import warn
+from ..core.presets import PresetName
 
 try:
     from fastapi import FastAPI
@@ -114,7 +115,7 @@ async def _drain_logger(logger: Any, *, timeout: _DrainTimeout = 5.0) -> None:
 def setup_logging(
     app: FastAPI | None = None,
     *,
-    preset: str | None = None,
+    preset: PresetName | None = None,
     skip_paths: list[str] | None = None,
     sample_rate: float = 1.0,
     redact_headers: list[str] | None = None,

--- a/src/fapilog/redaction/presets.py
+++ b/src/fapilog/redaction/presets.py
@@ -8,6 +8,23 @@ combined at runtime.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
+
+RedactionPresetName = Literal[
+    "CCPA_PII",
+    "CONTACT_INFO",
+    "CREDENTIALS",
+    "EU_GOVERNMENT_IDS",
+    "FINANCIAL_IDENTIFIERS",
+    "GDPR_PII",
+    "GDPR_PII_UK",
+    "HIPAA_PHI",
+    "ONLINE_IDENTIFIERS",
+    "PCI_DSS",
+    "PERSONAL_IDENTIFIERS",
+    "UK_GOVERNMENT_IDS",
+    "US_GOVERNMENT_IDS",
+]
 
 
 @dataclass(frozen=True)

--- a/src/fapilog/redaction/registry.py
+++ b/src/fapilog/redaction/registry.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from .presets import BUILTIN_PRESETS, RedactionPreset
+from .presets import BUILTIN_PRESETS, RedactionPreset, RedactionPresetName
 
 
-def get_redaction_preset(name: str) -> RedactionPreset:
+def get_redaction_preset(name: RedactionPresetName) -> RedactionPreset:
     """Get a preset by name.
 
     Args:
@@ -38,7 +38,9 @@ def list_redaction_presets() -> list[str]:
 
 
 @lru_cache(maxsize=32)
-def resolve_preset_fields(name: str) -> tuple[frozenset[str], frozenset[str]]:
+def resolve_preset_fields(
+    name: RedactionPresetName,
+) -> tuple[frozenset[str], frozenset[str]]:
     """Resolve all fields and patterns including inherited ones.
 
     Cached for performance - inheritance resolution happens once per preset.

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -684,6 +684,27 @@ class TestHighVolumePreset:
         assert settings.core.worker_count == 2
 
 
+class TestPresetNameLiteral:
+    """Test PresetName Literal type alias stays in sync with registry."""
+
+    def test_preset_name_literal_matches_registry(self) -> None:
+        """PresetName Literal values must exactly match PRESETS dict keys."""
+        from typing import get_args
+
+        from fapilog.core.presets import PRESETS, PresetName
+
+        assert set(get_args(PresetName)) == set(PRESETS.keys())
+
+    def test_preset_name_exported_from_package(self) -> None:
+        """PresetName is importable from top-level fapilog package."""
+        from typing import get_args
+
+        from fapilog import PresetName
+
+        # Verify it's the same type, not an empty re-export
+        assert len(get_args(PresetName)) == 8
+
+
 class TestPresetImmutability:
     """Test that get_preset returns copies, not references."""
 

--- a/tests/unit/test_redaction_presets.py
+++ b/tests/unit/test_redaction_presets.py
@@ -186,6 +186,27 @@ class TestPresetInheritance:
             preset_a.resolve(registry)
 
 
+class TestRedactionPresetNameLiteral:
+    """Test RedactionPresetName Literal type alias stays in sync with registry."""
+
+    def test_redaction_preset_name_literal_matches_registry(self) -> None:
+        """RedactionPresetName Literal values must exactly match BUILTIN_PRESETS keys."""
+        from typing import get_args
+
+        from fapilog.redaction.presets import BUILTIN_PRESETS, RedactionPresetName
+
+        assert set(get_args(RedactionPresetName)) == set(BUILTIN_PRESETS.keys())
+
+    def test_redaction_preset_name_exported_from_package(self) -> None:
+        """RedactionPresetName is importable from top-level fapilog package."""
+        from typing import get_args
+
+        from fapilog import RedactionPresetName
+
+        # Verify it's the same type, not an empty re-export
+        assert len(get_args(RedactionPresetName)) == 13
+
+
 class TestPresetFiltering:
     """Tests for preset filtering functions."""
 


### PR DESCRIPTION
## Summary

All preset parameters across the public API were typed as plain `str`, providing no IDE autocomplete, no static type checking, and no inline documentation of valid values. This adds `PresetName` and `RedactionPresetName` Literal type aliases so users get autocomplete and mypy checking without needing any new imports — they keep passing plain strings.

## Changes

- `src/fapilog/core/presets.py` (modified) — add `PresetName` Literal type alias, update `validate_preset()` and `get_preset()` signatures
- `src/fapilog/redaction/presets.py` (modified) — add `RedactionPresetName` Literal type alias
- `src/fapilog/redaction/registry.py` (modified) — update `get_redaction_preset()` and `resolve_preset_fields()` signatures
- `src/fapilog/builder.py` (modified) — update `with_preset()`, `with_redaction()`, `get_redaction_preset_info()`, and `self._preset` type
- `src/fapilog/__init__.py` (modified) — update `get_logger()`, `get_async_logger()`, internal helpers; re-export type aliases in `__all__`
- `src/fapilog/fastapi/setup.py` (modified) — update `setup_logging()` preset parameter
- `tests/unit/test_presets.py` (modified) — add sync-check and export tests for `PresetName`
- `tests/unit/test_redaction_presets.py` (modified) — add sync-check and export tests for `RedactionPresetName`

## Acceptance Criteria

- [x] `PresetName` Literal covers all 8 configuration presets
- [x] `RedactionPresetName` Literal covers all 13 redaction presets
- [x] All public API signatures updated to use Literal types
- [x] Runtime behavior unchanged — validation still raises `ValueError` for invalid presets
- [x] Type aliases exported from top-level `fapilog` package
- [x] Sync-check tests prevent Literal/registry drift

## Test Plan

- [x] Unit tests pass (130 in preset/redaction test files)
- [x] Full regression suite passes (250 tests across preset, builder, and integration files)
- [x] mypy passes with 0 errors across all 6 changed source files
- [x] diff-cover 94% >= 90% threshold
- [x] ruff check + format clean
- [x] No weak assertions
- [x] vulture clean

## Story

[10.56 - Literal Type Hints for Preset Names](docs/stories/10.56.literal-type-hints-for-preset-names.md)