### PR TITLE
feat(core): wire adaptive queue capacity growth on pressure escalation

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -13,6 +13,7 @@
 | `FAPILOG_ADAPTIVE__ESCALATE_TO_CRITICAL` | float | 0.92 | Fill ratio to escalate HIGH to CRITICAL |
 | `FAPILOG_ADAPTIVE__ESCALATE_TO_ELEVATED` | float | 0.6 | Fill ratio to escalate NORMAL to ELEVATED |
 | `FAPILOG_ADAPTIVE__ESCALATE_TO_HIGH` | float | 0.8 | Fill ratio to escalate ELEVATED to HIGH |
+| `FAPILOG_ADAPTIVE__MAX_QUEUE_GROWTH` | float | 4.0 | Maximum queue capacity as a multiplier of initial capacity (grow-only) |
 | `FAPILOG_ADAPTIVE__MAX_WORKERS` | int | 8 | Maximum number of workers when dynamic scaling is active |
 | `FAPILOG_CORE__APP_NAME` | str | fapilog | Logical application name |
 | `FAPILOG_CORE__ATEXIT_DRAIN_ENABLED` | bool | True | Register atexit handler to drain pending logs on normal process exit |

--- a/src/fapilog/core/concurrency.py
+++ b/src/fapilog/core/concurrency.py
@@ -228,6 +228,17 @@ class PriorityAwareQueue(Generic[T]):
         """Maximum live items the queue can hold."""
         return self._capacity
 
+    def grow_capacity(self, new_capacity: int) -> None:
+        """Increase queue capacity. Grow-only — ignored if new_capacity <= current.
+
+        Re-signals ``_space_available`` so blocked enqueuers wake up.
+        Thread-safe: CPython GIL makes the int write atomic.
+        """
+        if new_capacity <= self._capacity:
+            return
+        self._capacity = new_capacity
+        self._space_available.set()
+
     def qsize(self) -> int:
         """Return count of live (non-tombstoned) items."""
         return len(self._dq) - self._tombstone_count
@@ -443,3 +454,6 @@ __all__ = [
     "NonBlockingRingQueue",
     "PriorityAwareQueue",
 ]
+
+# Mark public API for vulture (Story 1.48)
+_VULTURE_USED: tuple[object, ...] = (PriorityAwareQueue.grow_capacity,)

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -609,6 +609,13 @@ class AdaptiveSettings(BaseModel):
         description="Maximum number of workers when dynamic scaling is active",
     )
 
+    # Queue capacity growth (Story 1.48)
+    max_queue_growth: float = Field(
+        default=4.0,
+        ge=1.0,
+        description="Maximum queue capacity as a multiplier of initial capacity (grow-only)",
+    )
+
     # De-escalation thresholds (fill ratio < threshold triggers level decrease)
     deescalate_from_critical: float = Field(
         default=0.75,

--- a/tests/integration/test_adaptive_queue_growth.py
+++ b/tests/integration/test_adaptive_queue_growth.py
@@ -1,0 +1,222 @@
+"""Integration tests for adaptive queue capacity growth (Story 1.48).
+
+Tests that the capacity growth callback is registered at startup,
+grows capacity on pressure escalation, respects ceiling, and does
+not shrink on de-escalation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fapilog.core.concurrency import PriorityAwareQueue
+from fapilog.core.pressure import PressureLevel, PressureMonitor
+from fapilog.core.settings import AdaptiveSettings
+
+
+async def _noop_sink(entry: dict[str, Any]) -> None:
+    pass
+
+
+def _make_logger(**overrides: Any) -> Any:
+    from fapilog.core.logger import SyncLoggerFacade
+
+    defaults: dict[str, Any] = {
+        "name": "t-queue-growth",
+        "queue_capacity": 100,
+        "batch_max_size": 8,
+        "batch_timeout_seconds": 0.05,
+        "backpressure_wait_ms": 10,
+        "drop_on_full": True,
+        "sink_write": _noop_sink,
+    }
+    defaults.update(overrides)
+    return SyncLoggerFacade(**defaults)
+
+
+class TestCapacityGrowthCallbackRegistered:
+    """Verify that the capacity growth callback is wired at startup."""
+
+    @pytest.mark.asyncio
+    async def test_callback_registered_when_adaptive_enabled(self) -> None:
+        logger = _make_logger()
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        logger.start()
+
+        monitor = logger._pressure_monitor
+        assert isinstance(monitor, PressureMonitor)
+        # At least 3 callbacks: filter, scaling, capacity growth
+        assert len(monitor._callbacks) >= 3
+
+        await logger.stop_and_drain()
+
+
+class TestCapacityGrowsOnEscalation:
+    """AC4: Controller grows capacity proportionally to pressure level."""
+
+    @pytest.mark.asyncio
+    async def test_capacity_grows_on_elevated(self) -> None:
+        logger = _make_logger(queue_capacity=100)
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        logger.start()
+        queue = logger._queue
+        assert isinstance(queue, PriorityAwareQueue)
+        assert queue.capacity == 100
+
+        monitor = logger._pressure_monitor
+        for cb in monitor._callbacks:
+            cb(PressureLevel.NORMAL, PressureLevel.ELEVATED)
+
+        # ELEVATED = 1.25x initial → 125
+        assert queue.capacity == 125
+
+        await logger.stop_and_drain()
+
+    @pytest.mark.asyncio
+    async def test_capacity_grows_on_high(self) -> None:
+        logger = _make_logger(queue_capacity=100)
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        logger.start()
+        queue = logger._queue
+
+        monitor = logger._pressure_monitor
+        for cb in monitor._callbacks:
+            cb(PressureLevel.NORMAL, PressureLevel.HIGH)
+
+        # HIGH = 1.5x initial → 150
+        assert queue.capacity == 150
+
+        await logger.stop_and_drain()
+
+    @pytest.mark.asyncio
+    async def test_capacity_grows_on_critical(self) -> None:
+        logger = _make_logger(queue_capacity=100)
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        logger.start()
+        queue = logger._queue
+
+        monitor = logger._pressure_monitor
+        for cb in monitor._callbacks:
+            cb(PressureLevel.NORMAL, PressureLevel.CRITICAL)
+
+        # CRITICAL = 2.0x initial → 200
+        assert queue.capacity == 200
+
+        await logger.stop_and_drain()
+
+
+class TestCapacityCeiling:
+    """AC5: Capacity never exceeds initial * max_queue_growth."""
+
+    @pytest.mark.asyncio
+    async def test_capacity_capped_at_ceiling(self) -> None:
+        logger = _make_logger(queue_capacity=100)
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True,
+            check_interval_seconds=0.01,
+            cooldown_seconds=0.0,
+            max_queue_growth=1.5,  # Ceiling = 150
+        )
+
+        logger.start()
+        queue = logger._queue
+
+        monitor = logger._pressure_monitor
+        for cb in monitor._callbacks:
+            cb(PressureLevel.NORMAL, PressureLevel.CRITICAL)
+
+        # CRITICAL wants 2.0x = 200, but ceiling is 1.5x = 150
+        assert queue.capacity == 150
+
+        await logger.stop_and_drain()
+
+
+class TestCapacityDoesNotShrinkOnDeescalation:
+    """AC6: Capacity stays at grown size when pressure drops."""
+
+    @pytest.mark.asyncio
+    async def test_no_shrink_on_deescalation(self) -> None:
+        logger = _make_logger(queue_capacity=100)
+        logger._cached_adaptive_enabled = True
+        logger._cached_adaptive_settings = AdaptiveSettings(
+            enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+        )
+
+        logger.start()
+        queue = logger._queue
+
+        monitor = logger._pressure_monitor
+        # Escalate to CRITICAL → 200
+        for cb in monitor._callbacks:
+            cb(PressureLevel.NORMAL, PressureLevel.CRITICAL)
+        assert queue.capacity == 200
+
+        # De-escalate to NORMAL → capacity stays at 200 (grow-only)
+        for cb in monitor._callbacks:
+            cb(PressureLevel.CRITICAL, PressureLevel.NORMAL)
+        assert queue.capacity == 200
+
+        await logger.stop_and_drain()
+
+
+class TestCapacityGrowthDiagnostic:
+    """Verify diagnostic is emitted on capacity growth."""
+
+    @pytest.mark.asyncio
+    async def test_diagnostic_emitted_on_growth(self) -> None:
+        diagnostics: list[tuple[str, str]] = []
+
+        original_warn = None
+
+        def _capture_warn(component: str, message: str, **kwargs: Any) -> None:
+            diagnostics.append((component, message))
+            if original_warn is not None:
+                original_warn(component, message, **kwargs)
+
+        import fapilog.core.diagnostics as diag_mod
+
+        original_warn = diag_mod.warn
+        diag_mod.warn = _capture_warn
+
+        try:
+            logger = _make_logger(queue_capacity=100)
+            logger._cached_adaptive_enabled = True
+            logger._cached_adaptive_settings = AdaptiveSettings(
+                enabled=True, check_interval_seconds=0.01, cooldown_seconds=0.0
+            )
+
+            logger.start()
+            monitor = logger._pressure_monitor
+            for cb in monitor._callbacks:
+                cb(PressureLevel.NORMAL, PressureLevel.ELEVATED)
+
+            growth_diags = [
+                (c, m)
+                for c, m in diagnostics
+                if c == "adaptive-controller" and "capacity" in m
+            ]
+            assert len(growth_diags) == 1
+            assert growth_diags[0][1] == "queue capacity grown"
+
+            await logger.stop_and_drain()
+        finally:
+            diag_mod.warn = original_warn

--- a/tests/unit/test_adaptive_settings_queue_growth.py
+++ b/tests/unit/test_adaptive_settings_queue_growth.py
@@ -1,0 +1,23 @@
+"""Unit tests for AdaptiveSettings.max_queue_growth — Story 1.48."""
+
+from __future__ import annotations
+
+from fapilog.core.settings import AdaptiveSettings
+
+
+class TestAdaptiveSettingsQueueGrowth:
+    def test_default_max_queue_growth(self) -> None:
+        settings = AdaptiveSettings()
+        assert settings.max_queue_growth == 4.0
+
+    def test_custom_max_queue_growth(self) -> None:
+        settings = AdaptiveSettings(max_queue_growth=2.0)
+        assert settings.max_queue_growth == 2.0
+
+    def test_max_queue_growth_minimum_is_one(self) -> None:
+        """Growth multiplier below 1.0 is invalid — no shrinking."""
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            AdaptiveSettings(max_queue_growth=0.5)

--- a/tests/unit/test_queue_capacity_growth.py
+++ b/tests/unit/test_queue_capacity_growth.py
@@ -1,0 +1,89 @@
+"""Unit tests for PriorityAwareQueue.grow_capacity() — Story 1.48."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from fapilog.core.concurrency import PriorityAwareQueue
+
+
+class TestGrowCapacity:
+    """Tests for grow_capacity() method on PriorityAwareQueue."""
+
+    def test_grow_increases_capacity(self) -> None:
+        queue: PriorityAwareQueue[dict[str, str]] = PriorityAwareQueue(
+            capacity=100, protected_levels={"ERROR"}
+        )
+        assert queue.capacity == 100
+
+        queue.grow_capacity(200)
+        assert queue.capacity == 200
+
+    def test_grow_only_no_shrink(self) -> None:
+        queue: PriorityAwareQueue[dict[str, str]] = PriorityAwareQueue(
+            capacity=200, protected_levels={"ERROR"}
+        )
+        queue.grow_capacity(100)
+        assert queue.capacity == 200  # Unchanged
+
+    def test_grow_same_capacity_is_noop(self) -> None:
+        queue: PriorityAwareQueue[dict[str, str]] = PriorityAwareQueue(
+            capacity=100, protected_levels={"ERROR"}
+        )
+        queue.grow_capacity(100)
+        assert queue.capacity == 100
+
+    def test_is_full_reflects_new_capacity(self) -> None:
+        queue: PriorityAwareQueue[dict[str, str]] = PriorityAwareQueue(
+            capacity=1, protected_levels={"ERROR"}
+        )
+        queue.try_enqueue({"level": "INFO", "msg": "a"})
+        assert queue.is_full()
+
+        queue.grow_capacity(2)
+        assert not queue.is_full()
+
+    def test_enqueue_succeeds_after_growth(self) -> None:
+        queue: PriorityAwareQueue[dict[str, str]] = PriorityAwareQueue(
+            capacity=1, protected_levels={"ERROR"}
+        )
+        queue.try_enqueue({"level": "INFO", "msg": "a"})
+        assert queue.is_full()
+
+        # Without growth, enqueue fails (unprotected event, no eviction)
+        assert not queue.try_enqueue({"level": "INFO", "msg": "b"})
+
+        queue.grow_capacity(2)
+        assert queue.try_enqueue({"level": "INFO", "msg": "b"})
+        assert queue.qsize() == 2
+
+    @pytest.mark.asyncio
+    async def test_grow_wakes_blocked_enqueuers(self) -> None:
+        queue: PriorityAwareQueue[dict[str, str]] = PriorityAwareQueue(
+            capacity=1, protected_levels={"ERROR"}
+        )
+        queue.try_enqueue({"level": "INFO", "msg": "a"})
+        assert queue.is_full()
+
+        enqueued = asyncio.Event()
+
+        async def blocked_enqueuer() -> None:
+            await queue.await_enqueue({"level": "INFO", "msg": "b"})
+            enqueued.set()
+
+        task = asyncio.create_task(blocked_enqueuer())
+
+        # Let the enqueuer block
+        await asyncio.sleep(0.05)
+        assert not enqueued.is_set()
+
+        # Grow capacity — should wake the blocked enqueuer
+        queue.grow_capacity(2)
+
+        await asyncio.wait_for(enqueued.wait(), timeout=1.0)
+        assert enqueued.is_set()
+        assert queue.qsize() == 2
+
+        await task


### PR DESCRIPTION
## Summary

`PriorityAwareQueue` has a fixed capacity set at initialization. When the queue fills, events are either dropped or evicted. Filter tightening reduces inflow, but during the transition window between detection and filter swap, the queue may still fill. Growing the queue capacity provides a buffer during that transition — extra headroom to absorb events while other actuators take effect.

## Changes

- `src/fapilog/core/concurrency.py` (modified) — add `grow_capacity()` method with grow-only semantics
- `src/fapilog/core/settings.py` (modified) — add `max_queue_growth` field to `AdaptiveSettings`
- `src/fapilog/core/logger.py` (modified) — register capacity growth callback with `PressureMonitor`
- `docs/env-vars.md` (modified) — auto-generated env var documentation
- `tests/unit/test_queue_capacity_growth.py` (new) — unit tests for `grow_capacity()`
- `tests/unit/test_adaptive_settings_queue_growth.py` (new) — unit tests for settings field
- `tests/integration/test_adaptive_queue_growth.py` (new) — integration tests for callback wiring

## Acceptance Criteria

- [x] `grow_capacity()` method exists on `PriorityAwareQueue`
- [x] Grow-only semantics — capacity can only increase, never decrease
- [x] Blocked enqueuers wake after capacity growth via `_space_available.set()`
- [x] Controller grows capacity by pressure level (1.25x/1.5x/2.0x)
- [x] Ceiling enforced at `initial_capacity * max_queue_growth`
- [x] Capacity does not shrink on de-escalation

## Test Plan

- [x] Unit tests: grow increases capacity, grow-only no shrink, same capacity noop, is_full reflects new capacity, enqueue succeeds after growth, blocked enqueuers wake
- [x] Settings tests: default value, custom value, validation rejects < 1.0
- [x] Integration tests: callback registered, capacity grows per level, ceiling capped, no shrink on de-escalation, diagnostic emitted
- [x] 100% diff-cover on changed lines
- [x] All quality gates pass (ruff, mypy, vulture, builder parity)

## Story

[1.48 - Queue Capacity Growth](docs/stories/1.48.queue-capacity-growth.md)