### PR TITLE
docs(user-guide): prefer with_queue_budget() over integer queue sizes

### DIFF
--- a/docs/user-guide/benchmarks.md
+++ b/docs/user-guide/benchmarks.md
@@ -88,7 +88,7 @@ Peak memory during throughput test:
 | stdlib | 85,719 |
 | fapilog | 10,670,043 |
 
-**Interpretation:** fapilog uses more memory due to its queue, batching buffers, and async infrastructure. This is a deliberate trade-off for non-blocking behavior. Configure `max_queue_size` based on available memory.
+**Interpretation:** fapilog uses more memory due to its queue, batching buffers, and async infrastructure. This is a deliberate trade-off for non-blocking behavior. Use `.with_queue_budget()` to set a memory ceiling, or configure `max_queue_size` directly.
 
 ### Worker Count Impact
 

--- a/docs/user-guide/builder-configuration.md
+++ b/docs/user-guide/builder-configuration.md
@@ -265,7 +265,7 @@ Optimize for throughput or latency:
 # High-throughput configuration
 logger = (
     LoggerBuilder()
-    .with_queue_size(10000)       # Large buffer
+    .with_queue_budget(main_mb=50, protected_mb=10)  # Memory ceiling
     .with_batch_size(500)         # Large batches
     .with_batch_timeout("1s")     # Flush every second
     .with_workers(4)              # Parallel processing
@@ -276,9 +276,9 @@ logger = (
 # Low-latency configuration
 logger = (
     LoggerBuilder()
-    .with_queue_size(1000)
-    .with_batch_size(10)          # Small batches
-    .with_batch_timeout("100ms")  # Flush quickly
+    .with_queue_budget(main_mb=2)  # Small buffer
+    .with_batch_size(10)           # Small batches
+    .with_batch_timeout("100ms")   # Flush quickly
     .add_stdout()
     .build()
 )
@@ -375,7 +375,7 @@ logger = (
     .with_shutdown_timeout("10s")
 
     # Performance
-    .with_queue_size(10000)
+    .with_queue_budget(main_mb=20, protected_mb=5)
     .with_batch_size(100)
     .with_workers(2)
 

--- a/docs/user-guide/presets.md
+++ b/docs/user-guide/presets.md
@@ -129,7 +129,7 @@ logger = get_logger(preset="production")
 **Settings:**
 - INFO level filters noise
 - `batch_max_size=256`, `batch_timeout_seconds=0.25`
-- `max_queue_size=10000`, `sink_concurrency=8`, `shutdown_timeout_seconds=25.0`
+- ~20 MB queue budget (`max_queue_size=10000` at ~2 KB/event), `sink_concurrency=8`, `shutdown_timeout_seconds=25.0`
 - Adaptive pipeline enabled: dynamic worker scaling (2-4), filter tightening, fixed queue capacity
 - Circuit breaker with rotating file fallback — failing sinks are isolated, events reroute to local files
 - File rotation: `./logs/fapilog-*.log`, 50MB max, 10 files, gzip compressed (fallback only)

--- a/docs/user-guide/reliability-defaults.md
+++ b/docs/user-guide/reliability-defaults.md
@@ -3,7 +3,7 @@
 This page summarizes the out-of-the-box behaviors that affect durability, backpressure, and data protection.
 
 ## Backpressure and drops
-- Queue size: `core.max_queue_size=10000`
+- Queue budget: ~20 MB default (`core.max_queue_size=10000` at ~2 KB/event)
 - Drop policy: `core.drop_on_full=True` (drop immediately when queue is full)
 - Batch flush: `core.batch_max_size=256`, `core.batch_timeout_seconds=0.25`
 
@@ -13,7 +13,7 @@ With the dedicated thread architecture, `try_enqueue()` is always non-blocking â
 
 When `drop_on_full=False` is configured with `SyncLoggerFacade`, a diagnostic warning is emitted at startup to alert you that blocking behavior is not supported.
 
-**Recommendation**: Size your queue appropriately (`core.max_queue_size`) to handle burst traffic without dropping. Both `SyncLoggerFacade` and `AsyncLoggerFacade` use the same non-blocking enqueue path.
+**Recommendation**: Size your queue appropriately (`.with_queue_budget()` or `core.max_queue_size`) to handle burst traffic without dropping. Both `SyncLoggerFacade` and `AsyncLoggerFacade` use the same non-blocking enqueue path.
 
 ## Redaction defaults
 


### PR DESCRIPTION
## Summary

Update user-guide docs to prefer the memory-based `with_queue_budget()` API over raw integer `with_queue_size()` calls, and add MB context where integer queue sizes are referenced.

## Changes

- `docs/user-guide/builder-configuration.md` (modified) — replace `with_queue_size()` with `with_queue_budget()` in examples
- `docs/user-guide/presets.md` (modified) — add ~20 MB context to production preset queue size
- `docs/user-guide/reliability-defaults.md` (modified) — add MB context and mention `with_queue_budget()`
- `docs/user-guide/benchmarks.md` (modified) — mention `with_queue_budget()` in recommendation

## Test Plan

- [x] Documentation only — no code changes