### PR TITLE
feat(core): add adaptive filter tightening on pressure escalation

### DIFF
--- a/src/fapilog/core/filter_ladder.py
+++ b/src/fapilog/core/filter_ladder.py
@@ -1,0 +1,117 @@
+"""Adaptive filter ladder builder (Story 1.45).
+
+Pre-builds filter tuples for each pressure level at startup.
+Workers pick up the active tuple via lock-free snapshot swap.
+
+Escalation ladder:
+  NORMAL   — user-configured filters unchanged
+  ELEVATED — tighten adaptive sampling (halve target_eps or inject one)
+  HIGH     — inject WARNING-level gate (drop DEBUG/INFO)
+  CRITICAL — protected-levels-only gate
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .pressure import PressureLevel
+
+
+def build_filter_ladder(
+    base_filters: list[Any],
+    protected_levels: frozenset[str],
+) -> dict[PressureLevel, tuple[Any, ...]]:
+    """Pre-build filter tuples for each pressure level.
+
+    Args:
+        base_filters: User-configured filter instances (NORMAL level).
+        protected_levels: Level names that must always pass (e.g. ERROR, CRITICAL).
+
+    Returns:
+        Dict mapping each PressureLevel to an immutable tuple of filter instances.
+    """
+    return {
+        PressureLevel.NORMAL: tuple(base_filters),
+        PressureLevel.ELEVATED: _build_elevated_filters(base_filters, protected_levels),
+        PressureLevel.HIGH: _build_high_filters(base_filters),
+        PressureLevel.CRITICAL: _build_critical_filters(protected_levels),
+    }
+
+
+def _build_elevated_filters(
+    base_filters: list[Any],
+    protected_levels: frozenset[str],
+) -> tuple[Any, ...]:
+    """ELEVATED: tighten or inject adaptive sampling.
+
+    If user already has an AdaptiveSamplingFilter, create a copy with halved
+    target_eps. Otherwise inject a new one with target_eps=50.
+    """
+    from ..plugins.filters.adaptive_sampling import (
+        AdaptiveSamplingConfig,
+        AdaptiveSamplingFilter,
+    )
+
+    result: list[Any] = []
+    found_adaptive = False
+
+    for f in base_filters:
+        if isinstance(f, AdaptiveSamplingFilter):
+            found_adaptive = True
+            tightened = AdaptiveSamplingFilter(
+                config=AdaptiveSamplingConfig(
+                    target_eps=f._target_eps / 2.0,
+                    min_sample_rate=f._min_rate,
+                    max_sample_rate=f._max_rate,
+                    window_seconds=f._window,
+                    always_pass_levels=sorted(f._always_pass | protected_levels),
+                    smoothing_factor=f._smoothing,
+                )
+            )
+            result.append(tightened)
+        else:
+            result.append(f)
+
+    if not found_adaptive:
+        injected = AdaptiveSamplingFilter(
+            config=AdaptiveSamplingConfig(
+                target_eps=50.0,
+                always_pass_levels=sorted(protected_levels),
+            )
+        )
+        result.append(injected)
+
+    return tuple(result)
+
+
+def _build_high_filters(base_filters: list[Any]) -> tuple[Any, ...]:
+    """HIGH: inject WARNING-level gate before user filters.
+
+    Drops everything below WARNING (DEBUG, INFO) post-dequeue.
+    """
+    from ..plugins.filters.level import LevelFilter, LevelFilterConfig
+
+    warning_gate = LevelFilter(config=LevelFilterConfig(min_level="WARNING"))
+    return (warning_gate, *base_filters)
+
+
+def _build_critical_filters(protected_levels: frozenset[str]) -> tuple[Any, ...]:
+    """CRITICAL: allow only protected levels.
+
+    Finds the minimum priority among protected levels and creates a
+    single level filter at that threshold.
+    """
+    from ..plugins.filters.level import LevelFilter, LevelFilterConfig
+    from .levels import get_level_priority
+
+    if not protected_levels:
+        # No protected levels — block everything by using FATAL
+        return (LevelFilter(config=LevelFilterConfig(min_level="FATAL")),)
+
+    # Find the lowest priority among protected levels
+    min_priority_level = min(protected_levels, key=get_level_priority)
+    return (LevelFilter(config=LevelFilterConfig(min_level=min_priority_level)),)
+
+
+# Mark public API for vulture (Story 1.45)
+_VULTURE_USED: tuple[object, ...] = (build_filter_ladder,)

--- a/tests/integration/test_adaptive_filter_tightening.py
+++ b/tests/integration/test_adaptive_filter_tightening.py
@@ -1,0 +1,297 @@
+"""Integration tests for adaptive filter tightening (Story 1.45).
+
+Tests that the filter ladder is built at startup when adaptive is enabled,
+the pressure callback swaps filter snapshots, and de-escalation restores them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fapilog.core.logger import SyncLoggerFacade
+from fapilog.core.pressure import PressureLevel, PressureMonitor
+from fapilog.plugins.filters.adaptive_sampling import AdaptiveSamplingFilter
+from fapilog.plugins.filters.level import LevelFilter, LevelFilterConfig
+
+
+async def _noop_sink(entry: dict[str, Any]) -> None:
+    pass
+
+
+def _make_logger(**overrides: Any) -> SyncLoggerFacade:
+    defaults: dict[str, Any] = {
+        "name": "t-filter-tightening",
+        "queue_capacity": 100,
+        "batch_max_size": 8,
+        "batch_timeout_seconds": 0.05,
+        "backpressure_wait_ms": 10,
+        "drop_on_full": True,
+        "sink_write": _noop_sink,
+    }
+    defaults.update(overrides)
+    return SyncLoggerFacade(**defaults)
+
+
+class TestFilterLadderBuiltAtStartup:
+    """AC1: Filter tuples pre-built at startup when adaptive enabled."""
+
+    @pytest.mark.asyncio
+    async def test_ladder_built_when_adaptive_enabled(self) -> None:
+        """Logger builds _adaptive_filter_ladder dict on start()."""
+        from fapilog.core.settings import AdaptiveSettings
+
+        logger = _make_logger()
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        logger.start()
+
+        assert hasattr(logger, "_adaptive_filter_ladder")
+        assert isinstance(logger._adaptive_filter_ladder, dict)
+        assert set(logger._adaptive_filter_ladder.keys()) == {
+            PressureLevel.NORMAL,
+            PressureLevel.ELEVATED,
+            PressureLevel.HIGH,
+            PressureLevel.CRITICAL,
+        }
+
+        await logger.stop_and_drain()
+
+    @pytest.mark.asyncio
+    async def test_ladder_not_built_when_adaptive_disabled(self) -> None:
+        """Logger does not build ladder when adaptive is disabled."""
+        logger = _make_logger()
+        logger.start()
+
+        assert (
+            not hasattr(logger, "_adaptive_filter_ladder")
+            or logger._adaptive_filter_ladder is None
+        )
+
+        await logger.stop_and_drain()
+
+
+class TestFilterSwapOnPressureChange:
+    """AC6: Filter swap via existing cache invalidation on level change."""
+
+    @pytest.mark.asyncio
+    async def test_callback_swaps_filters_snapshot(self) -> None:
+        """Pressure change callback sets _filters_snapshot to the ladder entry."""
+        from fapilog.core.settings import AdaptiveSettings
+
+        user_filter = LevelFilter(config=LevelFilterConfig(min_level="INFO"))
+        logger = _make_logger(filters=[user_filter])
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        logger.start()
+        original_snapshot = logger._filters_snapshot
+
+        # Verify NORMAL snapshot matches user filters
+        assert user_filter in original_snapshot
+
+        # Simulate pressure escalation by calling the registered callback
+        monitor = logger._pressure_monitor
+        assert isinstance(monitor, PressureMonitor)
+        assert len(monitor._callbacks) == 1
+
+        # Fire the callback for NORMAL -> ELEVATED
+        for cb in monitor._callbacks:
+            cb(PressureLevel.NORMAL, PressureLevel.ELEVATED)
+
+        # Snapshot should now be the ELEVATED ladder entry
+        elevated_snapshot = logger._filters_snapshot
+        assert elevated_snapshot is not original_snapshot
+        adaptive_filters = [
+            f for f in elevated_snapshot if isinstance(f, AdaptiveSamplingFilter)
+        ]
+        assert len(adaptive_filters) == 1
+
+        await logger.stop_and_drain()
+
+
+class TestDeescalationRestoresFilters:
+    """AC7: De-escalation restores previous filter set."""
+
+    @pytest.mark.asyncio
+    async def test_deescalation_restores_normal_filters(self) -> None:
+        """ELEVATED -> NORMAL restores user-configured filters."""
+        from fapilog.core.settings import AdaptiveSettings
+
+        user_filter = LevelFilter(config=LevelFilterConfig(min_level="INFO"))
+        logger = _make_logger(filters=[user_filter])
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        logger.start()
+        normal_snapshot = logger._filters_snapshot
+
+        monitor = logger._pressure_monitor
+        assert isinstance(monitor, PressureMonitor)
+
+        # Escalate then de-escalate
+        for cb in monitor._callbacks:
+            cb(PressureLevel.NORMAL, PressureLevel.ELEVATED)
+        assert logger._filters_snapshot is not normal_snapshot
+
+        for cb in monitor._callbacks:
+            cb(PressureLevel.ELEVATED, PressureLevel.NORMAL)
+        restored = logger._filters_snapshot
+        assert restored == normal_snapshot
+
+        await logger.stop_and_drain()
+
+    @pytest.mark.asyncio
+    async def test_critical_to_high_restores_high_filters(self) -> None:
+        """CRITICAL -> HIGH restores HIGH-level filters."""
+        from fapilog.core.settings import AdaptiveSettings
+
+        logger = _make_logger()
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        logger.start()
+        ladder = logger._adaptive_filter_ladder
+
+        monitor = logger._pressure_monitor
+        assert isinstance(monitor, PressureMonitor)
+
+        # Jump to CRITICAL
+        for cb in monitor._callbacks:
+            cb(PressureLevel.HIGH, PressureLevel.CRITICAL)
+        assert logger._filters_snapshot == ladder[PressureLevel.CRITICAL]
+
+        # De-escalate to HIGH
+        for cb in monitor._callbacks:
+            cb(PressureLevel.CRITICAL, PressureLevel.HIGH)
+        assert logger._filters_snapshot == ladder[PressureLevel.HIGH]
+
+        await logger.stop_and_drain()
+
+
+class TestDiagnosticOnFilterSwap:
+    """AC8: Diagnostic emitted on filter swap."""
+
+    @pytest.mark.asyncio
+    async def test_diagnostic_emitted_on_swap(self) -> None:
+        """Filter swap emits a diagnostic via diagnostics.warn()."""
+        from fapilog.core.settings import AdaptiveSettings
+
+        logger = _make_logger()
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        emitted: list[dict[str, Any]] = []
+        original_warn = None
+
+        import fapilog.core.diagnostics as diag_mod
+
+        original_warn = diag_mod.warn
+
+        def capture_warn(component: str, message: str, **fields: Any) -> None:
+            emitted.append({"component": component, "message": message, **fields})
+
+        diag_mod.warn = capture_warn  # type: ignore[assignment]
+        try:
+            logger.start()
+
+            monitor = logger._pressure_monitor
+            assert isinstance(monitor, PressureMonitor)
+
+            for cb in monitor._callbacks:
+                cb(PressureLevel.NORMAL, PressureLevel.ELEVATED)
+
+            # Should have captured a diagnostic about filter tightening
+            filter_diags = [
+                d
+                for d in emitted
+                if "adaptive-controller" in d.get("component", "")
+                and "filter" in d.get("message", "").lower()
+            ]
+            assert len(filter_diags) == 1
+            assert filter_diags[0]["pressure_level"] == "elevated"
+        finally:
+            diag_mod.warn = original_warn  # type: ignore[assignment]
+
+        await logger.stop_and_drain()
+
+    @pytest.mark.asyncio
+    async def test_diagnostic_failure_does_not_break_swap(self) -> None:
+        """If diagnostics.warn raises, filter swap still succeeds."""
+        from fapilog.core.settings import AdaptiveSettings
+
+        logger = _make_logger()
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        import fapilog.core.diagnostics as diag_mod
+
+        original_warn = diag_mod.warn
+
+        def broken_warn(component: str, message: str, **fields: Any) -> None:
+            raise RuntimeError("boom")
+
+        diag_mod.warn = broken_warn  # type: ignore[assignment]
+        try:
+            logger.start()
+            ladder = logger._adaptive_filter_ladder
+
+            monitor = logger._pressure_monitor
+            assert isinstance(monitor, PressureMonitor)
+
+            # Fire callback — diagnostic will fail but swap should succeed
+            for cb in monitor._callbacks:
+                cb(PressureLevel.NORMAL, PressureLevel.HIGH)
+
+            assert logger._filters_snapshot == ladder[PressureLevel.HIGH]
+        finally:
+            diag_mod.warn = original_warn  # type: ignore[assignment]
+
+        await logger.stop_and_drain()
+
+
+class TestLadderBuildFailOpen:
+    """Fail-open: ladder build failure doesn't block monitor startup."""
+
+    @pytest.mark.asyncio
+    async def test_ladder_failure_still_starts_monitor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If build_filter_ladder raises, monitor still starts."""
+        from fapilog.core.settings import AdaptiveSettings
+
+        logger = _make_logger()
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        import fapilog.core.filter_ladder as fl_mod
+
+        def broken_build(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("build failed")
+
+        monkeypatch.setattr(fl_mod, "build_filter_ladder", broken_build)
+
+        logger.start()
+
+        # Monitor should still be running despite ladder failure
+        assert isinstance(logger._pressure_monitor, PressureMonitor)
+        # Ladder should be None since build failed
+        assert logger._adaptive_filter_ladder is None
+
+        await logger.stop_and_drain()

--- a/tests/unit/test_filter_ladder.py
+++ b/tests/unit/test_filter_ladder.py
@@ -1,0 +1,234 @@
+"""Unit tests for adaptive filter ladder builder (Story 1.45)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fapilog.core.pressure import PressureLevel
+from fapilog.plugins.filters.adaptive_sampling import (
+    AdaptiveSamplingConfig,
+    AdaptiveSamplingFilter,
+)
+from fapilog.plugins.filters.level import LevelFilter, LevelFilterConfig
+
+
+class TestBuildFilterLadder:
+    """Tests for build_filter_ladder() factory."""
+
+    def test_ladder_contains_all_four_levels(self) -> None:
+        """Ladder returns a dict with all four PressureLevel keys."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        ladder = build_filter_ladder(
+            base_filters=[],
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        assert set(ladder.keys()) == {
+            PressureLevel.NORMAL,
+            PressureLevel.ELEVATED,
+            PressureLevel.HIGH,
+            PressureLevel.CRITICAL,
+        }
+
+    def test_all_ladder_entries_are_tuples(self) -> None:
+        """Each ladder entry is a tuple (immutable for lock-free swap)."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        ladder = build_filter_ladder(
+            base_filters=[],
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        for level, filters in ladder.items():
+            assert isinstance(filters, tuple), f"{level} entry is not a tuple"
+
+
+class TestNormalLevel:
+    """AC2: NORMAL level uses user-configured filters unchanged."""
+
+    def test_normal_level_matches_user_config(self) -> None:
+        """NORMAL level returns exact same filters as user configured."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        user_filters: list[Any] = [
+            LevelFilter(config=LevelFilterConfig(min_level="INFO")),
+        ]
+        ladder = build_filter_ladder(
+            base_filters=user_filters,
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        normal = ladder[PressureLevel.NORMAL]
+        assert len(normal) == 1
+        assert normal[0] is user_filters[0]
+
+    def test_normal_preserves_multiple_user_filters(self) -> None:
+        """NORMAL level preserves all user filters in order."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        f1 = LevelFilter(config=LevelFilterConfig(min_level="INFO"))
+        f2 = LevelFilter(config=LevelFilterConfig(min_level="DEBUG"))
+        ladder = build_filter_ladder(
+            base_filters=[f1, f2],
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        normal = ladder[PressureLevel.NORMAL]
+        assert normal == (f1, f2)
+
+
+class TestElevatedLevel:
+    """AC3: ELEVATED level tightens adaptive sampling."""
+
+    def test_elevated_injects_adaptive_sampling(self) -> None:
+        """When user has no adaptive sampling, ELEVATED injects one."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        user_filters: list[Any] = [
+            LevelFilter(config=LevelFilterConfig(min_level="INFO")),
+        ]
+        ladder = build_filter_ladder(
+            base_filters=user_filters,
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        elevated = ladder[PressureLevel.ELEVATED]
+        # Should contain original filters + injected adaptive sampling
+        adaptive_filters = [
+            f for f in elevated if isinstance(f, AdaptiveSamplingFilter)
+        ]
+        assert len(adaptive_filters) == 1
+        assert adaptive_filters[0]._target_eps == 50.0
+        # Protected levels should include user-configured protected levels
+        assert "ERROR" in adaptive_filters[0]._always_pass
+        assert "CRITICAL" in adaptive_filters[0]._always_pass
+
+    def test_elevated_tightens_existing_adaptive_sampling(self) -> None:
+        """When user already has adaptive sampling, ELEVATED halves its target_eps."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        user_adaptive = AdaptiveSamplingFilter(
+            config=AdaptiveSamplingConfig(target_eps=200.0)
+        )
+        user_filters: list[Any] = [user_adaptive]
+        ladder = build_filter_ladder(
+            base_filters=user_filters,
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        elevated = ladder[PressureLevel.ELEVATED]
+        adaptive_filters = [
+            f for f in elevated if isinstance(f, AdaptiveSamplingFilter)
+        ]
+        assert len(adaptive_filters) == 1
+        # Should be halved from user's 200.0
+        assert adaptive_filters[0]._target_eps == 100.0
+        # Should be a different instance (not mutating the user's filter)
+        assert adaptive_filters[0] is not user_adaptive
+
+    def test_elevated_preserves_user_filters(self) -> None:
+        """ELEVATED keeps non-adaptive user filters in place."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        level_f = LevelFilter(config=LevelFilterConfig(min_level="INFO"))
+        user_filters: list[Any] = [level_f]
+        ladder = build_filter_ladder(
+            base_filters=user_filters,
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        elevated = ladder[PressureLevel.ELEVATED]
+        assert level_f in elevated
+
+
+class TestHighLevel:
+    """AC4: HIGH level drops DEBUG and INFO entirely."""
+
+    def test_high_drops_debug_and_info(self) -> None:
+        """HIGH level injects a LevelFilter with min_level=WARNING."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        user_filters: list[Any] = [
+            LevelFilter(config=LevelFilterConfig(min_level="INFO")),
+        ]
+        ladder = build_filter_ladder(
+            base_filters=user_filters,
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        high = ladder[PressureLevel.HIGH]
+        # Should have a level filter that blocks below WARNING
+        level_filters = [f for f in high if isinstance(f, LevelFilter)]
+        assert len(level_filters) == 2  # injected WARNING gate + user's INFO filter
+        # The tightest level filter should block INFO
+        from fapilog.core.levels import get_level_priority
+
+        warning_priority = get_level_priority("WARNING")
+        has_warning_gate = any(
+            f._min_priority >= warning_priority for f in level_filters
+        )
+        assert has_warning_gate
+
+    def test_high_preserves_user_filters(self) -> None:
+        """HIGH level keeps remaining user filters after injecting level gate."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        user_level = LevelFilter(config=LevelFilterConfig(min_level="INFO"))
+        user_filters: list[Any] = [user_level]
+        ladder = build_filter_ladder(
+            base_filters=user_filters,
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        high = ladder[PressureLevel.HIGH]
+        # User filters should still be present
+        assert user_level in high
+
+
+class TestCriticalLevel:
+    """AC5: CRITICAL level allows only protected levels."""
+
+    def test_critical_allows_only_protected_levels(self) -> None:
+        """CRITICAL level creates a filter that only passes protected levels."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        protected = frozenset({"ERROR", "CRITICAL", "FATAL", "AUDIT", "SECURITY"})
+        ladder = build_filter_ladder(
+            base_filters=[],
+            protected_levels=protected,
+        )
+        critical = ladder[PressureLevel.CRITICAL]
+        # Should have exactly one level filter for protected-only
+        assert len(critical) == 1
+        assert isinstance(critical[0], LevelFilter)
+        # Verify it passes ERROR (priority 40) but not INFO (priority 20)
+        from fapilog.core.levels import get_level_priority
+
+        error_priority = get_level_priority("ERROR")
+        assert critical[0]._min_priority <= error_priority
+
+    def test_custom_protected_levels_respected(self) -> None:
+        """CRITICAL level respects custom protected_levels set."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        # Only FATAL protected
+        ladder = build_filter_ladder(
+            base_filters=[],
+            protected_levels=frozenset({"FATAL"}),
+        )
+        critical = ladder[PressureLevel.CRITICAL]
+        assert len(critical) == 1
+        from fapilog.core.levels import get_level_priority
+
+        fatal_priority = get_level_priority("FATAL")
+        assert critical[0]._min_priority == fatal_priority
+
+
+class TestElevatedWithEmptyFilters:
+    """Edge case: no user filters at all."""
+
+    def test_elevated_with_no_user_filters(self) -> None:
+        """ELEVATED still injects adaptive sampling when user has no filters."""
+        from fapilog.core.filter_ladder import build_filter_ladder
+
+        ladder = build_filter_ladder(
+            base_filters=[],
+            protected_levels=frozenset({"ERROR", "CRITICAL", "FATAL"}),
+        )
+        elevated = ladder[PressureLevel.ELEVATED]
+        adaptive_filters = [
+            f for f in elevated if isinstance(f, AdaptiveSamplingFilter)
+        ]
+        assert len(adaptive_filters) == 1


### PR DESCRIPTION
## Summary

Adds the highest-impact actuator for the adaptive pipeline: dynamically tightening filters based on queue pressure level. Pre-builds filter tuples at startup (one per pressure level) and swaps the active filter snapshot via lock-free callback when pressure changes.

Escalation ladder:
- **NORMAL** — user-configured filters unchanged
- **ELEVATED** — tighten adaptive sampling (halve target_eps or inject one)
- **HIGH** — inject WARNING-level gate (drop DEBUG/INFO)
- **CRITICAL** — protected-levels-only gate (ERROR, CRITICAL, FATAL, AUDIT, SECURITY)

## Changes

- `src/fapilog/core/filter_ladder.py` (new) — filter ladder builder with per-level constructors
- `src/fapilog/core/logger.py` (modified) — build ladder at startup, register swap callback with PressureMonitor
- `tests/unit/test_filter_ladder.py` (new) — 12 unit tests for ladder builder
- `tests/integration/test_adaptive_filter_tightening.py` (new) — 8 integration tests for wiring, swap, de-escalation, diagnostics

## Acceptance Criteria

- [x] Filter tuples pre-built at startup when adaptive mode enabled
- [x] NORMAL level uses user-configured filters unchanged
- [x] ELEVATED level tightens adaptive sampling (halve target_eps or inject target_eps=50)
- [x] HIGH level drops DEBUG and INFO via WARNING-level gate
- [x] CRITICAL level allows only protected levels
- [x] Filter swap via existing tuple-reference mechanism (no locks)
- [x] De-escalation restores previous level's filter set
- [x] Diagnostic emitted on each filter swap

## Test Plan

- [x] Unit tests for each ladder level (NORMAL, ELEVATED, HIGH, CRITICAL)
- [x] Integration test: ladder built at startup
- [x] Integration test: callback swaps filter snapshot
- [x] Integration test: de-escalation restores filters
- [x] Integration test: diagnostic emission on swap
- [x] Integration test: diagnostic failure doesn't break swap (fail-open)
- [x] Integration test: ladder build failure doesn't block monitor (fail-open)
- [x] ruff check, ruff format, mypy pass
- [x] diff-cover 98% on changed lines

## Story

[1.45 - Adaptive Filter Tightening](docs/stories/1.45.adaptive-filter-tightening.md)