### PR TITLE
fix(core): remove rotating_file as primary sink from adaptive preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ logger = get_logger(preset="minimal")
 |--------|-----------|-------------|-------------|-----------|-------------|
 | `dev` | DEBUG | No | No | No | See every log instantly while debugging locally |
 | `production` | INFO | Never | Yes | Yes | Audit trails, compliance—never lose logs |
-| `adaptive` | INFO | If needed | Yes | Yes | High-throughput with auto-scaling workers and circuit breakers |
+| `adaptive` | INFO | If needed | Fallback only | Yes | High-throughput with auto-scaling workers and circuit breakers |
 | `serverless` | INFO | If needed | No | Yes | Lambda/Cloud Functions with fast flush |
 | `hardened` | INFO | Never | Yes | Yes (HIPAA+PCI) | Regulated environments (HIPAA, PCI-DSS) |
 | `minimal` | INFO | Default | No | No | Migrating from another logger—start here |

--- a/docs/api-reference/builder.md
+++ b/docs/api-reference/builder.md
@@ -113,7 +113,7 @@ builder.with_preset("production")
 | `dev` | DEBUG | No | No | 1 (immediate) | 1 |
 | `minimal` | INFO | No | No | 256 | 1 |
 | `production` | INFO | Yes (50MB rotation) | Yes | 256 | 2 |
-| `adaptive` | INFO | Yes (50MB rotation) | Yes | 100 | 2 (up to 8) |
+| `adaptive` | INFO | Fallback only | Yes | 256 | 2 (up to 4) |
 | `serverless` | INFO | No | Yes | 25 | 2 |
 | `hardened` | INFO | Yes (50MB rotation) | Yes | 100 | 2 |
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -110,7 +110,7 @@ logger = get_logger(preset="minimal")            # Backwards compatible default
 | `dev` | No | No | No | Local development |
 | `minimal` | Default | No | No | Migration, explicit defaults |
 | `production` | Never | Yes | Yes | Audit trails, compliance |
-| `adaptive` | If needed | Yes | Yes | Auto-scaling under load |
+| `adaptive` | If needed | Fallback only | Yes | Auto-scaling under load |
 | `serverless` | If needed | No | Yes | Lambda/Cloud Functions |
 | `hardened` | Never | Yes | Yes (HIPAA+PCI) | Regulated environments |
 

--- a/docs/user-guide/presets.md
+++ b/docs/user-guide/presets.md
@@ -9,7 +9,7 @@ Presets provide pre-configured settings for common deployment scenarios. Choose 
 | `dev` | Local development | No | No | No |
 | `production` | Durable production | Never | Yes | Yes (CREDENTIALS) |
 | `serverless` | Lambda/Cloud Run | If needed | No | Yes (CREDENTIALS) |
-| `adaptive` | Auto-scaling production | If needed | Yes | Yes (CREDENTIALS) |
+| `adaptive` | Auto-scaling production | If needed | Fallback only | Yes (CREDENTIALS) |
 | `hardened` | Compliance (HIPAA/PCI) | Never | Yes | Yes (HIPAA + PCI + CREDENTIALS) |
 | `minimal` | Maximum control | Default | Default | No |
 

--- a/src/fapilog/core/presets.py
+++ b/src/fapilog/core/presets.py
@@ -26,7 +26,7 @@ PRESETS: dict[str, dict[str, Any]] = {
             "batch_timeout_seconds": 0.25,
             "drop_on_full": True,
             "redaction_fail_mode": "warn",
-            "sinks": ["stdout_json", "rotating_file"],
+            "sinks": ["stdout_json"],
             "enrichers": ["runtime_info", "context_vars"],
             "redactors": ["field_mask", "regex_mask", "url_credentials"],
             "protected_levels": ["ERROR", "CRITICAL"],

--- a/tests/unit/test_adaptive_preset.py
+++ b/tests/unit/test_adaptive_preset.py
@@ -116,20 +116,21 @@ class TestAdaptivePresetCircuitBreaker:
 
 
 class TestAdaptivePresetSinks:
-    """AC5: Rotating file sink included for fallback."""
+    """AC5: Rotating file sink is circuit breaker fallback only."""
 
-    def test_adaptive_preset_includes_rotating_file_sink(self) -> None:
-        """Adaptive preset includes rotating_file in sinks list."""
+    def test_adaptive_preset_primary_sink_is_stdout_only(self) -> None:
+        """Adaptive preset uses only stdout_json as primary sink."""
         config = get_preset("adaptive")
-        assert "rotating_file" in config["core"]["sinks"]
+        assert config["core"]["sinks"] == ["stdout_json"]
 
-    def test_adaptive_preset_includes_stdout_json_sink(self) -> None:
-        """Adaptive preset includes stdout_json in sinks list."""
+    def test_adaptive_preset_rotating_file_is_fallback_only(self) -> None:
+        """Rotating file is configured as circuit breaker fallback, not primary."""
         config = get_preset("adaptive")
-        assert "stdout_json" in config["core"]["sinks"]
+        assert "rotating_file" not in config["core"]["sinks"]
+        assert config["core"]["sink_circuit_breaker_fallback_sink"] == "rotating_file"
 
     def test_adaptive_preset_has_file_rotation_config(self) -> None:
-        """Adaptive preset configures rotating file sink like production."""
+        """Adaptive preset configures rotating file sink for fallback use."""
         config = get_preset("adaptive")
         rf = config["sink_config"]["rotating_file"]
         assert rf["directory"] == "./logs"


### PR DESCRIPTION
## Summary

The adaptive preset had `rotating_file` as both a primary sink and a circuit breaker fallback. With `drop_on_full=True`, file I/O on every event contradicts the high-throughput design. This change keeps `rotating_file` only as the circuit breaker fallback — when the primary sink fails, events route to disk instead of being lost.

## Changes

- `src/fapilog/core/presets.py` (modified) — remove `rotating_file` from adaptive primary sinks
- `tests/unit/test_adaptive_preset.py` (modified) — update sink assertions
- `README.md` (modified) — update preset table
- `docs/user-guide/presets.md` (modified) — update quick reference table
- `docs/user-guide/configuration.md` (modified) — update comparison table
- `docs/api-reference/builder.md` (modified) — update preset summary table, fix batch_size/workers

## Test Plan

- [x] 95 preset tests pass
- [x] ruff check + format clean
- [x] mypy clean
- [x] All pre-commit hooks pass