### PR TITLE
feat(core): add adaptive preset and builder API

### DIFF
--- a/scripts/builder_param_mappings.py
+++ b/scripts/builder_param_mappings.py
@@ -78,6 +78,22 @@ CORE_COVERAGE: dict[str, list[str]] = {
         "fallback_scrub_raw",
         "fallback_raw_max_bytes",
     ],
+    # Adaptive pipeline (Story 10.57)
+    "with_adaptive": [
+        "enabled",
+        "check_interval_seconds",
+        "cooldown_seconds",
+        "escalate_to_elevated",
+        "escalate_to_high",
+        "escalate_to_critical",
+        "deescalate_from_critical",
+        "deescalate_from_high",
+        "deescalate_from_elevated",
+        "batch_sizing",
+        "max_workers",
+        "max_queue_growth",
+        "circuit_pressure_boost",
+    ],
     # Graceful shutdown (Story 6.13)
     "with_atexit_drain": ["atexit_drain_enabled", "atexit_drain_timeout_seconds"],
     "with_signal_handlers": ["signal_handler_enabled"],

--- a/src/fapilog/core/presets.py
+++ b/src/fapilog/core/presets.py
@@ -6,6 +6,7 @@ import copy
 from typing import Any, Literal
 
 PresetName = Literal[
+    "adaptive",
     "dev",
     "fastapi",
     "hardened",
@@ -17,6 +18,50 @@ PresetName = Literal[
 ]
 
 PRESETS: dict[str, dict[str, Any]] = {
+    "adaptive": {
+        "core": {
+            "log_level": "INFO",
+            "worker_count": 2,
+            "batch_max_size": 100,
+            "drop_on_full": True,
+            "redaction_fail_mode": "warn",
+            "sinks": ["stdout_json", "rotating_file"],
+            "enrichers": ["runtime_info", "context_vars"],
+            "redactors": ["field_mask", "regex_mask", "url_credentials"],
+            "protected_levels": ["ERROR", "CRITICAL", "FATAL", "AUDIT", "SECURITY"],
+            "sink_circuit_breaker_enabled": True,
+            "sink_circuit_breaker_fallback_sink": "rotating_file",
+        },
+        "adaptive": {
+            "enabled": True,
+            "max_workers": 8,
+            "max_queue_growth": 4.0,
+            "batch_sizing": True,
+            "circuit_pressure_boost": 0.20,
+        },
+        "sink_config": {
+            "rotating_file": {
+                "directory": "./logs",
+                "filename_prefix": "fapilog",
+                "max_bytes": 52_428_800,
+                "max_files": 10,
+                "compress_rotated": True,
+            },
+            "postgres": {
+                "create_table": False,
+            },
+        },
+        "enricher_config": {
+            "runtime_info": {},
+            "context_vars": {},
+        },
+        "redactor_config": {
+            "field_mask": {},
+            "regex_mask": {},
+            "url_credentials": {},
+        },
+        "_apply_credentials_preset": True,
+    },
     "dev": {
         "core": {
             "log_level": "DEBUG",

--- a/src/fapilog/core/settings.py
+++ b/src/fapilog/core/settings.py
@@ -644,6 +644,36 @@ class AdaptiveSettings(BaseModel):
         description="Fill ratio below which ELEVATED de-escalates to NORMAL",
     )
 
+    @model_validator(mode="after")
+    def validate_threshold_ordering(self) -> AdaptiveSettings:
+        """Ensure escalation thresholds are ascending and de-escalation below escalation."""
+        if self.escalate_to_elevated >= self.escalate_to_high:
+            raise ValueError(
+                f"escalate_to_elevated ({self.escalate_to_elevated}) "
+                f"must be less than escalate_to_high ({self.escalate_to_high})"
+            )
+        if self.escalate_to_high >= self.escalate_to_critical:
+            raise ValueError(
+                f"escalate_to_high ({self.escalate_to_high}) "
+                f"must be less than escalate_to_critical ({self.escalate_to_critical})"
+            )
+        if self.deescalate_from_elevated >= self.escalate_to_elevated:
+            raise ValueError(
+                f"deescalate_from_elevated ({self.deescalate_from_elevated}) "
+                f"must be less than escalate_to_elevated ({self.escalate_to_elevated})"
+            )
+        if self.deescalate_from_high >= self.escalate_to_high:
+            raise ValueError(
+                f"deescalate_from_high ({self.deescalate_from_high}) "
+                f"must be less than escalate_to_high ({self.escalate_to_high})"
+            )
+        if self.deescalate_from_critical >= self.escalate_to_critical:
+            raise ValueError(
+                f"deescalate_from_critical ({self.deescalate_from_critical}) "
+                f"must be less than escalate_to_critical ({self.escalate_to_critical})"
+            )
+        return self
+
 
 class SizeGuardSettings(BaseModel):
     """Per-plugin configuration for SizeGuardProcessor."""

--- a/tests/test_builder_parity.py
+++ b/tests/test_builder_parity.py
@@ -89,6 +89,8 @@ BUILDER_TO_CORE_FIELDS: dict[str, list[str]] = {
     "with_flush_on_critical": ["flush_on_critical"],
     # Story 1.37: Priority-aware queue
     "with_protected_levels": ["protected_levels"],
+    # Story 10.57: Adaptive pipeline
+    "with_adaptive": [],  # Covers AdaptiveSettings (nested model, not CoreSettings)
     # Story 4.54: Redaction fail mode, Story 4.59: Raw output hardening
     "with_fallback_redaction": [
         "fallback_redact_mode",

--- a/tests/unit/test_adaptive_preset.py
+++ b/tests/unit/test_adaptive_preset.py
@@ -1,0 +1,163 @@
+"""Tests for adaptive preset definition (Story 10.57 AC1, AC5, AC7)."""
+
+from fapilog.core.presets import get_preset, list_presets, validate_preset
+from fapilog.core.settings import Settings
+
+
+class TestAdaptivePresetExists:
+    """AC7: Adaptive preset is discoverable."""
+
+    def test_adaptive_preset_exists(self) -> None:
+        """get_preset('adaptive') returns a config dict."""
+        config = get_preset("adaptive")
+        assert "core" in config
+
+    def test_adaptive_preset_in_list_presets(self) -> None:
+        """list_presets() includes 'adaptive'."""
+        presets = list_presets()
+        assert "adaptive" in presets
+
+    def test_adaptive_preset_validates(self) -> None:
+        """validate_preset('adaptive') does not raise."""
+        validate_preset("adaptive")
+
+
+class TestAdaptivePresetContent:
+    """AC1: Adaptive preset enables all adaptive features."""
+
+    def test_adaptive_preset_has_info_log_level(self) -> None:
+        """Adaptive preset sets log level to INFO."""
+        config = get_preset("adaptive")
+        assert config["core"]["log_level"] == "INFO"
+
+    def test_adaptive_preset_has_two_workers(self) -> None:
+        """Adaptive preset sets worker_count to 2."""
+        config = get_preset("adaptive")
+        assert config["core"]["worker_count"] == 2
+
+    def test_adaptive_preset_enables_adaptive(self) -> None:
+        """Adaptive preset enables adaptive.enabled."""
+        config = get_preset("adaptive")
+        assert config["adaptive"]["enabled"] is True
+
+    def test_adaptive_preset_enables_batch_sizing(self) -> None:
+        """Adaptive preset enables adaptive.batch_sizing."""
+        config = get_preset("adaptive")
+        assert config["adaptive"]["batch_sizing"] is True
+
+    def test_adaptive_preset_sets_max_workers(self) -> None:
+        """Adaptive preset sets max_workers to 8."""
+        config = get_preset("adaptive")
+        assert config["adaptive"]["max_workers"] == 8
+
+    def test_adaptive_preset_sets_max_queue_growth(self) -> None:
+        """Adaptive preset sets max_queue_growth to 4.0."""
+        config = get_preset("adaptive")
+        assert config["adaptive"]["max_queue_growth"] == 4.0
+
+    def test_adaptive_preset_sets_circuit_pressure_boost(self) -> None:
+        """Adaptive preset sets circuit_pressure_boost to 0.20."""
+        config = get_preset("adaptive")
+        assert config["adaptive"]["circuit_pressure_boost"] == 0.20
+
+    def test_adaptive_preset_enables_drop_on_full(self) -> None:
+        """Adaptive preset enables drop_on_full for latency."""
+        config = get_preset("adaptive")
+        assert config["core"]["drop_on_full"] is True
+
+
+class TestAdaptivePresetCircuitBreaker:
+    """AC1: Adaptive preset includes circuit breaker."""
+
+    def test_adaptive_preset_enables_circuit_breaker(self) -> None:
+        """Adaptive preset enables circuit breaker."""
+        config = get_preset("adaptive")
+        assert config["core"]["sink_circuit_breaker_enabled"] is True
+
+    def test_adaptive_preset_circuit_breaker_fallback_to_file(self) -> None:
+        """Adaptive preset routes circuit breaker fallback to rotating_file."""
+        config = get_preset("adaptive")
+        assert config["core"]["sink_circuit_breaker_fallback_sink"] == "rotating_file"
+
+
+class TestAdaptivePresetSinks:
+    """AC5: Rotating file sink included for fallback."""
+
+    def test_adaptive_preset_includes_rotating_file_sink(self) -> None:
+        """Adaptive preset includes rotating_file in sinks list."""
+        config = get_preset("adaptive")
+        assert "rotating_file" in config["core"]["sinks"]
+
+    def test_adaptive_preset_includes_stdout_json_sink(self) -> None:
+        """Adaptive preset includes stdout_json in sinks list."""
+        config = get_preset("adaptive")
+        assert "stdout_json" in config["core"]["sinks"]
+
+    def test_adaptive_preset_has_file_rotation_config(self) -> None:
+        """Adaptive preset configures rotating file sink like production."""
+        config = get_preset("adaptive")
+        rf = config["sink_config"]["rotating_file"]
+        assert rf["directory"] == "./logs"
+        assert rf["max_bytes"] == 52_428_800
+        assert rf["max_files"] == 10
+        assert rf["compress_rotated"] is True
+
+
+class TestAdaptivePresetRedaction:
+    """Adaptive preset has production-grade redaction."""
+
+    def test_adaptive_preset_has_redactors(self) -> None:
+        """Adaptive preset enables field_mask, regex_mask, url_credentials."""
+        config = get_preset("adaptive")
+        assert config["core"]["redactors"] == [
+            "field_mask",
+            "regex_mask",
+            "url_credentials",
+        ]
+
+    def test_adaptive_preset_applies_credentials_preset(self) -> None:
+        """Adaptive preset has marker for CREDENTIALS preset."""
+        config = get_preset("adaptive")
+        assert config.get("_apply_credentials_preset") is True
+
+
+class TestAdaptivePresetProtectedLevels:
+    """AC1: Protected levels configured."""
+
+    def test_adaptive_preset_has_protected_levels(self) -> None:
+        """Adaptive preset protects ERROR, CRITICAL, FATAL, AUDIT, SECURITY."""
+        config = get_preset("adaptive")
+        expected = ["ERROR", "CRITICAL", "FATAL", "AUDIT", "SECURITY"]
+        assert config["core"]["protected_levels"] == expected
+
+
+class TestAdaptivePresetToSettings:
+    """Adaptive preset creates valid Settings."""
+
+    def test_adaptive_preset_creates_valid_settings(self) -> None:
+        """Adaptive preset can be converted to Settings."""
+        config = get_preset("adaptive")
+        settings = Settings(**config)
+        assert settings.core.log_level == "INFO"
+        assert settings.adaptive.enabled is True
+        assert settings.adaptive.batch_sizing is True
+        assert settings.adaptive.max_workers == 8
+
+    def test_adaptive_preset_returns_deep_copy(self) -> None:
+        """get_preset returns a copy, not the original dict."""
+        config1 = get_preset("adaptive")
+        config2 = get_preset("adaptive")
+        config1["adaptive"]["max_workers"] = 99
+        assert config2["adaptive"]["max_workers"] == 8
+
+
+class TestPresetNameLiteralIncludesAdaptive:
+    """PresetName Literal type includes 'adaptive'."""
+
+    def test_preset_name_literal_matches_registry(self) -> None:
+        """PresetName Literal values match PRESETS dict keys."""
+        from typing import get_args
+
+        from fapilog.core.presets import PRESETS, PresetName
+
+        assert set(get_args(PresetName)) == set(PRESETS.keys())

--- a/tests/unit/test_adaptive_settings_validation.py
+++ b/tests/unit/test_adaptive_settings_validation.py
@@ -1,0 +1,146 @@
+"""Tests for AdaptiveSettings threshold validation (Story 10.57 AC6)."""
+
+import pytest
+from pydantic import ValidationError
+
+from fapilog.core.settings import AdaptiveSettings
+
+
+class TestDefaultThresholds:
+    """Default thresholds must be valid."""
+
+    def test_default_thresholds_are_valid(self) -> None:
+        """Default AdaptiveSettings creates without error."""
+        settings = AdaptiveSettings()
+        assert settings.escalate_to_elevated == 0.60
+        assert settings.escalate_to_high == 0.80
+        assert settings.escalate_to_critical == 0.92
+
+    def test_default_deescalation_below_escalation(self) -> None:
+        """Default de-escalation thresholds are below corresponding escalation."""
+        settings = AdaptiveSettings()
+        assert settings.deescalate_from_elevated < settings.escalate_to_elevated
+        assert settings.deescalate_from_high < settings.escalate_to_high
+        assert settings.deescalate_from_critical < settings.escalate_to_critical
+
+
+class TestEscalationAscending:
+    """Escalation thresholds must be ascending: elevated < high < critical."""
+
+    def test_valid_ascending_escalation(self) -> None:
+        """Custom ascending thresholds are accepted."""
+        settings = AdaptiveSettings(
+            escalate_to_elevated=0.50,
+            escalate_to_high=0.70,
+            escalate_to_critical=0.90,
+            deescalate_from_elevated=0.30,
+            deescalate_from_high=0.50,
+            deescalate_from_critical=0.60,
+        )
+        assert settings.escalate_to_elevated == 0.50
+
+    def test_elevated_not_less_than_high_raises(self) -> None:
+        """Escalation elevated >= high raises ValidationError."""
+        with pytest.raises(
+            ValidationError,
+            match="escalate_to_elevated.*must be less than.*escalate_to_high",
+        ):
+            AdaptiveSettings(
+                escalate_to_elevated=0.85,
+                escalate_to_high=0.80,
+                escalate_to_critical=0.92,
+            )
+
+    def test_high_not_less_than_critical_raises(self) -> None:
+        """Escalation high >= critical raises ValidationError."""
+        with pytest.raises(
+            ValidationError,
+            match="escalate_to_high.*must be less than.*escalate_to_critical",
+        ):
+            AdaptiveSettings(
+                escalate_to_elevated=0.50,
+                escalate_to_high=0.95,
+                escalate_to_critical=0.90,
+            )
+
+    def test_equal_escalation_thresholds_raises(self) -> None:
+        """Equal escalation thresholds raise ValidationError."""
+        with pytest.raises(ValidationError, match="must be less than"):
+            AdaptiveSettings(
+                escalate_to_elevated=0.80,
+                escalate_to_high=0.80,
+                escalate_to_critical=0.92,
+            )
+
+
+class TestDeescalationBelowEscalation:
+    """De-escalation thresholds must be below corresponding escalation."""
+
+    def test_deescalate_elevated_above_escalate_raises(self) -> None:
+        """De-escalate from elevated >= escalate to elevated raises."""
+        with pytest.raises(
+            ValidationError,
+            match="deescalate_from_elevated.*must be less than.*escalate_to_elevated",
+        ):
+            AdaptiveSettings(
+                escalate_to_elevated=0.60,
+                deescalate_from_elevated=0.65,
+            )
+
+    def test_deescalate_high_above_escalate_raises(self) -> None:
+        """De-escalate from high >= escalate to high raises."""
+        with pytest.raises(
+            ValidationError,
+            match="deescalate_from_high.*must be less than.*escalate_to_high",
+        ):
+            AdaptiveSettings(
+                escalate_to_high=0.80,
+                deescalate_from_high=0.85,
+            )
+
+    def test_deescalate_critical_above_escalate_raises(self) -> None:
+        """De-escalate from critical >= escalate to critical raises."""
+        with pytest.raises(
+            ValidationError,
+            match="deescalate_from_critical.*must be less than.*escalate_to_critical",
+        ):
+            AdaptiveSettings(
+                escalate_to_critical=0.92,
+                deescalate_from_critical=0.95,
+            )
+
+    def test_equal_deescalation_and_escalation_raises(self) -> None:
+        """Equal de-escalation and escalation thresholds raise."""
+        with pytest.raises(ValidationError, match="must be less than"):
+            AdaptiveSettings(
+                escalate_to_elevated=0.60,
+                deescalate_from_elevated=0.60,
+            )
+
+
+class TestEnvVarOverride:
+    """AC4: Environment variable configuration."""
+
+    def test_env_var_sets_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FAPILOG_ADAPTIVE__ENABLED env var enables adaptive mode."""
+        monkeypatch.setenv("FAPILOG_ADAPTIVE__ENABLED", "true")
+        from fapilog.core.settings import Settings
+
+        settings = Settings()
+        assert settings.adaptive.enabled is True
+
+    def test_env_var_sets_max_workers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FAPILOG_ADAPTIVE__MAX_WORKERS env var overrides max workers."""
+        monkeypatch.setenv("FAPILOG_ADAPTIVE__MAX_WORKERS", "6")
+        from fapilog.core.settings import Settings
+
+        settings = Settings()
+        assert settings.adaptive.max_workers == 6
+
+    def test_env_var_sets_cooldown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FAPILOG_ADAPTIVE__COOLDOWN_SECONDS env var overrides cooldown."""
+        monkeypatch.setenv("FAPILOG_ADAPTIVE__COOLDOWN_SECONDS", "3.0")
+        from fapilog.core.settings import Settings
+
+        settings = Settings()
+        assert settings.adaptive.cooldown_seconds == 3.0

--- a/tests/unit/test_builder_adaptive.py
+++ b/tests/unit/test_builder_adaptive.py
@@ -1,0 +1,95 @@
+"""Tests for LoggerBuilder.with_adaptive() method (Story 10.57 AC2)."""
+
+from fapilog.builder import LoggerBuilder
+
+
+class TestWithAdaptive:
+    """Tests for with_adaptive() builder method."""
+
+    def test_with_adaptive_sets_enabled(self) -> None:
+        """with_adaptive() sets adaptive.enabled to True by default."""
+        builder = LoggerBuilder()
+        builder.with_adaptive()
+        assert builder._config["adaptive"]["enabled"] is True
+
+    def test_with_adaptive_disabled(self) -> None:
+        """with_adaptive(enabled=False) sets adaptive.enabled to False."""
+        builder = LoggerBuilder()
+        builder.with_adaptive(enabled=False)
+        assert builder._config["adaptive"]["enabled"] is False
+
+    def test_with_adaptive_sets_max_workers(self) -> None:
+        """with_adaptive(max_workers=6) sets adaptive.max_workers."""
+        builder = LoggerBuilder()
+        builder.with_adaptive(max_workers=6)
+        assert builder._config["adaptive"]["max_workers"] == 6
+
+    def test_with_adaptive_sets_max_queue_growth(self) -> None:
+        """with_adaptive(max_queue_growth=2.0) sets adaptive.max_queue_growth."""
+        builder = LoggerBuilder()
+        builder.with_adaptive(max_queue_growth=2.0)
+        assert builder._config["adaptive"]["max_queue_growth"] == 2.0
+
+    def test_with_adaptive_sets_batch_sizing(self) -> None:
+        """with_adaptive(batch_sizing=True) sets adaptive.batch_sizing."""
+        builder = LoggerBuilder()
+        builder.with_adaptive(batch_sizing=True)
+        assert builder._config["adaptive"]["batch_sizing"] is True
+
+    def test_with_adaptive_sets_check_interval(self) -> None:
+        """with_adaptive(check_interval_seconds=0.5) sets check interval."""
+        builder = LoggerBuilder()
+        builder.with_adaptive(check_interval_seconds=0.5)
+        assert builder._config["adaptive"]["check_interval_seconds"] == 0.5
+
+    def test_with_adaptive_sets_cooldown(self) -> None:
+        """with_adaptive(cooldown_seconds=3.0) sets cooldown."""
+        builder = LoggerBuilder()
+        builder.with_adaptive(cooldown_seconds=3.0)
+        assert builder._config["adaptive"]["cooldown_seconds"] == 3.0
+
+    def test_with_adaptive_sets_circuit_pressure_boost(self) -> None:
+        """with_adaptive(circuit_pressure_boost=0.15) sets boost."""
+        builder = LoggerBuilder()
+        builder.with_adaptive(circuit_pressure_boost=0.15)
+        assert builder._config["adaptive"]["circuit_pressure_boost"] == 0.15
+
+    def test_with_adaptive_returns_self(self) -> None:
+        """with_adaptive() returns self for method chaining."""
+        builder = LoggerBuilder()
+        result = builder.with_adaptive()
+        assert result is builder
+
+    def test_with_adaptive_none_params_omitted(self) -> None:
+        """with_adaptive() with defaults only sets enabled."""
+        builder = LoggerBuilder()
+        builder.with_adaptive()
+        adaptive = builder._config["adaptive"]
+        assert adaptive == {"enabled": True}
+
+    def test_with_adaptive_chaining_with_circuit_breaker(self) -> None:
+        """with_adaptive() chains with with_circuit_breaker()."""
+        builder = LoggerBuilder()
+        result = builder.with_adaptive(
+            max_workers=6, batch_sizing=True
+        ).with_circuit_breaker(enabled=True, fallback_sink="rotating_file")
+        assert result is builder
+        assert builder._config["adaptive"]["max_workers"] == 6
+        assert builder._config["core"]["sink_circuit_breaker_enabled"] is True
+
+    def test_with_adaptive_merges_on_repeated_calls(self) -> None:
+        """Calling with_adaptive() twice merges values."""
+        builder = LoggerBuilder()
+        builder.with_adaptive(max_workers=4)
+        builder.with_adaptive(batch_sizing=True)
+        adaptive = builder._config["adaptive"]
+        assert adaptive["max_workers"] == 4
+        assert adaptive["batch_sizing"] is True
+        assert adaptive["enabled"] is True
+
+    def test_with_adaptive_with_preset_overrides(self) -> None:
+        """with_adaptive() overrides preset adaptive settings."""
+        builder = LoggerBuilder()
+        builder.with_preset("adaptive").with_adaptive(max_workers=4)
+        # Builder config should have the override
+        assert builder._config["adaptive"]["max_workers"] == 4

--- a/tests/unit/test_presets.py
+++ b/tests/unit/test_presets.py
@@ -302,6 +302,7 @@ class TestPresetValidation:
     @pytest.mark.parametrize(
         "name",
         [
+            "adaptive",
             "dev",
             "high-volume",
             "production",
@@ -335,7 +336,7 @@ class TestPresetValidation:
         """Error message includes list of valid presets."""
         with pytest.raises(
             ValueError,
-            match="Valid presets: dev, fastapi, hardened, high-volume, minimal, production, production-latency, serverless",
+            match="Valid presets: adaptive, dev, fastapi, hardened, high-volume, minimal, production, production-latency, serverless",
         ):
             validate_preset("invalid")
 
@@ -380,6 +381,7 @@ class TestPresetToSettings:
     @pytest.mark.parametrize(
         "name",
         [
+            "adaptive",
             "dev",
             "high-volume",
             "production",
@@ -400,10 +402,11 @@ class TestPresetToSettings:
 class TestPresetList:
     """Test preset listing."""
 
-    def test_list_presets_returns_all_eight(self):
-        """list_presets returns all eight preset names."""
+    def test_list_presets_returns_all(self):
+        """list_presets returns all preset names."""
         presets = list_presets()
         assert set(presets) == {
+            "adaptive",
             "dev",
             "high-volume",
             "production",
@@ -702,7 +705,7 @@ class TestPresetNameLiteral:
         from fapilog import PresetName
 
         # Verify it's the same type, not an empty re-export
-        assert len(get_args(PresetName)) == 8
+        assert len(get_args(PresetName)) == 9
 
 
 class TestPresetImmutability:

--- a/tests/unit/test_redaction_defaults.py
+++ b/tests/unit/test_redaction_defaults.py
@@ -221,6 +221,7 @@ class TestPresetConsistency:
         This test ensures new presets get documented.
         """
         expected_presets = {
+            "adaptive",
             "dev",
             "production",
             "production-latency",


### PR DESCRIPTION
## Summary

Add a unified configuration interface for adaptive pipeline features: an `adaptive` preset for one-line setup, a `LoggerBuilder.with_adaptive()` method for fine-grained control, and threshold ordering validation on `AdaptiveSettings`.

## Changes

- `src/fapilog/core/presets.py` (modified) — add `adaptive` preset and update `PresetName` Literal
- `src/fapilog/core/settings.py` (modified) — add threshold ordering `@model_validator` to `AdaptiveSettings`
- `src/fapilog/builder.py` (modified) — add `with_adaptive()` method, apply CREDENTIALS preset for adaptive
- `scripts/builder_param_mappings.py` (modified) — add `with_adaptive` parity coverage mapping
- `tests/unit/test_adaptive_preset.py` (new) — 22 tests for preset content, sinks, circuit breaker, redaction
- `tests/unit/test_adaptive_settings_validation.py` (new) — 13 tests for threshold validation and env vars
- `tests/unit/test_builder_adaptive.py` (new) — 13 tests for builder method params, chaining, merging
- `tests/unit/test_presets.py` (modified) — update preset name lists and counts
- `tests/unit/test_redaction_defaults.py` (modified) — add adaptive to expected presets set
- `tests/test_builder_parity.py` (modified) — add `with_adaptive` to builder coverage mapping

## Acceptance Criteria

- [x] Adaptive preset enables all adaptive features (production base, circuit breaker, rotating file fallback, protected levels)
- [x] Builder API `with_adaptive()` method with optional parameter overrides
- [x] AdaptiveSettings model complete with all parameters
- [x] Environment variable support (`FAPILOG_ADAPTIVE__*`)
- [x] Rotating file sink included as circuit breaker fallback
- [x] Threshold validation (escalation ascending, de-escalation below escalation)
- [x] Preset appears in `list_presets()`

## Test Plan

- [x] Unit tests pass (48 new, 3180 total)
- [x] Coverage >= 90% on changed lines (100%)
- [x] ruff check + format pass
- [x] mypy passes
- [x] Builder parity check passes
- [x] No weak assertions
- [x] No dead code

## Story

[10.57 - Adaptive Preset and Builder API](docs/stories/10.57.adaptive-preset-and-builder-api.md)