### PR TITLE
chore(release): v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-02-19
+
+### Fixed
+
+- **Release - Re-release of v0.18.0:** No code changes. Version bump for PyPI package re-upload.
+
 ## [0.18.0] - 2026-02-19
 
 ### Added


### PR DESCRIPTION
## Summary

Release v0.18.1 — version bump for PyPI re-upload (v0.18.0 package already exists).

## Changes

- `CHANGELOG.md` (modified)

## Changelog Preview

### Fixed

- **Release - Re-release of v0.18.0:** No code changes. Version bump for PyPI package re-upload.

## Post-Merge

After merging this PR, run `/release tag` to create the git tag.